### PR TITLE
#56 integrate Gemini NPC chat with deterministic per-NPC history

### DIFF
--- a/src/interaction/adjacencyResolver.test.ts
+++ b/src/interaction/adjacencyResolver.test.ts
@@ -10,6 +10,7 @@ const baseState = (): WorldState => ({
   guards: [],
   doors: [],
   interactiveObjects: [],
+  npcConversationHistoryByNpcId: {},
 });
 
 const makeGuard = (x: number, y: number): Guard => ({

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
+import { createNpcInteractionService } from './npcInteraction';
+import { createInitialWorldState } from '../world/state';
+import type { ConversationMessage } from '../world/types';
+
+describe('createNpcInteractionService', () => {
+  it('appends player then assistant messages for a single npc turn', async () => {
+    const complete = vi.fn(async () => ({ text: 'The archives are west of here.' }));
+    const llmClient: LlmClient = { complete };
+    const service = createNpcInteractionService(llmClient);
+
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Where are the archives?',
+    });
+
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: npc.id,
+        playerMessage: 'Where are the archives?',
+        conversationHistory: [{ role: 'player', text: 'Where are the archives?' }],
+      }),
+    );
+    expect(result.responseText).toBe('Archivist: The archives are west of here.');
+    expect(result.updatedWorldState.npcConversationHistoryByNpcId[npc.id]).toEqual([
+      { role: 'player', text: 'Where are the archives?' },
+      { role: 'assistant', text: 'The archives are west of here.' },
+    ]);
+  });
+
+  it('preserves prior per-npc history when appending a new turn', async () => {
+    const complete = vi.fn(async () => ({ text: 'The lower vault is sealed.' }));
+    const llmClient: LlmClient = { complete };
+    const service = createNpcInteractionService(llmClient);
+
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+    const priorHistory: ConversationMessage[] = [
+      { role: 'player', text: 'Any updates?' },
+      { role: 'assistant', text: 'No updates yet.' },
+    ];
+
+    const seededState = {
+      ...worldState,
+      npcConversationHistoryByNpcId: {
+        ...worldState.npcConversationHistoryByNpcId,
+        [npc.id]: priorHistory,
+      },
+    };
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState: seededState,
+      playerMessage: 'What about the lower vault?',
+    });
+
+    expect(result.updatedWorldState.npcConversationHistoryByNpcId[npc.id]).toEqual([
+      ...priorHistory,
+      { role: 'player', text: 'What about the lower vault?' },
+      { role: 'assistant', text: 'The lower vault is sealed.' },
+    ]);
+  });
+
+  it('stores deterministic fallback assistant text when llm request throws', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => {
+        throw new Error('timeout');
+      },
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Can you hear me?',
+    });
+
+    expect(result.responseText).toBe(`Archivist: ${REQUEST_FAILURE_FALLBACK_TEXT}`);
+    expect(result.updatedWorldState.npcConversationHistoryByNpcId[npc.id]).toEqual([
+      { role: 'player', text: 'Can you hear me?' },
+      { role: 'assistant', text: REQUEST_FAILURE_FALLBACK_TEXT },
+    ]);
+  });
+
+  it('keeps npc conversation history JSON-serializable', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({ text: 'Stay on patrol routes.' }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Any advice?',
+    });
+
+    const json = JSON.stringify(result.updatedWorldState);
+    const parsed = JSON.parse(json) as typeof result.updatedWorldState;
+
+    expect(parsed.npcConversationHistoryByNpcId[npc.id]).toEqual([
+      { role: 'player', text: 'Any advice?' },
+      { role: 'assistant', text: 'Stay on patrol routes.' },
+    ]);
+  });
+});

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -1,14 +1,17 @@
-import type { LlmClient } from '../llm/client';
-import type { Npc, Player } from '../world/types';
+import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
+import type { ConversationMessage, Npc, Player, WorldState } from '../world/types';
 
 export interface NpcInteractionRequest {
   npc: Npc;
   player: Player;
+  worldState: WorldState;
+  playerMessage: string;
 }
 
 export interface NpcInteractionResult {
   npcId: string;
   responseText: string;
+  updatedWorldState: WorldState;
 }
 
 export interface NpcInteractionService {
@@ -26,15 +29,42 @@ const buildPromptContext = (request: NpcInteractionRequest): string => {
 
 export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractionService => ({
   handleNpcInteraction: async (request: NpcInteractionRequest): Promise<NpcInteractionResult> => {
-    const llmResponse = await llmClient.complete({
-      actorId: request.npc.id,
-      context: buildPromptContext(request),
-      playerMessage: `${request.player.displayName} interacts.`,
-    });
+    const previousHistory = request.worldState.npcConversationHistoryByNpcId[request.npc.id] ?? [];
+    const playerMessageRecord: ConversationMessage = {
+      role: 'player',
+      text: request.playerMessage,
+    };
+    const historyWithPlayerMessage = [...previousHistory, playerMessageRecord];
+
+    const assistantText = await llmClient
+      .complete({
+        actorId: request.npc.id,
+        context: buildPromptContext(request),
+        playerMessage: request.playerMessage,
+        conversationHistory: historyWithPlayerMessage,
+      })
+      .then((llmResponse) => llmResponse.text)
+      .catch(() => REQUEST_FAILURE_FALLBACK_TEXT);
+
+    const assistantMessageRecord: ConversationMessage = {
+      role: 'assistant',
+      text: assistantText,
+    };
+
+    const updatedHistoryByNpcId = {
+      ...request.worldState.npcConversationHistoryByNpcId,
+      [request.npc.id]: [...historyWithPlayerMessage, assistantMessageRecord],
+    };
+
+    const updatedWorldState: WorldState = {
+      ...request.worldState,
+      npcConversationHistoryByNpcId: updatedHistoryByNpcId,
+    };
 
     return {
       npcId: request.npc.id,
-      responseText: `${request.npc.displayName}: ${llmResponse.text}`,
+      responseText: `${request.npc.displayName}: ${assistantText}`,
+      updatedWorldState,
     };
   },
 });
@@ -42,8 +72,26 @@ export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractio
 export const handleNpcInteraction = async (
   request: NpcInteractionRequest,
 ): Promise<NpcInteractionResult> => {
+  const fallbackText = `${request.npc.displayName} has nothing to say yet.`;
+  const playerMessageRecord: ConversationMessage = {
+    role: 'player',
+    text: request.playerMessage,
+  };
+  const assistantMessageRecord: ConversationMessage = {
+    role: 'assistant',
+    text: fallbackText,
+  };
+  const previousHistory = request.worldState.npcConversationHistoryByNpcId[request.npc.id] ?? [];
+
   return {
     npcId: request.npc.id,
-    responseText: `${request.npc.displayName} has nothing to say yet.`,
+    responseText: fallbackText,
+    updatedWorldState: {
+      ...request.worldState,
+      npcConversationHistoryByNpcId: {
+        ...request.worldState.npcConversationHistoryByNpcId,
+        [request.npc.id]: [...previousHistory, playerMessageRecord, assistantMessageRecord],
+      },
+    },
   };
 };

--- a/src/llm/client.test.ts
+++ b/src/llm/client.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createGeminiLlmClient,
+  MISSING_API_KEY_FALLBACK_TEXT,
+  REQUEST_FAILURE_FALLBACK_TEXT,
+} from './client';
+
+const prompt = {
+  actorId: 'npc-1',
+  context: 'npc:npc-1|npcName:Archivist',
+  playerMessage: 'Hello there',
+  conversationHistory: [{ role: 'player' as const, text: 'Hello there' }],
+};
+
+describe('createGeminiLlmClient', () => {
+  it('returns model text on successful Gemini response', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'Welcome, traveler.' }],
+            },
+          },
+        ],
+      }),
+    }));
+
+    const client = createGeminiLlmClient({
+      apiKey: 'test-key',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await client.complete(prompt);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(response).toEqual({ text: 'Welcome, traveler.' });
+  });
+
+  it('returns deterministic fallback when API key is missing', async () => {
+    const fetchImpl = vi.fn();
+    const client = createGeminiLlmClient({
+      apiKey: '',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await client.complete(prompt);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(response).toEqual({ text: MISSING_API_KEY_FALLBACK_TEXT });
+  });
+
+  it('returns deterministic fallback when request fails', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      json: async () => ({}),
+    }));
+
+    const client = createGeminiLlmClient({
+      apiKey: 'test-key',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await client.complete(prompt);
+
+    expect(response).toEqual({ text: REQUEST_FAILURE_FALLBACK_TEXT });
+  });
+
+  it('returns deterministic fallback when fetch throws', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('network down');
+    });
+
+    const client = createGeminiLlmClient({
+      apiKey: 'test-key',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await client.complete(prompt);
+
+    expect(response).toEqual({ text: REQUEST_FAILURE_FALLBACK_TEXT });
+  });
+});

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -2,6 +2,12 @@ export interface LlmPrompt {
   actorId: string;
   context: string;
   playerMessage: string;
+  conversationHistory: LlmConversationMessage[];
+}
+
+export interface LlmConversationMessage {
+  role: 'player' | 'assistant';
+  text: string;
 }
 
 export interface LlmResponse {
@@ -11,6 +17,110 @@ export interface LlmResponse {
 export interface LlmClient {
   complete(prompt: LlmPrompt): Promise<LlmResponse>;
 }
+
+export interface GeminiLlmClientOptions {
+  apiKey?: string;
+  model?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_GEMINI_MODEL = 'gemini-2.0-flash';
+const DEFAULT_TIMEOUT_MS = 6_000;
+
+export const MISSING_API_KEY_FALLBACK_TEXT =
+  'I cannot access my briefing network right now. Please try again later.';
+export const REQUEST_FAILURE_FALLBACK_TEXT =
+  'I cannot process that request right now. Please try again later.';
+
+const toGeminiRole = (role: LlmConversationMessage['role']): 'user' | 'model' => {
+  return role === 'player' ? 'user' : 'model';
+};
+
+const extractGeminiText = (payload: unknown): string | null => {
+  if (typeof payload !== 'object' || payload === null) {
+    return null;
+  }
+
+  const candidates = (payload as { candidates?: unknown }).candidates;
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    return null;
+  }
+
+  const firstCandidate = candidates[0] as { content?: { parts?: Array<{ text?: unknown }> } };
+  const parts = firstCandidate.content?.parts;
+  if (!Array.isArray(parts)) {
+    return null;
+  }
+
+  const text = parts
+    .map((part) => (typeof part.text === 'string' ? part.text : ''))
+    .join('')
+    .trim();
+
+  return text.length > 0 ? text : null;
+};
+
+export const createGeminiLlmClient = (options: GeminiLlmClientOptions = {}): LlmClient => {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const apiKey = options.apiKey ?? import.meta.env.VITE_GEMINI_API_KEY;
+  const model = options.model ?? DEFAULT_GEMINI_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return {
+    complete: async (prompt: LlmPrompt): Promise<LlmResponse> => {
+      if (!apiKey) {
+        return { text: MISSING_API_KEY_FALLBACK_TEXT };
+      }
+
+      const abortController = new AbortController();
+      const timeout = setTimeout(() => {
+        abortController.abort();
+      }, timeoutMs);
+
+      try {
+        const response = await fetchImpl(
+          `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              systemInstruction: {
+                parts: [{ text: `actorId:${prompt.actorId}|context:${prompt.context}` }],
+              },
+              contents: prompt.conversationHistory.map((message) => ({
+                role: toGeminiRole(message.role),
+                parts: [{ text: message.text }],
+              })),
+              generationConfig: {
+                temperature: 0,
+              },
+            }),
+            signal: abortController.signal,
+          },
+        );
+
+        if (!response.ok) {
+          return { text: REQUEST_FAILURE_FALLBACK_TEXT };
+        }
+
+        const payload = (await response.json()) as unknown;
+        const text = extractGeminiText(payload);
+        if (!text) {
+          return { text: REQUEST_FAILURE_FALLBACK_TEXT };
+        }
+
+        return { text };
+      } catch {
+        return { text: REQUEST_FAILURE_FALLBACK_TEXT };
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+  };
+};
 
 export const createStubLlmClient = (): LlmClient => {
   return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { resolveAdjacentTarget } from './interaction/adjacencyResolver';
 import { handleDoorInteraction } from './interaction/doorInteraction';
 import { handleGuardInteraction } from './interaction/guardInteraction';
 import { createNpcInteractionService } from './interaction/npcInteraction';
-import { createStubLlmClient } from './llm/client';
+import { createGeminiLlmClient } from './llm/client';
 import { createPixiRenderPort } from './render/scene';
 import { createLevelUi } from './render/levelUi';
 import { getRuntimeLayoutMarkup } from './render/runtimeLayout';
@@ -32,12 +32,13 @@ if (!viewportElement || !levelControlsElement || !worldStateElement || !interact
 
 const world = createWorld();
 const commandBuffer = createCommandBuffer();
-const llmClient = createStubLlmClient();
+const llmClient = createGeminiLlmClient();
 const npcInteractionService = createNpcInteractionService(llmClient);
 bindKeyboardCommands(window, commandBuffer);
 
 const LEVELS_BASE_URL = '/levels';
 const MANIFEST_URL = `${LEVELS_BASE_URL}/manifest.json`;
+const DEFAULT_NPC_PLAYER_MESSAGE = 'Can you help me?';
 
 /** Tracks which level id is currently active so reset can reload the same level. */
 let activeLevelId: string | null = null;
@@ -73,7 +74,10 @@ const runInteractionIfRequested = async (
   const interactionResult = await npcInteractionService.handleNpcInteraction({
     npc: adjacentTarget.target,
     player: worldState.player,
+    worldState,
+    playerMessage: DEFAULT_NPC_PLAYER_MESSAGE,
   });
+  world.resetToState(interactionResult.updatedWorldState);
   interactionLogElement.textContent = interactionResult.responseText;
 };
 

--- a/src/render/scene.test.ts
+++ b/src/render/scene.test.ts
@@ -47,6 +47,7 @@ const createWorldState = (): WorldState => ({
       state: 'idle',
     },
   ],
+  npcConversationHistoryByNpcId: {},
 });
 
 describe('render entity circle helpers', () => {

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -82,6 +82,7 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       doorState: d.doorState,
     })),
     interactiveObjects: [],
+    npcConversationHistoryByNpcId: {},
   };
   validateSpatialLayout(worldState);
   return worldState;

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -31,6 +31,7 @@ export const createInitialWorldState = (): WorldState => ({
       state: 'idle',
     },
   ],
+  npcConversationHistoryByNpcId: {},
 });
 
 export const serializeWorldState = (worldState: WorldState): string => JSON.stringify(worldState);

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -16,6 +16,13 @@ export interface Npc {
   dialogueContextKey: string;
 }
 
+export interface ConversationMessage {
+  role: 'player' | 'assistant';
+  text: string;
+}
+
+export type NpcConversationHistoryByNpcId = Record<string, ConversationMessage[]>;
+
 /** Shared base for all interactable world objects. JSON-serializable. */
 export interface Interactable {
   id: string;
@@ -75,6 +82,7 @@ export interface WorldState {
   guards: Guard[];
   doors: Door[];
   interactiveObjects: InteractiveObject[];
+  npcConversationHistoryByNpcId: NpcConversationHistoryByNpcId;
 }
 
 export type WorldCommand =


### PR DESCRIPTION
## Summary
- integrate Gemini-backed chat behind the existing `src/llm` boundary via `createGeminiLlmClient`
- add deterministic fallback behavior for missing API key and request failures
- implement deterministic NPC turn loop (`player -> assistant`) with per-NPC serializable history in `WorldState`
- wire runtime NPC interaction through the new loop and persist updated world state
- add tests for LLM boundary success/failure and NPC interaction flow/history serializability

## Validation
- `npm run lint`
- `npm test`
- `npm run build`

## Scope Notes
- excludes reopen behavior (`#57`)
- excludes guard world-knowledge enrichment (`#58`)

Closes #56