### PR TITLE
#48 enforce shared spatial rules for movement and level loading

### DIFF
--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import starterJson from '../../public/levels/starter.json';
 import { deserializeLevel, validateLevelData } from './level';
+import * as spatialRules from './spatialRules';
 import type { LevelData } from './types';
 
 const minimalLevel: LevelData = {
@@ -96,6 +97,52 @@ describe('deserializeLevel', () => {
 
     // WorldState does not expose version, but deserialization must succeed
     expect(state).toBeDefined();
+  });
+
+  it('fails deterministically when an entity is out of bounds', () => {
+    const invalid: LevelData = {
+      ...minimalLevel,
+      guards: [
+        {
+          id: 'guard-1',
+          displayName: 'Out Guard',
+          x: 20,
+          y: 3,
+          guardState: 'idle',
+        },
+      ],
+    };
+
+    expect(() => deserializeLevel(invalid)).toThrowError(
+      'Invalid world layout: guard:guard-1 is out of bounds at (20, 3)',
+    );
+  });
+
+  it('fails deterministically when entities overlap at the same coordinate', () => {
+    const invalid: LevelData = {
+      ...minimalLevel,
+      doors: [
+        {
+          id: 'door-1',
+          displayName: 'Overlap Door',
+          x: 2,
+          y: 3,
+          doorState: 'closed',
+        },
+      ],
+    };
+
+    expect(() => deserializeLevel(invalid)).toThrowError(
+      'Invalid world layout: overlapping coordinates at (2, 3) between player:player and door:door-1',
+    );
+  });
+
+  it('uses the shared spatial rules path during level deserialization', () => {
+    const validateSpy = vi.spyOn(spatialRules, 'validateSpatialLayout');
+
+    deserializeLevel(minimalLevel);
+
+    expect(validateSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -1,4 +1,5 @@
 import type { LevelData, WorldState } from './types';
+import { validateSpatialLayout } from './spatialRules';
 
 const DEFAULT_TILE_SIZE = 48;
 
@@ -55,7 +56,7 @@ export function validateLevelData(input: unknown): LevelData {
  * Pure and deterministic: same input always produces the same output.
  */
 export function deserializeLevel(levelData: LevelData): WorldState {
-  return {
+  const worldState: WorldState = {
     tick: 0,
     grid: {
       width: levelData.width,
@@ -82,4 +83,6 @@ export function deserializeLevel(levelData: LevelData): WorldState {
     })),
     interactiveObjects: [],
   };
+  validateSpatialLayout(worldState);
+  return worldState;
 }

--- a/src/world/levelLoader.test.ts
+++ b/src/world/levelLoader.test.ts
@@ -57,6 +57,44 @@ describe('fetchAndLoadLevel', () => {
 
     await expect(fetchAndLoadLevel('/levels/bad.json')).rejects.toThrow();
   });
+
+  it('fails deterministically when loaded coordinates are out of bounds', async () => {
+    mockFetch({
+      ...minimalLevel,
+      guards: [
+        {
+          id: 'guard-1',
+          displayName: 'Out Guard',
+          x: 20,
+          y: 2,
+          guardState: 'idle',
+        },
+      ],
+    });
+
+    await expect(fetchAndLoadLevel('/levels/out-of-bounds.json')).rejects.toThrow(
+      'Invalid world layout: guard:guard-1 is out of bounds at (20, 2)',
+    );
+  });
+
+  it('fails deterministically when loaded entities overlap', async () => {
+    mockFetch({
+      ...minimalLevel,
+      doors: [
+        {
+          id: 'door-1',
+          displayName: 'Overlap Door',
+          x: 2,
+          y: 3,
+          doorState: 'closed',
+        },
+      ],
+    });
+
+    await expect(fetchAndLoadLevel('/levels/overlap.json')).rejects.toThrow(
+      'Invalid world layout: overlapping coordinates at (2, 3) between player:player and door:door-1',
+    );
+  });
 });
 
 describe('fetchLevelManifest', () => {

--- a/src/world/spatialRules.test.ts
+++ b/src/world/spatialRules.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { canMovePlayerTo, getBlockingOccupants, isInBounds, validateSpatialLayout } from './spatialRules';
+import { createInitialWorldState } from './state';
+
+describe('spatialRules', () => {
+  it('detects in-bounds and out-of-bounds coordinates', () => {
+    const worldState = createInitialWorldState();
+
+    expect(isInBounds({ x: 0, y: 0 }, worldState.grid)).toBe(true);
+    expect(isInBounds({ x: worldState.grid.width, y: 0 }, worldState.grid)).toBe(false);
+    expect(isInBounds({ x: 0, y: -1 }, worldState.grid)).toBe(false);
+  });
+
+  it('returns blocking occupants for npc and interactive object tiles', () => {
+    const worldState = createInitialWorldState();
+
+    const npcBlockers = getBlockingOccupants(worldState, { x: 8, y: 3 });
+    expect(npcBlockers.map((blocker) => blocker.label)).toEqual(['npc:npc-1']);
+
+    const objectBlockers = getBlockingOccupants(worldState, { x: 4, y: 5 });
+    expect(objectBlockers.map((blocker) => blocker.label)).toEqual(['interactiveObject:obj-1']);
+  });
+
+  it('allows movement only into in-bounds unoccupied tiles', () => {
+    const worldState = createInitialWorldState();
+
+    expect(canMovePlayerTo(worldState, { x: 2, y: 1 })).toBe(true);
+    expect(canMovePlayerTo(worldState, { x: -1, y: 1 })).toBe(false);
+    expect(canMovePlayerTo(worldState, { x: 8, y: 3 })).toBe(false);
+  });
+
+  it('validates a non-overlapping in-bounds layout', () => {
+    const worldState = createInitialWorldState();
+
+    expect(() => validateSpatialLayout(worldState)).not.toThrow();
+  });
+
+  it('throws deterministic errors for out-of-bounds and overlapping coordinates', () => {
+    const worldState = createInitialWorldState();
+
+    const outOfBounds = {
+      ...worldState,
+      player: {
+        ...worldState.player,
+        position: { x: worldState.grid.width, y: 0 },
+      },
+    };
+
+    expect(() => validateSpatialLayout(outOfBounds)).toThrowError(
+      `Invalid world layout: player:${worldState.player.id} is out of bounds at (${worldState.grid.width}, 0)`,
+    );
+
+    const overlapping = {
+      ...worldState,
+      npcs: [
+        {
+          ...worldState.npcs[0],
+          position: { ...worldState.player.position },
+        },
+      ],
+    };
+
+    expect(() => validateSpatialLayout(overlapping)).toThrowError(
+      `Invalid world layout: overlapping coordinates at (${worldState.player.position.x}, ${worldState.player.position.y}) between player:${worldState.player.id} and npc:${worldState.npcs[0].id}`,
+    );
+  });
+});

--- a/src/world/spatialRules.ts
+++ b/src/world/spatialRules.ts
@@ -1,0 +1,78 @@
+import type { GridPosition, WorldGrid, WorldState } from './types';
+
+interface SpatialEntity {
+  label: string;
+  position: GridPosition;
+}
+
+const samePosition = (a: GridPosition, b: GridPosition): boolean => a.x === b.x && a.y === b.y;
+
+export const isInBounds = (position: GridPosition, grid: WorldGrid): boolean =>
+  position.x >= 0 && position.x < grid.width && position.y >= 0 && position.y < grid.height;
+
+export const getBlockingOccupants = (worldState: WorldState, position: GridPosition): SpatialEntity[] => {
+  const blockers: SpatialEntity[] = [];
+
+  for (const npc of worldState.npcs) {
+    if (samePosition(npc.position, position)) {
+      blockers.push({ label: `npc:${npc.id}`, position: npc.position });
+    }
+  }
+
+  for (const interactiveObject of worldState.interactiveObjects) {
+    if (samePosition(interactiveObject.position, position)) {
+      blockers.push({ label: `interactiveObject:${interactiveObject.id}`, position: interactiveObject.position });
+    }
+  }
+
+  for (const guard of worldState.guards) {
+    if (samePosition(guard.position, position)) {
+      blockers.push({ label: `guard:${guard.id}`, position: guard.position });
+    }
+  }
+
+  for (const door of worldState.doors) {
+    if (samePosition(door.position, position)) {
+      blockers.push({ label: `door:${door.id}`, position: door.position });
+    }
+  }
+
+  return blockers;
+};
+
+export const canMovePlayerTo = (worldState: WorldState, target: GridPosition): boolean =>
+  isInBounds(target, worldState.grid) && getBlockingOccupants(worldState, target).length === 0;
+
+const collectSpatialEntities = (worldState: WorldState): SpatialEntity[] => [
+  { label: `player:${worldState.player.id}`, position: worldState.player.position },
+  ...worldState.npcs.map((npc) => ({ label: `npc:${npc.id}`, position: npc.position })),
+  ...worldState.interactiveObjects.map((interactiveObject) => ({
+    label: `interactiveObject:${interactiveObject.id}`,
+    position: interactiveObject.position,
+  })),
+  ...worldState.guards.map((guard) => ({ label: `guard:${guard.id}`, position: guard.position })),
+  ...worldState.doors.map((door) => ({ label: `door:${door.id}`, position: door.position })),
+];
+
+export const validateSpatialLayout = (worldState: WorldState): void => {
+  const entities = collectSpatialEntities(worldState);
+  const occupiedByCoordinate = new Map<string, string>();
+
+  for (const entity of entities) {
+    if (!isInBounds(entity.position, worldState.grid)) {
+      throw new Error(
+        `Invalid world layout: ${entity.label} is out of bounds at (${entity.position.x}, ${entity.position.y})`,
+      );
+    }
+
+    const coordinateKey = `${entity.position.x},${entity.position.y}`;
+    const existingEntityLabel = occupiedByCoordinate.get(coordinateKey);
+    if (existingEntityLabel) {
+      throw new Error(
+        `Invalid world layout: overlapping coordinates at (${entity.position.x}, ${entity.position.y}) between ${existingEntityLabel} and ${entity.label}`,
+      );
+    }
+
+    occupiedByCoordinate.set(coordinateKey, entity.label);
+  }
+};

--- a/src/world/world.test.ts
+++ b/src/world/world.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import * as spatialRules from './spatialRules';
 import { createWorld } from './world';
 
 describe('createWorld', () => {
@@ -15,13 +16,84 @@ describe('createWorld', () => {
     expect(world.getState().tick).toBe(1);
   });
 
-  it('clamps player movement to the grid bounds', () => {
+  it('keeps player position unchanged when movement goes out of bounds', () => {
     const world = createWorld();
 
     world.applyCommands([{ type: 'move', dx: -10, dy: -10 }]);
-    expect(world.getState().player.position).toEqual({ x: 0, y: 0 });
+    expect(world.getState().player.position).toEqual({ x: 1, y: 1 });
 
-    world.applyCommands([{ type: 'move', dx: 99, dy: 99 }]);
+    world.applyCommands([
+      { type: 'move', dx: 10, dy: 6 },
+      { type: 'move', dx: 1, dy: 0 },
+    ]);
     expect(world.getState().player.position).toEqual({ x: 11, y: 7 });
+  });
+
+  it('blocks movement into occupied npc, interactive object, guard, and door tiles', () => {
+    const world = createWorld();
+    const baseState = world.getState();
+
+    world.resetToState({
+      ...baseState,
+      player: {
+        ...baseState.player,
+        position: { x: 2, y: 2 },
+      },
+      npcs: [
+        {
+          id: 'npc-blocker',
+          displayName: 'Npc blocker',
+          dialogueContextKey: 'npc-blocker',
+          position: { x: 3, y: 2 },
+        },
+      ],
+      interactiveObjects: [
+        {
+          id: 'object-blocker',
+          displayName: 'Object blocker',
+          interactionType: 'inspect',
+          state: 'idle',
+          position: { x: 2, y: 3 },
+        },
+      ],
+      guards: [
+        {
+          id: 'guard-blocker',
+          displayName: 'Guard blocker',
+          guardState: 'idle',
+          position: { x: 1, y: 2 },
+        },
+      ],
+      doors: [
+        {
+          id: 'door-blocker',
+          displayName: 'Door blocker',
+          doorState: 'closed',
+          position: { x: 2, y: 1 },
+        },
+      ],
+    });
+
+    world.applyCommands([{ type: 'move', dx: 1, dy: 0 }]);
+    expect(world.getState().player.position).toEqual({ x: 2, y: 2 });
+
+    world.applyCommands([{ type: 'move', dx: 0, dy: 1 }]);
+    expect(world.getState().player.position).toEqual({ x: 2, y: 2 });
+
+    world.applyCommands([{ type: 'move', dx: -1, dy: 0 }]);
+    expect(world.getState().player.position).toEqual({ x: 2, y: 2 });
+
+    world.applyCommands([{ type: 'move', dx: 0, dy: -1 }]);
+    expect(world.getState().player.position).toEqual({ x: 2, y: 2 });
+  });
+
+  it('uses the shared spatial rule path for runtime movement checks', () => {
+    const world = createWorld();
+    const canMoveSpy = vi.spyOn(spatialRules, 'canMovePlayerTo');
+
+    world.applyCommands([{ type: 'move', dx: 1, dy: 0 }]);
+
+    expect(canMoveSpy).toHaveBeenCalledTimes(1);
+    expect(canMoveSpy).toHaveBeenCalledWith(expect.any(Object), { x: 2, y: 1 });
   });
 });

--- a/src/world/world.ts
+++ b/src/world/world.ts
@@ -1,21 +1,23 @@
 import { createInitialWorldState } from './state';
+import { canMovePlayerTo } from './spatialRules';
 import type { World, WorldCommand, WorldState } from './types';
-
-const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
 
 const applyCommand = (worldState: WorldState, command: WorldCommand): WorldState => {
   if (command.type === 'move') {
-    const nextX = clamp(worldState.player.position.x + command.dx, 0, worldState.grid.width - 1);
-    const nextY = clamp(worldState.player.position.y + command.dy, 0, worldState.grid.height - 1);
+    const nextPosition = {
+      x: worldState.player.position.x + command.dx,
+      y: worldState.player.position.y + command.dy,
+    };
+
+    if (!canMovePlayerTo(worldState, nextPosition)) {
+      return worldState;
+    }
 
     return {
       ...worldState,
       player: {
         ...worldState.player,
-        position: {
-          x: nextX,
-          y: nextY,
-        },
+        position: nextPosition,
       },
     };
   }


### PR DESCRIPTION
## Summary
- add shared world-layer spatial rules in `src/world/spatialRules.ts` for bounds, occupancy, and deterministic overlap validation
- route runtime movement checks through shared rules so player moves are rejected (position unchanged) when target tiles are out-of-bounds or occupied
- route level deserialization through the same shared rules to fail deterministically on out-of-bounds/overlapping coordinates
- extend world/level/loader tests and add dedicated shared-rules tests for accepted + rejected paths, including assertions that both runtime and load paths call shared rules

## Validation
- `npm test` ✅ (9 files, 76 tests passed)
- `npm run lint` ✅
- `npm run build` ✅

## Scope Guard
- no changes for #39
- no changes for #28
- no changes for #47

Closes #48