### PR TITLE
#58 add deterministic guard persona and world context for guard llm requests

### DIFF
--- a/src/interaction/guardInteraction.test.ts
+++ b/src/interaction/guardInteraction.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { handleGuardInteraction } from './guardInteraction';
+import { describe, expect, it, vi } from 'vitest';
+import { createInitialWorldState } from '../world/state';
+import { MISSING_API_KEY_FALLBACK_TEXT, REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
+import { GUARD_PERSONA_CONTRACT } from './guardPromptContext';
+import { createGuardInteractionService, handleGuardInteraction } from './guardInteraction';
 import type { Guard, Player } from '../world/types';
 
 const player: Player = { id: 'player-1', displayName: 'Hero', position: { x: 1, y: 1 } };
@@ -35,5 +38,101 @@ describe('handleGuardInteraction', () => {
     const first = handleGuardInteraction({ guard, player });
     const second = handleGuardInteraction({ guard, player });
     expect(first).toEqual(second);
+  });
+});
+
+describe('createGuardInteractionService', () => {
+  it('sends guard persona + world context only for guard requests', async () => {
+    const complete = vi.fn(async () => ({ text: 'All clear in this sector.' }));
+    const llmClient: LlmClient = { complete };
+    const service = createGuardInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    worldState.guards = [makeGuard('patrolling')];
+    worldState.npcs = [
+      {
+        id: 'npc-1',
+        displayName: 'Archivist',
+        position: { x: 8, y: 3 },
+        dialogueContextKey: 'archive_keeper_intro',
+      },
+    ];
+
+    const result = await service.handleGuardInteraction({
+      guard: worldState.guards[0],
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Report nearby activity.',
+    });
+
+    expect(result.responseText).toBe('Guard: All clear in this sector.');
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'guard-1',
+        playerMessage: 'Report nearby activity.',
+      }),
+    );
+
+    const calledPrompt = complete.mock.calls.at(0)?.at(0) as { context: string } | undefined;
+    expect(calledPrompt).toBeDefined();
+    if (!calledPrompt) {
+      throw new Error('Expected guard LLM prompt to be provided.');
+    }
+    const parsedContext = JSON.parse(calledPrompt.context) as {
+      guardPersonaContract: string;
+      worldContext: {
+        player: { id: string; position: { x: number; y: number } };
+        guards: Array<{ id: string; position: { x: number; y: number } }>;
+        npcs: Array<{ id: string; position: { x: number; y: number } }>;
+        interactiveObjects: Array<{ id: string; kind: 'door' | 'object'; position: { x: number; y: number } }>;
+      };
+    };
+
+    expect(parsedContext.guardPersonaContract).toBe(GUARD_PERSONA_CONTRACT);
+    expect(parsedContext.worldContext.player.position).toEqual(worldState.player.position);
+    expect(parsedContext.worldContext.guards).toEqual([
+      { id: 'guard-1', position: worldState.guards[0].position },
+    ]);
+    expect(parsedContext.worldContext.npcs).toEqual([
+      { id: 'npc-1', position: worldState.npcs[0].position },
+    ]);
+  });
+
+  it('preserves deterministic missing-api-key fallback text from llm boundary', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({ text: MISSING_API_KEY_FALLBACK_TEXT }),
+    };
+    const service = createGuardInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    worldState.guards = [makeGuard('idle')];
+
+    const result = await service.handleGuardInteraction({
+      guard: worldState.guards[0],
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Status?',
+    });
+
+    expect(result.responseText).toBe(`Guard: ${MISSING_API_KEY_FALLBACK_TEXT}`);
+  });
+
+  it('returns deterministic request-failure fallback when llm call throws', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => {
+        throw new Error('network down');
+      },
+    };
+    const service = createGuardInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    worldState.guards = [makeGuard('alert')];
+
+    const result = await service.handleGuardInteraction({
+      guard: worldState.guards[0],
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Any trouble?',
+    });
+
+    expect(result.responseText).toBe(`Guard: ${REQUEST_FAILURE_FALLBACK_TEXT}`);
   });
 });

--- a/src/interaction/guardInteraction.ts
+++ b/src/interaction/guardInteraction.ts
@@ -1,4 +1,7 @@
+import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
+import type { WorldState } from '../world/types';
 import type { Guard, Player } from '../world/types';
+import { buildGuardPromptContext } from './guardPromptContext';
 
 export interface GuardInteractionRequest {
   guard: Guard;
@@ -8,6 +11,17 @@ export interface GuardInteractionRequest {
 export interface GuardInteractionResult {
   guardId: string;
   responseText: string;
+}
+
+export interface GuardLlmInteractionRequest {
+  guard: Guard;
+  player: Player;
+  worldState: WorldState;
+  playerMessage: string;
+}
+
+export interface GuardInteractionService {
+  handleGuardInteraction(request: GuardLlmInteractionRequest): Promise<GuardInteractionResult>;
 }
 
 const GUARD_STATE_RESPONSES: Record<Guard['guardState'], string> = {
@@ -21,4 +35,25 @@ export const handleGuardInteraction = (
 ): GuardInteractionResult => ({
   guardId: request.guard.id,
   responseText: GUARD_STATE_RESPONSES[request.guard.guardState],
+});
+
+export const createGuardInteractionService = (llmClient: LlmClient): GuardInteractionService => ({
+  handleGuardInteraction: async (
+    request: GuardLlmInteractionRequest,
+  ): Promise<GuardInteractionResult> => {
+    const assistantText = await llmClient
+      .complete({
+        actorId: request.guard.id,
+        context: buildGuardPromptContext(request.guard, request.worldState),
+        playerMessage: request.playerMessage,
+        conversationHistory: [{ role: 'player', text: request.playerMessage }],
+      })
+      .then((llmResponse) => llmResponse.text)
+      .catch(() => REQUEST_FAILURE_FALLBACK_TEXT);
+
+    return {
+      guardId: request.guard.id,
+      responseText: `${request.guard.displayName}: ${assistantText}`,
+    };
+  },
 });

--- a/src/interaction/guardPromptContext.test.ts
+++ b/src/interaction/guardPromptContext.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { createInitialWorldState } from '../world/state';
+import { buildGuardPromptContext, buildGuardWorldContextPayload, GUARD_PERSONA_CONTRACT } from './guardPromptContext';
+
+describe('buildGuardWorldContextPayload', () => {
+  it('includes player, guard, npc, and interactive object positions including doors', () => {
+    const worldState = createInitialWorldState();
+    worldState.player.position = { x: 2, y: 3 };
+    worldState.guards = [
+      {
+        id: 'guard-2',
+        displayName: 'South Guard',
+        position: { x: 4, y: 5 },
+        guardState: 'patrolling',
+      },
+      {
+        id: 'guard-1',
+        displayName: 'North Guard',
+        position: { x: 1, y: 0 },
+        guardState: 'idle',
+      },
+    ];
+    worldState.npcs = [
+      {
+        id: 'npc-2',
+        displayName: 'Engineer',
+        position: { x: 8, y: 1 },
+        dialogueContextKey: 'engineer_intro',
+      },
+      {
+        id: 'npc-1',
+        displayName: 'Archivist',
+        position: { x: 3, y: 9 },
+        dialogueContextKey: 'archive_keeper_intro',
+      },
+    ];
+    worldState.doors = [
+      {
+        id: 'door-2',
+        displayName: 'South Door',
+        position: { x: 7, y: 7 },
+        doorState: 'closed',
+      },
+      {
+        id: 'door-1',
+        displayName: 'North Door',
+        position: { x: 5, y: 6 },
+        doorState: 'open',
+      },
+    ];
+    worldState.interactiveObjects = [
+      {
+        id: 'obj-2',
+        displayName: 'Terminal',
+        position: { x: 10, y: 2 },
+        interactionType: 'inspect',
+        state: 'idle',
+      },
+      {
+        id: 'obj-1',
+        displayName: 'Lever',
+        position: { x: 6, y: 3 },
+        interactionType: 'use',
+        state: 'used',
+      },
+    ];
+
+    const payload = buildGuardWorldContextPayload(worldState);
+
+    expect(payload.player).toEqual({
+      id: worldState.player.id,
+      position: { x: 2, y: 3 },
+    });
+    expect(payload.guards).toEqual([
+      { id: 'guard-1', position: { x: 1, y: 0 } },
+      { id: 'guard-2', position: { x: 4, y: 5 } },
+    ]);
+    expect(payload.npcs).toEqual([
+      { id: 'npc-1', position: { x: 3, y: 9 } },
+      { id: 'npc-2', position: { x: 8, y: 1 } },
+    ]);
+    expect(payload.interactiveObjects).toEqual([
+      { id: 'door-1', kind: 'door', position: { x: 5, y: 6 } },
+      { id: 'door-2', kind: 'door', position: { x: 7, y: 7 } },
+      { id: 'obj-1', kind: 'object', position: { x: 6, y: 3 } },
+      { id: 'obj-2', kind: 'object', position: { x: 10, y: 2 } },
+    ]);
+  });
+
+  it('produces deterministic serialized prompt context for identical world snapshot', () => {
+    const worldState = createInitialWorldState();
+    worldState.guards = [
+      {
+        id: 'guard-1',
+        displayName: 'Guard',
+        position: { x: 4, y: 4 },
+        guardState: 'alert',
+      },
+    ];
+    const guard = worldState.guards[0];
+
+    const first = buildGuardPromptContext(guard, worldState);
+    const second = buildGuardPromptContext(guard, worldState);
+    const reconstructed = JSON.parse(JSON.stringify(worldState)) as typeof worldState;
+    const third = buildGuardPromptContext(reconstructed.guards[0], reconstructed);
+
+    expect(first).toBe(second);
+    expect(first).toBe(third);
+  });
+
+  it('returns JSON-serializable payload data and includes guard persona contract', () => {
+    const worldState = createInitialWorldState();
+    worldState.guards = [
+      {
+        id: 'guard-1',
+        displayName: 'Guard',
+        position: { x: 2, y: 2 },
+        guardState: 'idle',
+      },
+    ];
+
+    const promptContext = buildGuardPromptContext(worldState.guards[0], worldState);
+    const parsed = JSON.parse(promptContext) as {
+      guardPersonaContract: string;
+      worldContext: ReturnType<typeof buildGuardWorldContextPayload>;
+    };
+    const roundTrip = JSON.parse(JSON.stringify(parsed)) as typeof parsed;
+
+    expect(parsed.guardPersonaContract).toBe(GUARD_PERSONA_CONTRACT);
+    expect(roundTrip.worldContext).toEqual(parsed.worldContext);
+  });
+});

--- a/src/interaction/guardPromptContext.ts
+++ b/src/interaction/guardPromptContext.ts
@@ -1,0 +1,90 @@
+import type { Guard, WorldState } from '../world/types';
+
+export const GUARD_PERSONA_CONTRACT =
+  'You are a vigilant city guard. Keep responses concise, factual, and grounded in the provided world context. Do not invent positions or events not present in context.';
+
+export interface GuardWorldContextPayload {
+  player: {
+    id: string;
+    position: {
+      x: number;
+      y: number;
+    };
+  };
+  guards: Array<{
+    id: string;
+    position: {
+      x: number;
+      y: number;
+    };
+  }>;
+  npcs: Array<{
+    id: string;
+    position: {
+      x: number;
+      y: number;
+    };
+  }>;
+  interactiveObjects: Array<{
+    id: string;
+    kind: 'door' | 'object';
+    position: {
+      x: number;
+      y: number;
+    };
+  }>;
+}
+
+const compareById = <T extends { id: string }>(a: T, b: T): number => a.id.localeCompare(b.id);
+
+export const buildGuardWorldContextPayload = (worldState: WorldState): GuardWorldContextPayload => {
+  const guards = [...worldState.guards]
+    .sort(compareById)
+    .map((guard) => ({
+      id: guard.id,
+      position: { x: guard.position.x, y: guard.position.y },
+    }));
+
+  const npcs = [...worldState.npcs]
+    .sort(compareById)
+    .map((npc) => ({
+      id: npc.id,
+      position: { x: npc.position.x, y: npc.position.y },
+    }));
+
+  const doors = worldState.doors.map((door) => ({
+    id: door.id,
+    kind: 'door' as const,
+    position: { x: door.position.x, y: door.position.y },
+  }));
+  const objects = worldState.interactiveObjects.map((object) => ({
+    id: object.id,
+    kind: 'object' as const,
+    position: { x: object.position.x, y: object.position.y },
+  }));
+  const interactiveObjects = [...doors, ...objects].sort(compareById);
+
+  return {
+    player: {
+      id: worldState.player.id,
+      position: {
+        x: worldState.player.position.x,
+        y: worldState.player.position.y,
+      },
+    },
+    guards,
+    npcs,
+    interactiveObjects,
+  };
+};
+
+export const buildGuardPromptContext = (guard: Guard, worldState: WorldState): string => {
+  return JSON.stringify({
+    actor: {
+      id: guard.id,
+      guardState: guard.guardState,
+    },
+    guardPersonaContract: GUARD_PERSONA_CONTRACT,
+    worldContext: buildGuardWorldContextPayload(worldState),
+  });
+};

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -3,6 +3,7 @@ import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
 import { createNpcInteractionService } from './npcInteraction';
 import { renderNpcConversationThread } from './npcThread';
 import { createInitialWorldState } from '../world/state';
+import { GUARD_PERSONA_CONTRACT } from './guardPromptContext';
 import type { ConversationMessage } from '../world/types';
 
 describe('createNpcInteractionService', () => {
@@ -29,6 +30,12 @@ describe('createNpcInteractionService', () => {
         conversationHistory: [{ role: 'player', text: 'Where are the archives?' }],
       }),
     );
+    const calledPrompt = complete.mock.calls.at(0)?.at(0) as { context: string } | undefined;
+    expect(calledPrompt).toBeDefined();
+    if (!calledPrompt) {
+      throw new Error('Expected NPC LLM prompt to be provided.');
+    }
+    expect(calledPrompt.context).not.toContain(GUARD_PERSONA_CONTRACT);
     expect(result.responseText).toBe('Archivist: The archives are west of here.');
     expect(result.updatedWorldState.npcConversationHistoryByNpcId[npc.id]).toEqual([
       { role: 'player', text: 'Where are the archives?' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { createCommandBuffer } from './input/commands';
 import { bindKeyboardCommands } from './input/keyboard';
 import { resolveAdjacentTarget } from './interaction/adjacencyResolver';
 import { handleDoorInteraction } from './interaction/doorInteraction';
-import { handleGuardInteraction } from './interaction/guardInteraction';
+import { createGuardInteractionService } from './interaction/guardInteraction';
 import { createNpcInteractionService } from './interaction/npcInteraction';
 import { renderNpcConversationThread } from './interaction/npcThread';
 import { createGeminiLlmClient } from './llm/client';
@@ -34,12 +34,14 @@ if (!viewportElement || !levelControlsElement || !worldStateElement || !interact
 const world = createWorld();
 const commandBuffer = createCommandBuffer();
 const llmClient = createGeminiLlmClient();
+const guardInteractionService = createGuardInteractionService(llmClient);
 const npcInteractionService = createNpcInteractionService(llmClient);
 bindKeyboardCommands(window, commandBuffer);
 
 const LEVELS_BASE_URL = '/levels';
 const MANIFEST_URL = `${LEVELS_BASE_URL}/manifest.json`;
 const DEFAULT_NPC_PLAYER_MESSAGE = 'Can you help me?';
+const DEFAULT_GUARD_PLAYER_MESSAGE = 'State your current status.';
 
 /** Tracks which level id is currently active so reset can reload the same level. */
 let activeLevelId: string | null = null;
@@ -60,7 +62,12 @@ const runInteractionIfRequested = async (
   }
 
   if (adjacentTarget.kind === 'guard') {
-    const result = handleGuardInteraction({ guard: adjacentTarget.target, player: worldState.player });
+    const result = await guardInteractionService.handleGuardInteraction({
+      guard: adjacentTarget.target,
+      player: worldState.player,
+      worldState,
+      playerMessage: DEFAULT_GUARD_PLAYER_MESSAGE,
+    });
     interactionLogElement.textContent = result.responseText;
     return;
   }


### PR DESCRIPTION
## Summary
- add a deterministic guard prompt-context builder with a baseline guard persona contract
- include world-context payload data for player position, all guards, all NPCs, and interactive objects including doors
- add a guard interaction service that routes guard requests through the existing llm boundary
- keep guard enrichment guard-scoped and leave non-guard NPC prompt behavior unchanged
- preserve deterministic fallback behavior from #56 for missing API key/request failures

## Validation
- `npm run lint`
- `npm test`
- `npm run build`

Closes #58