### PR TITLE
#55 redesign runtime layout for viewport/interaction split

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { createNpcInteractionService } from './interaction/npcInteraction';
 import { createStubLlmClient } from './llm/client';
 import { createPixiRenderPort } from './render/scene';
 import { createLevelUi } from './render/levelUi';
+import { getRuntimeLayoutMarkup } from './render/runtimeLayout';
 import type { WorldCommand, WorldState } from './world/types';
 import { createWorld } from './world/world';
 import { fetchAndLoadLevel, fetchLevelManifest } from './world/levelLoader';
@@ -18,32 +19,7 @@ if (!appElement) {
   throw new Error('Expected #app root element.');
 }
 
-appElement.innerHTML = `
-  <div class="guard-game-shell">
-    <header class="guard-game-header">
-      <h1>Guard Game</h1>
-      <p>Deterministic runtime bootstrap</p>
-    </header>
-    <main class="guard-game-main">
-      <section class="guard-game-panel">
-        <h2>Viewport</h2>
-        <div id="viewport" class="guard-game-viewport"></div>
-      </section>
-      <section class="guard-game-panel">
-        <h2>Level Controls</h2>
-        <div id="level-controls" class="guard-game-level-controls"></div>
-      </section>
-      <section class="guard-game-panel">
-        <h2>World State</h2>
-        <pre id="world-state" class="guard-game-world-state"></pre>
-      </section>
-      <section class="guard-game-panel">
-        <h2>Interaction</h2>
-        <p id="interaction-log" class="guard-game-interaction-log">No interaction yet.</p>
-      </section>
-    </main>
-  </div>
-`;
+appElement.innerHTML = getRuntimeLayoutMarkup();
 
 const viewportElement = document.querySelector<HTMLElement>('#viewport');
 const levelControlsElement = document.querySelector<HTMLElement>('#level-controls');

--- a/src/render/runtimeLayout.test.ts
+++ b/src/render/runtimeLayout.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { getRuntimeLayoutMarkup } from './runtimeLayout';
+
+describe('runtime layout markup', () => {
+  it('places viewport and interaction in the primary two-column area', () => {
+    const markup = getRuntimeLayoutMarkup();
+
+    expect(markup).toContain('class="guard-game-primary"');
+    expect(markup).toContain('id="viewport"');
+    expect(markup).toContain('id="interaction-log"');
+
+    const viewportIndex = markup.indexOf('id="viewport"');
+    const interactionIndex = markup.indexOf('id="interaction-log"');
+    const primaryIndex = markup.indexOf('class="guard-game-primary"');
+    const secondaryIndex = markup.indexOf('class="guard-game-secondary"');
+
+    expect(primaryIndex).toBeGreaterThanOrEqual(0);
+    expect(secondaryIndex).toBeGreaterThan(primaryIndex);
+    expect(viewportIndex).toBeGreaterThan(primaryIndex);
+    expect(interactionIndex).toBeGreaterThan(viewportIndex);
+    expect(interactionIndex).toBeLessThan(secondaryIndex);
+  });
+
+  it('places level controls and world state below the primary area', () => {
+    const markup = getRuntimeLayoutMarkup();
+
+    const levelControlsIndex = markup.indexOf('id="level-controls"');
+    const worldStateIndex = markup.indexOf('id="world-state"');
+    const secondaryIndex = markup.indexOf('class="guard-game-secondary"');
+
+    expect(levelControlsIndex).toBeGreaterThan(secondaryIndex);
+    expect(worldStateIndex).toBeGreaterThan(levelControlsIndex);
+  });
+});

--- a/src/render/runtimeLayout.ts
+++ b/src/render/runtimeLayout.ts
@@ -1,0 +1,32 @@
+export const getRuntimeLayoutMarkup = (): string => {
+  return `
+  <div class="guard-game-shell">
+    <header class="guard-game-header">
+      <h1>Guard Game</h1>
+      <p>Deterministic runtime bootstrap</p>
+    </header>
+    <main class="guard-game-main">
+      <section class="guard-game-primary" aria-label="Gameplay and interaction">
+        <section class="guard-game-panel guard-game-panel-viewport">
+          <h2>Viewport</h2>
+          <div id="viewport" class="guard-game-viewport"></div>
+        </section>
+        <section class="guard-game-panel guard-game-panel-interaction">
+          <h2>Interaction</h2>
+          <p id="interaction-log" class="guard-game-interaction-log">No interaction yet.</p>
+        </section>
+      </section>
+      <section class="guard-game-secondary" aria-label="Level controls and world state">
+        <section class="guard-game-panel">
+          <h2>Level Controls</h2>
+          <div id="level-controls" class="guard-game-level-controls"></div>
+        </section>
+        <section class="guard-game-panel">
+          <h2>World State</h2>
+          <pre id="world-state" class="guard-game-world-state"></pre>
+        </section>
+      </section>
+    </main>
+  </div>
+`;
+};

--- a/src/style.css
+++ b/src/style.css
@@ -51,10 +51,23 @@ body {
 }
 
 .guard-game-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.guard-game-primary {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  padding: 1rem;
+  grid-template-columns: minmax(320px, 1fr) minmax(280px, 0.9fr);
+  align-items: stretch;
+}
+
+.guard-game-secondary {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
 }
 
 .guard-game-panel {
@@ -62,6 +75,17 @@ body {
   border-radius: 0.75rem;
   padding: 0.75rem;
   background: rgba(16, 32, 44, 0.62);
+}
+
+.guard-game-panel-viewport {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.guard-game-panel-interaction {
+  display: flex;
+  flex-direction: column;
 }
 
 .guard-game-panel h2 {
@@ -99,5 +123,32 @@ body {
 
 .guard-game-interaction-log {
   margin: 0;
-  min-height: 2rem;
+  min-height: 12rem;
+  max-height: 480px;
+  overflow: auto;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(187, 224, 239, 0.2);
+  background: rgba(5, 10, 18, 0.75);
+}
+
+@media (max-width: 900px) {
+  .guard-game-primary {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 700px) {
+  #app {
+    padding: 0.75rem;
+  }
+
+  .guard-game-secondary {
+    grid-template-columns: 1fr;
+  }
+
+  .guard-game-viewport {
+    width: 100%;
+    max-width: 288px;
+  }
 }


### PR DESCRIPTION
## Summary
- move runtime shell into a dedicated layout markup helper and restructure sections so viewport is left and interaction is right in the primary area
- place level controls and world state in a secondary area below the primary two-column layout
- update CSS for desktop two-column composition with mobile-friendly stacked fallbacks
- add a focused layout markup test to protect panel ordering and placement intent

## Validation
- npm run lint
- npm run test
- npm run build

## Closes #55
