### PR TITLE
Strengthen agent workflow for issue closure reconciliation

### DIFF
--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -34,6 +34,9 @@ Your job is to orchestrate a complete ticket workflow across specialized agents 
 5. Completion stage:
 - When merge-ready, invoke `developer` to finish the PR flow.
 - Confirm merge result and local-main fast-forward status.
+- If implementation used partial PR slices, verify parent-ticket completeness before declaring done:
+	- run `reviewer` in complete mode for the parent issue
+	- close the parent issue when complete, or report explicit remaining acceptance-criteria gaps when not complete
 
 ## Constraints
 - Keep each loop focused on one ticket at a time.

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -71,6 +71,9 @@ If the user asks you to finish a PR, follow this exact sequence:
   - consider and apply non-blocking comment adjustments when they improve quality
   - merge the PR
   - if the merged PR is the final slice for the ticket (for example the PR uses `Closes #<ticket-number>`), move the ticket to `Done`/`Completed`; if it is a partial PR (for example `Refs #<ticket-number>`), keep the ticket in progress/open
+  - after merge, run a parent-issue closure audit for any `Refs` links in the merged PR:
+    - if all acceptance criteria are now complete across merged slices, close the parent issue with a completion note
+    - if acceptance criteria remain, leave the parent open and add a brief status note describing remaining work
   - fast-forward local `main`
 3. If PR does not pass:
   - evaluate blocking comments and apply feasible fixes

--- a/.github/agents/requirement-engineer.agent.md
+++ b/.github/agents/requirement-engineer.agent.md
@@ -36,6 +36,7 @@ Your job is to produce clear, implementation-ready GitHub issues for the Guard G
 - Dependencies and ordering notes are explicit (link to other issues with #<number>).
 - Labels are applied: CHANGE, REFACTORING, or other issue labels relevant to implementation work.
 - Risks and open questions are listed when relevant.
+- If using parent + subtasks, include explicit parent-closure policy (what closes parent and who verifies completion).
 
 ## Working Process
 1. Clarify objective and player-facing outcome.

--- a/.github/skills/check/SKILL.md
+++ b/.github/skills/check/SKILL.md
@@ -19,10 +19,15 @@ Perform a structured self-review of an opened PR.
 - No obvious dead code or leftover debug artifacts.
 4. Validation:
 - Build/tests/manual checks are documented and recent.
+5. Issue linkage and closure intent:
+- PR body includes explicit closure intent (`Closes` vs `Refs`).
+- If this PR is partial (`Refs`), parent-issue closure ownership and timing are stated.
+- Ticket state outcomes after merge are unambiguous (what closes now vs what remains open).
 
 ## Cleanup Actions
 - Make any necessary cleanup commits.
 - Update PR description if scope or validation changed.
+- Update PR description if issue linkage/closure intent is unclear.
 
 ## Output
 - Findings (if any)

--- a/.github/skills/pr/SKILL.md
+++ b/.github/skills/pr/SKILL.md
@@ -12,7 +12,10 @@ Open a high-quality PR that is easy to review.
 1. Confirm branch is pushed and up to date.
 2. Prepare concise PR title and summary.
 3. Include validation evidence.
-4. Link the ticket correctly (`Refs` or `Closes` as appropriate).
+4. Declare explicit issue-closure intent in the PR body:
+- Use `Closes #<issue>` only when this PR is intended to complete the issue.
+- Use `Refs #<issue>` when this is a partial slice.
+- If using `Refs`, include one line naming who closes the parent issue and when (for example: `Parent closure: after AC-complete review in completion stage`).
 5. Add required labels.
 
 ## Output


### PR DESCRIPTION
## Summary
This AI behavior customization hardens ticket/PR workflow instructions so parent issues are not left open unintentionally after partial PR merges.

## Changes
- Updated `.github/skills/pr/SKILL.md` to require explicit closure intent in PR bodies (`Closes` vs `Refs`) and owner/timing for parent closure on partial slices.
- Updated `.github/skills/check/SKILL.md` to add issue-linkage and closure-intent reconciliation checks.
- Updated `.github/agents/developer.agent.md` to require a post-merge parent-issue closure audit for any `Refs` links.
- Updated `.github/agents/coordinator.agent.md` to require parent completeness verification in completion stage when partial slices are used.
- Updated `.github/agents/requirement-engineer.agent.md` to include parent/subtask closure policy in issue quality checklist.

## Validation
- Reviewed focused diff for all changed customization files.
- Confirmed changes are limited to agent/skill workflow files only.

## Notes
- AI behavior customization only.
- No runtime gameplay code changed.