### PR TITLE
#9 integrate NPC interaction and LLM client stubs into flow

### DIFF
--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -1,3 +1,4 @@
+import type { LlmClient } from '../llm/client';
 import type { Npc, Player } from '../world/types';
 
 export interface NpcInteractionRequest {
@@ -9,6 +10,34 @@ export interface NpcInteractionResult {
   npcId: string;
   responseText: string;
 }
+
+export interface NpcInteractionService {
+  handleNpcInteraction(request: NpcInteractionRequest): Promise<NpcInteractionResult>;
+}
+
+const buildPromptContext = (request: NpcInteractionRequest): string => {
+  return [
+    `npc:${request.npc.id}`,
+    `npcName:${request.npc.displayName}`,
+    `dialogueContext:${request.npc.dialogueContextKey}`,
+    `player:${request.player.displayName}`,
+  ].join('|');
+};
+
+export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractionService => ({
+  handleNpcInteraction: async (request: NpcInteractionRequest): Promise<NpcInteractionResult> => {
+    const llmResponse = await llmClient.complete({
+      actorId: request.npc.id,
+      context: buildPromptContext(request),
+      playerMessage: `${request.player.displayName} interacts.`,
+    });
+
+    return {
+      npcId: request.npc.id,
+      responseText: `${request.npc.displayName}: ${llmResponse.text}`,
+    };
+  },
+});
 
 export const handleNpcInteraction = async (
   request: NpcInteractionRequest,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import './style.css';
 import { createCommandBuffer } from './input/commands';
-import { handleNpcInteraction } from './interaction/npcInteraction';
+import { createNpcInteractionService } from './interaction/npcInteraction';
+import { createStubLlmClient } from './llm/client';
 import { createPixiRenderPort } from './render/scene';
 import type { WorldCommand, WorldState } from './world/types';
 import { createWorld } from './world/world';
@@ -44,6 +45,8 @@ if (!viewportElement || !worldStateElement || !interactionLogElement) {
 
 const world = createWorld();
 const commandBuffer = createCommandBuffer();
+const llmClient = createStubLlmClient();
+const npcInteractionService = createNpcInteractionService(llmClient);
 
 const keyToCommandMap: Record<string, WorldCommand> = {
   ArrowUp: { type: 'move', dx: 0, dy: -1 },
@@ -87,7 +90,7 @@ const runInteractionIfRequested = async (
     return;
   }
 
-  const interactionResult = await handleNpcInteraction({
+  const interactionResult = await npcInteractionService.handleNpcInteraction({
     npc: nearbyNpc,
     player: worldState.player,
   });


### PR DESCRIPTION
## Closes #9

### Summary
- introduced an explicit `NpcInteractionService` in `src/interaction/npcInteraction.ts`
- wired the service to invoke the LLM stub client through `LlmClient.complete(...)`
- updated `main.ts` orchestration to instantiate `createStubLlmClient()` and route interaction calls through the new service interface
- kept render/world modules free of LLM dependencies

### Validation
- `npm run lint`
- `npm run build`
- `npm run test` (pass-with-no-tests)