### PR TITLE
#33 define shared Interactable base and Guard/Door world types

### DIFF
--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -20,6 +20,8 @@ export const createInitialWorldState = (): WorldState => ({
       dialogueContextKey: 'archive_keeper_intro',
     },
   ],
+  guards: [],
+  doors: [],
   interactiveObjects: [
     {
       id: 'obj-1',

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -16,10 +16,24 @@ export interface Npc {
   dialogueContextKey: string;
 }
 
-export interface InteractiveObject {
+/** Shared base for all interactable world objects. JSON-serializable. */
+export interface Interactable {
   id: string;
   displayName: string;
   position: GridPosition;
+}
+
+/** A guard entity that the player can interact with. */
+export interface Guard extends Interactable {
+  guardState: 'idle' | 'patrolling' | 'alert';
+}
+
+/** A door that the player can pass through or be blocked by. */
+export interface Door extends Interactable {
+  doorState: 'open' | 'closed' | 'locked';
+}
+
+export interface InteractiveObject extends Interactable {
   interactionType: 'inspect' | 'use' | 'talk';
   state: 'idle' | 'used';
 }
@@ -35,6 +49,8 @@ export interface WorldState {
   grid: WorldGrid;
   player: Player;
   npcs: Npc[];
+  guards: Guard[];
+  doors: Door[];
   interactiveObjects: InteractiveObject[];
 }
 


### PR DESCRIPTION
## Closes #33

### Summary
Introduces the foundational world-model type hierarchy for interactable objects.

### Changes
**`src/world/types.ts`**
- Added `Interactable` base interface (`id`, `displayName`, `position: GridPosition`) — shared by all interactable world objects.
- Added `Guard extends Interactable` with `guardState: 'idle' | 'patrolling' | 'alert'`.
- Added `Door extends Interactable` with `doorState: 'open' | 'closed' | 'locked'`.
- Updated `InteractiveObject` to extend `Interactable` (removes duplicate fields, no functional change).
- Added `guards: Guard[]` and `doors: Door[]` to `WorldState`.

**`src/world/state.ts`**
- Seeded `guards: []` and `doors: []` in `createInitialWorldState()`.

### Key decisions
- Used `position: GridPosition` (nested) rather than flat `x`/`y` to maintain consistency with existing `Player` and `Npc` types.
- Kept existing `interactiveObjects: InteractiveObject[]` unchanged to preserve serialization paths.
- No interaction behavior logic added — types and world model only.

### Validation
- `npm run build` ✅
- `npm run lint` ✅
- `npm run test` ✅ (5/5 tests pass)

<!-- CHANGE -->
