### PR TITLE
#57 render and reload per-NPC chat thread in interaction panel

### DIFF
--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
 import { createNpcInteractionService } from './npcInteraction';
+import { renderNpcConversationThread } from './npcThread';
 import { createInitialWorldState } from '../world/state';
 import type { ConversationMessage } from '../world/types';
 
@@ -115,5 +116,112 @@ describe('createNpcInteractionService', () => {
       { role: 'player', text: 'Any advice?' },
       { role: 'assistant', text: 'Stay on patrol routes.' },
     ]);
+  });
+
+  it('starts from a clean thread for npc with no prior history and renders that first turn', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({ text: 'Start with the north corridor.' }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Can you help me?',
+    });
+
+    const interactionPanelText = renderNpcConversationThread(result.updatedWorldState, npc.id);
+    expect(interactionPanelText).toBe('Player: Can you help me?\nNPC: Start with the north corridor.');
+  });
+
+  it('reloads same npc thread on reopen and adds only one new turn per interaction', async () => {
+    const complete = vi
+      .fn<() => Promise<{ text: string }>>()
+      .mockResolvedValueOnce({ text: 'The archives are west.' })
+      .mockResolvedValueOnce({ text: 'Use the lower key.' });
+    const llmClient: LlmClient = { complete };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+
+    const firstResult = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Where are the archives?',
+    });
+    const firstPanelText = renderNpcConversationThread(firstResult.updatedWorldState, npc.id);
+    expect(firstPanelText).toBe('Player: Where are the archives?\nNPC: The archives are west.');
+
+    const secondResult = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState: firstResult.updatedWorldState,
+      playerMessage: 'What key do I need?',
+    });
+
+    const secondPanelText = renderNpcConversationThread(secondResult.updatedWorldState, npc.id);
+    expect(secondPanelText).toBe(
+      [
+        'Player: Where are the archives?',
+        'NPC: The archives are west.',
+        'Player: What key do I need?',
+        'NPC: Use the lower key.',
+      ].join('\n'),
+    );
+
+    expect(secondResult.updatedWorldState.npcConversationHistoryByNpcId[npc.id]).toEqual([
+      { role: 'player', text: 'Where are the archives?' },
+      { role: 'assistant', text: 'The archives are west.' },
+      { role: 'player', text: 'What key do I need?' },
+      { role: 'assistant', text: 'Use the lower key.' },
+    ]);
+  });
+
+  it('switches npc threads without cross-contamination in rendered interaction panel text', async () => {
+    const complete = vi
+      .fn<() => Promise<{ text: string }>>()
+      .mockResolvedValueOnce({ text: 'Archivist response.' })
+      .mockResolvedValueOnce({ text: 'Engineer response.' });
+    const llmClient: LlmClient = { complete };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const firstNpc = worldState.npcs[0];
+    const secondNpc = {
+      ...firstNpc,
+      id: 'npc-2',
+      displayName: 'Engineer',
+      dialogueContextKey: 'engineer_intro',
+      position: { x: 7, y: 3 },
+    };
+    const stateWithTwoNpcs = {
+      ...worldState,
+      npcs: [firstNpc, secondNpc],
+    };
+
+    const firstNpcResult = await service.handleNpcInteraction({
+      npc: firstNpc,
+      player: stateWithTwoNpcs.player,
+      worldState: stateWithTwoNpcs,
+      playerMessage: 'Hello archivist',
+    });
+
+    const secondNpcResult = await service.handleNpcInteraction({
+      npc: secondNpc,
+      player: stateWithTwoNpcs.player,
+      worldState: firstNpcResult.updatedWorldState,
+      playerMessage: 'Hello engineer',
+    });
+
+    const firstNpcPanelText = renderNpcConversationThread(secondNpcResult.updatedWorldState, firstNpc.id);
+    const secondNpcPanelText = renderNpcConversationThread(secondNpcResult.updatedWorldState, secondNpc.id);
+
+    expect(firstNpcPanelText).toBe('Player: Hello archivist\nNPC: Archivist response.');
+    expect(secondNpcPanelText).toBe('Player: Hello engineer\nNPC: Engineer response.');
+    expect(secondNpcPanelText).not.toContain('Archivist response.');
+    expect(firstNpcPanelText).not.toContain('Engineer response.');
   });
 });

--- a/src/interaction/npcThread.ts
+++ b/src/interaction/npcThread.ts
@@ -1,0 +1,16 @@
+import type { ConversationMessage, WorldState } from '../world/types';
+
+const formatConversationLine = (message: ConversationMessage): string => {
+  const speaker = message.role === 'player' ? 'Player' : 'NPC';
+  return `${speaker}: ${message.text}`;
+};
+
+export const getNpcConversationHistory = (
+  worldState: WorldState,
+  npcId: string,
+): ConversationMessage[] => worldState.npcConversationHistoryByNpcId[npcId] ?? [];
+
+export const renderNpcConversationThread = (
+  worldState: WorldState,
+  npcId: string,
+): string => getNpcConversationHistory(worldState, npcId).map(formatConversationLine).join('\n');

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { resolveAdjacentTarget } from './interaction/adjacencyResolver';
 import { handleDoorInteraction } from './interaction/doorInteraction';
 import { handleGuardInteraction } from './interaction/guardInteraction';
 import { createNpcInteractionService } from './interaction/npcInteraction';
+import { renderNpcConversationThread } from './interaction/npcThread';
 import { createGeminiLlmClient } from './llm/client';
 import { createPixiRenderPort } from './render/scene';
 import { createLevelUi } from './render/levelUi';
@@ -77,8 +78,9 @@ const runInteractionIfRequested = async (
     worldState,
     playerMessage: DEFAULT_NPC_PLAYER_MESSAGE,
   });
-  world.resetToState(interactionResult.updatedWorldState);
-  interactionLogElement.textContent = interactionResult.responseText;
+  const updatedWorldState = interactionResult.updatedWorldState;
+  world.resetToState(updatedWorldState);
+  interactionLogElement.textContent = renderNpcConversationThread(updatedWorldState, adjacentTarget.target.id);
 };
 
 const fixedTickDurationMs = 100;


### PR DESCRIPTION
## Summary
- render NPC interaction panel text from `worldState.npcConversationHistoryByNpcId` for the currently interacted NPC
- ensure NPC interaction panel content is replaced from stored per-NPC history (prevents replay duplication from UI appends)
- add focused tests for no-history initialization, same-NPC reopen, and cross-NPC thread switch isolation

## Validation
- `npm run lint`
- `npm test`
- `npm run build`

## Closes #57