### PR TITLE
#7 replace Vite starter UI with Guard Game runtime bootstrap

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,95 @@
-import './style.css'
-import typescriptLogo from './typescript.svg'
-import viteLogo from '/vite.svg'
-import { setupCounter } from './counter.ts'
+import './style.css';
+import { createCommandBuffer } from './input/commands';
+import { handleNpcInteraction } from './interaction/npcInteraction';
+import { createStubLlmClient } from './llm/client';
+import { createRenderPortStub } from './render/scene';
+import type { WorldCommand } from './world/types';
+import { createWorld } from './world/world';
 
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://www.typescriptlang.org/" target="_blank">
-      <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />
-    </a>
-    <h1>Vite + TypeScript</h1>
-    <div class="card">
-      <button id="counter" type="button"></button>
-    </div>
-    <p class="read-the-docs">
-      Click on the Vite and TypeScript logos to learn more
-    </p>
-  </div>
-`
+const FIXED_TIME_STEP_MS = 100;
 
-setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+const appRoot = document.querySelector<HTMLDivElement>('#app');
+if (!appRoot) {
+  throw new Error('Missing #app root element.');
+}
+
+appRoot.innerHTML = `
+  <main>
+    <h1>Guard Game</h1>
+    <p>Runtime bootstrap active. Grid rendering and movement are implemented in follow-up tickets.</p>
+    <button id="test-interaction" type="button">Test NPC Interaction</button>
+    <p id="status">Status: idle</p>
+    <pre id="state-output"></pre>
+  </main>
+`;
+
+const interactionButton = document.querySelector<HTMLButtonElement>('#test-interaction');
+const statusOutput = document.querySelector<HTMLParagraphElement>('#status');
+const stateOutput = document.querySelector<HTMLPreElement>('#state-output');
+
+if (!interactionButton || !statusOutput || !stateOutput) {
+  throw new Error('Missing runtime UI elements.');
+}
+
+const world = createWorld();
+const commandBuffer = createCommandBuffer();
+const renderPort = createRenderPortStub();
+const llmClient = createStubLlmClient();
+
+interactionButton.addEventListener('click', () => {
+  commandBuffer.enqueue({ type: 'interact' });
+});
+
+const processInteraction = async (): Promise<void> => {
+  const state = world.getState();
+  const firstNpc = state.npcs[0];
+  if (!firstNpc) {
+    statusOutput.textContent = 'Status: no NPC available for interaction.';
+    return;
+  }
+
+  const interactionResult = await handleNpcInteraction({
+    npc: firstNpc,
+    player: state.player,
+  });
+  const llmResult = await llmClient.complete({
+    actorId: firstNpc.id,
+    context: firstNpc.dialogueContextKey,
+    playerMessage: interactionResult.responseText,
+  });
+
+  statusOutput.textContent = `Status: ${interactionResult.responseText} | LLM: ${llmResult.text}`;
+};
+
+const tick = (): void => {
+  const commands = commandBuffer.drain();
+  const hasInteractionCommand = commands.some((command: WorldCommand) => command.type === 'interact');
+
+  world.applyCommands(commands);
+
+  const nextState = world.getState();
+  renderPort.render(nextState);
+  stateOutput.textContent = JSON.stringify(nextState, null, 2);
+
+  if (hasInteractionCommand) {
+    void processInteraction();
+  }
+};
+
+let previousTime = performance.now();
+let accumulator = 0;
+
+const runFrame = (now: number): void => {
+  accumulator += now - previousTime;
+  previousTime = now;
+
+  while (accumulator >= FIXED_TIME_STEP_MS) {
+    tick();
+    accumulator -= FIXED_TIME_STEP_MS;
+  }
+
+  requestAnimationFrame(runFrame);
+};
+
+tick();
+requestAnimationFrame(runFrame);


### PR DESCRIPTION
## #7

## Refs #2

## Closes #7

## Summary
- replace Vite starter markup/counter bootstrap in `src/main.ts` with Guard Game runtime shell
- wire world creation, command buffer, render port, interaction stub, and LLM stub in main orchestration
- add deterministic fixed-step main loop that drains command queue and applies world commands
- add a simple interaction trigger button to exercise interaction + llm boundary through stubs

## Scope
- CHANGE only
- runtime bootstrap/orchestration in main entry point
- no Pixi grid rendering implementation yet (tracked separately)

## Validation
- `npm run build` passes
- `npm run lint` passes
- `npm run test` passes (no test files, exit code 0)