### PR TITLE
Align agent tool access with role responsibilities

### DIFF
--- a/.github/agents/ai-behavior-adjuster.agent.md
+++ b/.github/agents/ai-behavior-adjuster.agent.md
@@ -1,7 +1,7 @@
 ---
 name: ai behavior adjuster
 description: "Use when adjusting AI behavior in Guard Game by changing agents, skills, instructions, prompts, or workflow customization files outside ticket flow; creates a plan, branches from main, pushes changes, and opens a PR for user review."
-tools: [read/readFile, search/codebase, search/fileSearch, search/textSearch, search/listDirectory, edit/editFiles, edit/createFile, edit/createDirectory, execute/runInTerminal, github/create_pull_request, github/issue_write, github/list_pull_requests, github/pull_request_read, github/search_pull_requests, todo]
+tools: [read/readFile, search/codebase, search/fileSearch, search/textSearch, search/listDirectory, edit/editFiles, edit/createFile, edit/createDirectory, execute/runInTerminal, github/create_pull_request, github/issue_write, github/add_issue_comment, github/add_reply_to_pull_request_comment, github/list_pull_requests, github/pull_request_read, github/search_pull_requests, todo]
 argument-hint: "AI behavior change request or customization goal"
 user-invocable: true
 ---

--- a/.github/agents/requirement-engineer.agent.md
+++ b/.github/agents/requirement-engineer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: requirement engineer
 description: "Use when creating or refining GitHub issues for Guard Game; defines scope, acceptance criteria, dependencies, and implementation-ready requirements aligned with project architecture."
-tools: [read, search, todo]
+tools: [read, search, todo, github/issue_read, github/issue_write, github/list_issues, github/search_issues]
 argument-hint: "Feature idea or GitHub issue number and requirement goal"
 user-invocable: true
 ---

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: "Use when reviewing a PR against a GitHub issue in Guard Game; supports partial-scope reviews and issue-level completeness reviews across multiple PRs."
-tools: [read/readFile, search/codebase, search/fileSearch, search/textSearch, github/add_comment_to_pending_review, github/add_issue_comment, github/add_reply_to_pull_request_comment, github/issue_read, github/list_branches, github/list_commits, github/list_issue_types, github/list_issues, github/list_pull_requests, github/pull_request_read, github/search_issues, github/search_pull_requests, github/search_repositories, github/search_users, github/update_pull_request, todo]
+tools: [read/readFile, search/codebase, search/fileSearch, search/textSearch, web/fetch, github/add_comment_to_pending_review, github/add_issue_comment, github/add_reply_to_pull_request_comment, github/issue_read, github/list_branches, github/list_commits, github/list_issue_types, github/list_issues, github/list_pull_requests, github/pull_request_read, github/search_issues, github/search_pull_requests, github/search_repositories, github/search_users, github/update_pull_request, todo]
 argument-hint: "GitHub issue number, PR link/number, and review mode (partial or complete)"
 user-invocable: true
 ---


### PR DESCRIPTION
## AI Behavior Customization

### Changes
- **requirement-engineer**: Added GitHub issue tools (`github/issue_read`, `github/issue_write`, `github/list_issues`, `github/search_issues`) — critical for issue creation/refinement role
- **reviewer**: Added `web/fetch` for external context gathering during reviews
- **ai-behavior-adjuster**: Added PR communication tools (`github/add_issue_comment`, `github/add_reply_to_pull_request_comment`) for workflow status updates

### Rationale
Each agent now has the full set of tools needed for effective role execution:
- Requirement engineer can now directly create and update GitHub issues instead of just designing them
- Reviewer can fetch external documentation/context for nuanced assessments
- AI behavior adjuster can provide status updates and communicate with reviewers on PRs

### Validation
- YAML frontmatter syntax verified
- Tool names validated against MCP GitHub tool catalog
- No runtime functionality changes; purely capability expansion