### PR TITLE
#7 replace Vite starter UI with Guard Game runtime bootstrap

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,123 @@
-import './style.css'
-import typescriptLogo from './typescript.svg'
-import viteLogo from '/vite.svg'
-import { setupCounter } from './counter.ts'
+import './style.css';
+import { createCommandBuffer } from './input/commands';
+import { handleNpcInteraction } from './interaction/npcInteraction';
+import { createRenderPortStub } from './render/scene';
+import type { WorldCommand, WorldState } from './world/types';
+import { createWorld } from './world/world';
 
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://www.typescriptlang.org/" target="_blank">
-      <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />
-    </a>
-    <h1>Vite + TypeScript</h1>
-    <div class="card">
-      <button id="counter" type="button"></button>
-    </div>
-    <p class="read-the-docs">
-      Click on the Vite and TypeScript logos to learn more
-    </p>
+const appElement = document.querySelector<HTMLDivElement>('#app');
+
+if (!appElement) {
+  throw new Error('Expected #app root element.');
+}
+
+appElement.innerHTML = `
+  <div class="guard-game-shell">
+    <header class="guard-game-header">
+      <h1>Guard Game</h1>
+      <p>Deterministic runtime bootstrap</p>
+    </header>
+    <main class="guard-game-main">
+      <section class="guard-game-panel">
+        <h2>Viewport</h2>
+        <div id="viewport" class="guard-game-viewport"></div>
+      </section>
+      <section class="guard-game-panel">
+        <h2>World State</h2>
+        <pre id="world-state" class="guard-game-world-state"></pre>
+      </section>
+      <section class="guard-game-panel">
+        <h2>Interaction</h2>
+        <p id="interaction-log" class="guard-game-interaction-log">No interaction yet.</p>
+      </section>
+    </main>
   </div>
-`
+`;
 
-setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+const viewportElement = document.querySelector<HTMLElement>('#viewport');
+const worldStateElement = document.querySelector<HTMLElement>('#world-state');
+const interactionLogElement = document.querySelector<HTMLElement>('#interaction-log');
+
+if (!viewportElement || !worldStateElement || !interactionLogElement) {
+  throw new Error('Expected runtime shell elements to exist.');
+}
+
+const world = createWorld();
+const commandBuffer = createCommandBuffer();
+const renderPort = createRenderPortStub({
+  viewport: viewportElement,
+  worldState: worldStateElement,
+});
+
+const keyToCommandMap: Record<string, WorldCommand> = {
+  ArrowUp: { type: 'move', dx: 0, dy: -1 },
+  ArrowDown: { type: 'move', dx: 0, dy: 1 },
+  ArrowLeft: { type: 'move', dx: -1, dy: 0 },
+  ArrowRight: { type: 'move', dx: 1, dy: 0 },
+  w: { type: 'move', dx: 0, dy: -1 },
+  a: { type: 'move', dx: -1, dy: 0 },
+  s: { type: 'move', dx: 0, dy: 1 },
+  d: { type: 'move', dx: 1, dy: 0 },
+  e: { type: 'interact' },
+};
+
+window.addEventListener('keydown', (event: KeyboardEvent) => {
+  const command = keyToCommandMap[event.key];
+  if (!command) {
+    return;
+  }
+
+  event.preventDefault();
+  commandBuffer.enqueue(command);
+});
+
+const runInteractionIfRequested = async (
+  worldState: WorldState,
+  commands: WorldCommand[],
+): Promise<void> => {
+  const includesInteract = commands.some((command) => command.type === 'interact');
+  if (!includesInteract) {
+    return;
+  }
+
+  const nearbyNpc = worldState.npcs.find((npc) => {
+    const deltaX = Math.abs(npc.position.x - worldState.player.position.x);
+    const deltaY = Math.abs(npc.position.y - worldState.player.position.y);
+    return deltaX + deltaY <= 1;
+  });
+
+  if (!nearbyNpc) {
+    interactionLogElement.textContent = 'No NPC nearby to interact with.';
+    return;
+  }
+
+  const interactionResult = await handleNpcInteraction({
+    npc: nearbyNpc,
+    player: worldState.player,
+  });
+
+  interactionLogElement.textContent = interactionResult.responseText;
+};
+
+const fixedTickDurationMs = 100;
+let previousFrameTime = performance.now();
+let accumulatedTime = 0;
+
+const runFrame = (currentTime: number): void => {
+  accumulatedTime += currentTime - previousFrameTime;
+  previousFrameTime = currentTime;
+
+  while (accumulatedTime >= fixedTickDurationMs) {
+    const commands = commandBuffer.drain();
+    world.applyCommands(commands);
+    const worldState = world.getState();
+    void runInteractionIfRequested(worldState, commands);
+    accumulatedTime -= fixedTickDurationMs;
+  }
+
+  renderPort.render(world.getState());
+  requestAnimationFrame(runFrame);
+};
+
+renderPort.render(world.getState());
+requestAnimationFrame(runFrame);

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -4,8 +4,19 @@ export interface RenderPort {
   render(worldState: WorldState): void;
 }
 
-export const createRenderPortStub = (): RenderPort => ({
-  render: (_worldState: WorldState) => {
-    // Render implementation is added in the next increment.
+export interface DomRenderTargets {
+  viewport: HTMLElement;
+  worldState: HTMLElement;
+}
+
+const formatPlayerPosition = (worldState: WorldState): string => {
+  const { x, y } = worldState.player.position;
+  return `Player @ (${x}, ${y})`;
+};
+
+export const createRenderPortStub = (targets: DomRenderTargets): RenderPort => ({
+  render: (worldState: WorldState) => {
+    targets.viewport.textContent = formatPlayerPosition(worldState);
+    targets.worldState.textContent = JSON.stringify(worldState, null, 2);
   },
 });

--- a/src/style.css
+++ b/src/style.css
@@ -1,96 +1,96 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: 'Trebuchet MS', 'Gill Sans', sans-serif;
+  line-height: 1.4;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #eaf4f8;
+  background: radial-gradient(circle at top, #204251 0%, #0f2231 45%, #08131d 100%);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
 #app {
-  max-width: 1280px;
+  min-height: 100vh;
+  padding: 1.25rem;
+}
+
+.guard-game-shell {
+  width: min(960px, 100%);
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  border: 1px solid rgba(187, 224, 239, 0.35);
+  border-radius: 1rem;
+  background: rgba(7, 17, 29, 0.75);
+  box-shadow: 0 14px 45px rgba(3, 7, 10, 0.42);
+  overflow: hidden;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vanilla:hover {
-  filter: drop-shadow(0 0 2em #3178c6aa);
+.guard-game-header {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(187, 224, 239, 0.2);
 }
 
-.card {
-  padding: 2em;
+.guard-game-header h1 {
+  margin: 0;
+  font-size: 1.8rem;
 }
 
-.read-the-docs {
-  color: #888;
+.guard-game-header p {
+  margin: 0.25rem 0 0;
+  opacity: 0.85;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+.guard-game-main {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  padding: 1rem;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.guard-game-panel {
+  border: 1px solid rgba(187, 224, 239, 0.22);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(16, 32, 44, 0.62);
+}
+
+.guard-game-panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.guard-game-viewport {
+  min-height: 120px;
+  border-radius: 0.5rem;
+  border: 1px dashed rgba(187, 224, 239, 0.35);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+.guard-game-world-state {
+  margin: 0;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  background: rgba(5, 10, 18, 0.75);
+  border: 1px solid rgba(187, 224, 239, 0.2);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 280px;
+  overflow: auto;
+}
+
+.guard-game-interaction-log {
+  margin: 0;
+  min-height: 2rem;
 }


### PR DESCRIPTION
## Closes #7

### Summary
- replaced the Vite counter starter bootstrap with a Guard Game application shell in `src/main.ts`
- wired `world`, `command buffer`, interaction stub, and render port through explicit interfaces
- added a deterministic fixed-tick loop that drains queued commands and applies them to the world before render
- updated the render stub to present viewport/player position and serialized world state output in the shell
- replaced starter CSS with Guard Game runtime shell styles

### Validation
- `npm run lint`
- `npm run build`
- `npm run test` (passes with no test files)