### PR TITLE
#36 author 20x20 starter level with two guard-door pairs

### DIFF
--- a/public/levels/manifest.json
+++ b/public/levels/manifest.json
@@ -1,1 +1,1 @@
-[]
+[{ "id": "starter", "name": "Starter" }]

--- a/public/levels/starter.json
+++ b/public/levels/starter.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "name": "Starter",
+  "width": 20,
+  "height": 20,
+  "player": { "x": 10, "y": 10 },
+  "guards": [
+    {
+      "id": "guard-1",
+      "displayName": "West Guard",
+      "x": 5,
+      "y": 10,
+      "guardState": "patrolling"
+    },
+    {
+      "id": "guard-2",
+      "displayName": "North Guard",
+      "x": 10,
+      "y": 5,
+      "guardState": "patrolling"
+    }
+  ],
+  "doors": [
+    {
+      "id": "door-1",
+      "displayName": "West Door",
+      "x": 2,
+      "y": 10,
+      "doorState": "closed"
+    },
+    {
+      "id": "door-2",
+      "displayName": "North Door",
+      "x": 10,
+      "y": 2,
+      "doorState": "closed"
+    }
+  ]
+}

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import starterJson from '../../public/levels/starter.json';
 import { deserializeLevel, validateLevelData } from './level';
 import type { LevelData } from './types';
 
@@ -141,5 +142,56 @@ describe('validateLevelData', () => {
   it('throws when input is not an object', () => {
     expect(() => validateLevelData(null)).toThrowError('expected an object');
     expect(() => validateLevelData('string')).toThrowError('expected an object');
+  });
+});
+
+describe('starter level', () => {
+  const starterRaw: unknown = starterJson;
+
+  it('passes validateLevelData without throwing', () => {
+    expect(() => validateLevelData(starterRaw)).not.toThrow();
+  });
+
+  it('deserializes to a WorldState with two guards and two doors', () => {
+    const level = validateLevelData(starterRaw);
+    const state = deserializeLevel(level);
+
+    expect(state.guards).toHaveLength(2);
+    expect(state.doors).toHaveLength(2);
+  });
+
+  it('places the player at (10, 10)', () => {
+    const level = validateLevelData(starterRaw);
+    const state = deserializeLevel(level);
+
+    expect(state.player.position).toEqual({ x: 10, y: 10 });
+  });
+
+  it('has a 20×20 grid', () => {
+    const level = validateLevelData(starterRaw);
+    const state = deserializeLevel(level);
+
+    expect(state.grid.width).toBe(20);
+    expect(state.grid.height).toBe(20);
+  });
+
+  it('all guards start in patrolling state and all doors start closed', () => {
+    const level = validateLevelData(starterRaw);
+    const state = deserializeLevel(level);
+
+    for (const guard of state.guards) {
+      expect(guard.guardState).toBe('patrolling');
+    }
+    for (const door of state.doors) {
+      expect(door.doorState).toBe('closed');
+    }
+  });
+
+  it('guard ids and door ids match expected descriptive values', () => {
+    const level = validateLevelData(starterRaw);
+    const state = deserializeLevel(level);
+
+    expect(state.guards.map((g) => g.id)).toEqual(['guard-1', 'guard-2']);
+    expect(state.doors.map((d) => d.id)).toEqual(['door-1', 'door-2']);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
+    "resolveJsonModule": true,
     "noEmit": true,
 
     /* Linting */


### PR DESCRIPTION
## Summary

Authors `public/levels/starter.json` — a complete 20×20 starter level with two guard-door pairs — and registers it in `manifest.json`. Adds six deserialization tests that load the real JSON file and verify the produced `WorldState`.

## Changes

### `public/levels/starter.json` (new)
- 20×20 grid, `version: 1`
- Player at `(10, 10)` — center with clearance
- **Pair 1 (west):** `guard-1` "West Guard" at `(5, 10)` | `door-1` "West Door" at `(2, 10)` — 3 tiles apart, no shared adjacency
- **Pair 2 (north):** `guard-2` "North Guard" at `(10, 5)` | `door-2` "North Door" at `(10, 2)` — 3 tiles apart, no shared adjacency
- Guards: `patrolling` state; doors: `closed` state

### `public/levels/manifest.json`
- Updated from `[]` to `[{ "id": "starter", "name": "Starter" }]`

### `src/world/level.test.ts`
- New `describe('starter level')` block with 6 tests: validates, deserializes, checks entity counts, player position, grid dimensions, states, and descriptive ids

### `tsconfig.json`
- Added `"resolveJsonModule": true` to support static JSON imports in tests

## Validation

- `npm run test` — 59/59 tests pass (7 test files)
- `npm run build` — tsc clean, Vite build succeeds
- `npm run lint` — no violations

## Layout decisions

Guards and doors are spaced ≥3 tiles apart so no player cell is simultaneously adjacent to both entities in a pair. The two pairs occupy opposing quadrants (west corridor vs north corridor), ensuring no cross-pair adjacency overlap.

Closes #36
Refs #30