### PR TITLE
#11 isolate keyboard movement mapping in input

### DIFF
--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCommandBuffer } from './commands';
+import { bindKeyboardCommands, mapKeyboardEventToWorldCommand } from './keyboard';
+
+describe('mapKeyboardEventToWorldCommand', () => {
+  it('maps arrow keys and WASD to movement commands', () => {
+    expect(mapKeyboardEventToWorldCommand('ArrowUp')).toEqual({ type: 'move', dx: 0, dy: -1 });
+    expect(mapKeyboardEventToWorldCommand('ArrowDown')).toEqual({ type: 'move', dx: 0, dy: 1 });
+    expect(mapKeyboardEventToWorldCommand('ArrowLeft')).toEqual({ type: 'move', dx: -1, dy: 0 });
+    expect(mapKeyboardEventToWorldCommand('ArrowRight')).toEqual({ type: 'move', dx: 1, dy: 0 });
+    expect(mapKeyboardEventToWorldCommand('w')).toEqual({ type: 'move', dx: 0, dy: -1 });
+    expect(mapKeyboardEventToWorldCommand('a')).toEqual({ type: 'move', dx: -1, dy: 0 });
+    expect(mapKeyboardEventToWorldCommand('s')).toEqual({ type: 'move', dx: 0, dy: 1 });
+    expect(mapKeyboardEventToWorldCommand('d')).toEqual({ type: 'move', dx: 1, dy: 0 });
+  });
+
+  it('preserves interact mapping and ignores unrelated keys', () => {
+    expect(mapKeyboardEventToWorldCommand('e')).toEqual({ type: 'interact' });
+    expect(mapKeyboardEventToWorldCommand('q')).toBeNull();
+  });
+});
+
+describe('bindKeyboardCommands', () => {
+  it('enqueues commands for recognized keys and prevents browser defaults', () => {
+    const commandBuffer = createCommandBuffer();
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    const target = {
+      addEventListener,
+      removeEventListener,
+    } as unknown as Window;
+
+    const binding = bindKeyboardCommands(target, commandBuffer);
+    expect(addEventListener).toHaveBeenCalledTimes(1);
+    expect(addEventListener.mock.calls[0][0]).toBe('keydown');
+
+    const handler = addEventListener.mock.calls[0][1] as (event: KeyboardEvent) => void;
+    const handledEvent = {
+      key: 'ArrowRight',
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent;
+
+    handler(handledEvent);
+
+    expect(handledEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(commandBuffer.drain()).toEqual([{ type: 'move', dx: 1, dy: 0 }]);
+
+    const ignoredEvent = {
+      key: 'q',
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent;
+
+    handler(ignoredEvent);
+
+    expect(ignoredEvent.preventDefault).not.toHaveBeenCalled();
+    expect(commandBuffer.drain()).toEqual([]);
+
+    binding.dispose();
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(removeEventListener).toHaveBeenCalledWith('keydown', handler);
+  });
+});

--- a/src/input/keyboard.ts
+++ b/src/input/keyboard.ts
@@ -1,0 +1,45 @@
+import type { CommandBuffer } from './commands';
+import type { WorldCommand } from '../world/types';
+
+const keyToCommandMap: Record<string, WorldCommand> = {
+  ArrowUp: { type: 'move', dx: 0, dy: -1 },
+  ArrowDown: { type: 'move', dx: 0, dy: 1 },
+  ArrowLeft: { type: 'move', dx: -1, dy: 0 },
+  ArrowRight: { type: 'move', dx: 1, dy: 0 },
+  w: { type: 'move', dx: 0, dy: -1 },
+  a: { type: 'move', dx: -1, dy: 0 },
+  s: { type: 'move', dx: 0, dy: 1 },
+  d: { type: 'move', dx: 1, dy: 0 },
+  e: { type: 'interact' },
+};
+
+export const mapKeyboardEventToWorldCommand = (key: string): WorldCommand | null => {
+  return keyToCommandMap[key] ?? null;
+};
+
+export interface KeyboardCommandInputBinding {
+  dispose(): void;
+}
+
+export const bindKeyboardCommands = (
+  target: Window,
+  commandBuffer: CommandBuffer,
+): KeyboardCommandInputBinding => {
+  const onKeyDown = (event: KeyboardEvent): void => {
+    const command = mapKeyboardEventToWorldCommand(event.key);
+    if (!command) {
+      return;
+    }
+
+    event.preventDefault();
+    commandBuffer.enqueue(command);
+  };
+
+  target.addEventListener('keydown', onKeyDown);
+
+  return {
+    dispose: () => {
+      target.removeEventListener('keydown', onKeyDown);
+    },
+  };
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import './style.css';
 import { createCommandBuffer } from './input/commands';
+import { bindKeyboardCommands } from './input/keyboard';
 import { createNpcInteractionService } from './interaction/npcInteraction';
 import { createStubLlmClient } from './llm/client';
 import { createPixiRenderPort } from './render/scene';
@@ -47,28 +48,7 @@ const world = createWorld();
 const commandBuffer = createCommandBuffer();
 const llmClient = createStubLlmClient();
 const npcInteractionService = createNpcInteractionService(llmClient);
-
-const keyToCommandMap: Record<string, WorldCommand> = {
-  ArrowUp: { type: 'move', dx: 0, dy: -1 },
-  ArrowDown: { type: 'move', dx: 0, dy: 1 },
-  ArrowLeft: { type: 'move', dx: -1, dy: 0 },
-  ArrowRight: { type: 'move', dx: 1, dy: 0 },
-  w: { type: 'move', dx: 0, dy: -1 },
-  a: { type: 'move', dx: -1, dy: 0 },
-  s: { type: 'move', dx: 0, dy: 1 },
-  d: { type: 'move', dx: 1, dy: 0 },
-  e: { type: 'interact' },
-};
-
-window.addEventListener('keydown', (event: KeyboardEvent) => {
-  const command = keyToCommandMap[event.key];
-  if (!command) {
-    return;
-  }
-
-  event.preventDefault();
-  commandBuffer.enqueue(command);
-});
+bindKeyboardCommands(window, commandBuffer);
 
 const runInteractionIfRequested = async (
   worldState: WorldState,

--- a/src/world/world.test.ts
+++ b/src/world/world.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createWorld } from './world';
+
+describe('createWorld', () => {
+  it('applies movement commands deterministically in order', () => {
+    const world = createWorld();
+
+    world.applyCommands([
+      { type: 'move', dx: 1, dy: 0 },
+      { type: 'move', dx: 0, dy: 1 },
+      { type: 'move', dx: -1, dy: 0 },
+    ]);
+
+    expect(world.getState().player.position).toEqual({ x: 1, y: 2 });
+    expect(world.getState().tick).toBe(1);
+  });
+
+  it('clamps player movement to the grid bounds', () => {
+    const world = createWorld();
+
+    world.applyCommands([{ type: 'move', dx: -10, dy: -10 }]);
+    expect(world.getState().player.position).toEqual({ x: 0, y: 0 });
+
+    world.applyCommands([{ type: 'move', dx: 99, dy: 99 }]);
+    expect(world.getState().player.position).toEqual({ x: 11, y: 7 });
+  });
+});


### PR DESCRIPTION
## Summary
- move keyboard-to-command translation and keydown binding into `src/input`
- keep `main.ts` responsible only for runtime orchestration
- add tests for keyboard command mapping and deterministic world movement

## Validation
- `npm run build`
- `npm run lint`
- `npm run test`

Closes #11