### PR TITLE
#8 implement Pixi scene with grid tiles and player sprite

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import './style.css';
 import { createCommandBuffer } from './input/commands';
 import { handleNpcInteraction } from './interaction/npcInteraction';
-import { createRenderPortStub } from './render/scene';
+import { createPixiRenderPort } from './render/scene';
 import type { WorldCommand, WorldState } from './world/types';
 import { createWorld } from './world/world';
 
@@ -44,10 +44,6 @@ if (!viewportElement || !worldStateElement || !interactionLogElement) {
 
 const world = createWorld();
 const commandBuffer = createCommandBuffer();
-const renderPort = createRenderPortStub({
-  viewport: viewportElement,
-  worldState: worldStateElement,
-});
 
 const keyToCommandMap: Record<string, WorldCommand> = {
   ArrowUp: { type: 'move', dx: 0, dy: -1 },
@@ -103,21 +99,33 @@ const fixedTickDurationMs = 100;
 let previousFrameTime = performance.now();
 let accumulatedTime = 0;
 
-const runFrame = (currentTime: number): void => {
-  accumulatedTime += currentTime - previousFrameTime;
-  previousFrameTime = currentTime;
+const startRuntime = async (): Promise<void> => {
+  const renderPort = await createPixiRenderPort({
+    viewport: viewportElement,
+  });
 
-  while (accumulatedTime >= fixedTickDurationMs) {
-    const commands = commandBuffer.drain();
-    world.applyCommands(commands);
-    const worldState = world.getState();
-    void runInteractionIfRequested(worldState, commands);
-    accumulatedTime -= fixedTickDurationMs;
-  }
+  const runFrame = (currentTime: number): void => {
+    accumulatedTime += currentTime - previousFrameTime;
+    previousFrameTime = currentTime;
 
-  renderPort.render(world.getState());
+    while (accumulatedTime >= fixedTickDurationMs) {
+      const commands = commandBuffer.drain();
+      world.applyCommands(commands);
+      const worldState = world.getState();
+      void runInteractionIfRequested(worldState, commands);
+      accumulatedTime -= fixedTickDurationMs;
+    }
+
+    const currentWorldState = world.getState();
+    renderPort.render(currentWorldState);
+    worldStateElement.textContent = JSON.stringify(currentWorldState, null, 2);
+    requestAnimationFrame(runFrame);
+  };
+
+  const initialWorldState = world.getState();
+  renderPort.render(initialWorldState);
+  worldStateElement.textContent = JSON.stringify(initialWorldState, null, 2);
   requestAnimationFrame(runFrame);
 };
 
-renderPort.render(world.getState());
-requestAnimationFrame(runFrame);
+void startRuntime();

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,22 +1,110 @@
+import { Application, Container, Graphics } from 'pixi.js';
 import type { WorldState } from '../world/types';
 
 export interface RenderPort {
   render(worldState: WorldState): void;
 }
 
-export interface DomRenderTargets {
+export interface PixiRenderTargets {
   viewport: HTMLElement;
-  worldState: HTMLElement;
 }
 
-const formatPlayerPosition = (worldState: WorldState): string => {
-  const { x, y } = worldState.player.position;
-  return `Player @ (${x}, ${y})`;
+interface RenderContext {
+  app: Application;
+  gridGraphics: Graphics;
+  playerGraphics: Graphics;
+  rootContainer: Container;
+  lastWidth: number;
+  lastHeight: number;
+}
+
+const ensureCanvasSize = (context: RenderContext, worldState: WorldState): void => {
+  const nextWidth = worldState.grid.width * worldState.grid.tileSize;
+  const nextHeight = worldState.grid.height * worldState.grid.tileSize;
+
+  if (context.lastWidth === nextWidth && context.lastHeight === nextHeight) {
+    return;
+  }
+
+  context.lastWidth = nextWidth;
+  context.lastHeight = nextHeight;
+  context.app.renderer.resize(nextWidth, nextHeight);
 };
 
-export const createRenderPortStub = (targets: DomRenderTargets): RenderPort => ({
-  render: (worldState: WorldState) => {
-    targets.viewport.textContent = formatPlayerPosition(worldState);
-    targets.worldState.textContent = JSON.stringify(worldState, null, 2);
+const drawGrid = (context: RenderContext, worldState: WorldState): void => {
+  const tileSize = worldState.grid.tileSize;
+  const widthPx = worldState.grid.width * tileSize;
+  const heightPx = worldState.grid.height * tileSize;
+
+  context.gridGraphics.clear();
+  context.gridGraphics.rect(0, 0, widthPx, heightPx).fill({ color: 0x112332 });
+
+  for (let x = 0; x <= worldState.grid.width; x += 1) {
+    context.gridGraphics
+      .moveTo(x * tileSize, 0)
+      .lineTo(x * tileSize, heightPx)
+      .stroke({ color: 0x2f4a5c, width: 1, alpha: 0.95 });
+  }
+
+  for (let y = 0; y <= worldState.grid.height; y += 1) {
+    context.gridGraphics
+      .moveTo(0, y * tileSize)
+      .lineTo(widthPx, y * tileSize)
+      .stroke({ color: 0x2f4a5c, width: 1, alpha: 0.95 });
+  }
+};
+
+const drawPlayerMarker = (context: RenderContext, worldState: WorldState): void => {
+  const tileSize = worldState.grid.tileSize;
+  const centerX = worldState.player.position.x * tileSize + tileSize / 2;
+  const centerY = worldState.player.position.y * tileSize + tileSize / 2;
+  const radius = Math.max(6, tileSize * 0.28);
+
+  context.playerGraphics.clear();
+  context.playerGraphics.circle(centerX, centerY, radius).fill({ color: 0xffcf66 });
+  context.playerGraphics
+    .circle(centerX, centerY, radius)
+    .stroke({ color: 0x6a4c13, width: 2, alpha: 1 });
+};
+
+export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<RenderPort> => {
+  const app = new Application();
+  await app.init({
+    width: 1,
+    height: 1,
+    antialias: true,
+    background: 0x091522,
+  });
+
+  targets.viewport.replaceChildren(app.canvas);
+
+  const gridGraphics = new Graphics();
+  const playerGraphics = new Graphics();
+  const rootContainer = new Container();
+  rootContainer.addChild(gridGraphics);
+  rootContainer.addChild(playerGraphics);
+  app.stage.addChild(rootContainer);
+
+  const context: RenderContext = {
+    app,
+    gridGraphics,
+    playerGraphics,
+    rootContainer,
+    lastWidth: 0,
+    lastHeight: 0,
+  };
+
+  return {
+    render: (worldState: WorldState) => {
+      ensureCanvasSize(context, worldState);
+      drawGrid(context, worldState);
+      drawPlayerMarker(context, worldState);
+    },
+  };
+};
+
+export const createRenderPortStub = (): RenderPort => ({
+  render: (_worldState: WorldState) => {
+    // Reserved for non-Pixi render testing scenarios.
   },
 });

--- a/src/style.css
+++ b/src/style.css
@@ -73,9 +73,13 @@ body {
   min-height: 120px;
   border-radius: 0.5rem;
   border: 1px dashed rgba(187, 224, 239, 0.35);
-  display: grid;
-  place-items: center;
-  font-weight: 700;
+  padding: 0.25rem;
+  overflow: auto;
+  background: rgba(5, 10, 18, 0.75);
+}
+
+.guard-game-viewport canvas {
+  display: block;
 }
 
 .guard-game-world-state {


### PR DESCRIPTION
## Closes #8

### Summary
- replaced the render stub with a Pixi-based render port in `src/render/scene.ts`
- initialized Pixi `Application`, root container, grid graphics, and player marker rendering derived only from `WorldState`
- updated `main.ts` to initialize the Pixi render port asynchronously and render world state through the port each frame
- kept world-state JSON debug output in `main.ts` orchestration while render logic stays in `src/render`
- adjusted viewport styles to host the Pixi canvas cleanly

### Validation
- `npm run lint`
- `npm run build`
- `npm run test` (pass-with-no-tests)