### PR TITLE
#64 riddle level: Two Guards Two Doors with outcome overlay

### DIFF
--- a/public/levels/manifest.json
+++ b/public/levels/manifest.json
@@ -1,1 +1,5 @@
-[{ "id": "starter", "name": "Starter" }]
+[
+  { "id": "starter", "name": "Starter" },
+  { "id": "riddle", "name": "Two Guards" }
+]
+

--- a/public/levels/riddle.json
+++ b/public/levels/riddle.json
@@ -1,22 +1,22 @@
 {
   "version": 1,
-  "name": "Two Guards",
+  "name": "Two Guards, Two Doors",
   "width": 20,
   "height": 20,
-  "player": { "x": 10, "y": 10 },
+  "player": { "x": 10, "y": 15 },
   "guards": [
     {
       "id": "guard-truth",
-      "displayName": "Guard A",
-      "x": 5,
+      "displayName": "Guard True",
+      "x": 8,
       "y": 10,
       "guardState": "idle",
       "honestyTrait": "truth-teller"
     },
     {
       "id": "guard-liar",
-      "displayName": "Guard B",
-      "x": 15,
+      "displayName": "Guard False",
+      "x": 12,
       "y": 10,
       "guardState": "idle",
       "honestyTrait": "liar"
@@ -25,18 +25,18 @@
   "doors": [
     {
       "id": "door-safe",
-      "displayName": "Door A",
-      "x": 2,
-      "y": 10,
-      "doorState": "open",
+      "displayName": "Left Door",
+      "x": 5,
+      "y": 5,
+      "doorState": "closed",
       "outcome": "safe"
     },
     {
       "id": "door-danger",
-      "displayName": "Door B",
-      "x": 18,
-      "y": 10,
-      "doorState": "open",
+      "displayName": "Right Door",
+      "x": 15,
+      "y": 5,
+      "doorState": "closed",
       "outcome": "danger"
     }
   ]

--- a/public/levels/riddle.json
+++ b/public/levels/riddle.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "name": "Two Guards",
+  "width": 20,
+  "height": 20,
+  "player": { "x": 10, "y": 10 },
+  "guards": [
+    {
+      "id": "guard-truth",
+      "displayName": "Guard A",
+      "x": 5,
+      "y": 10,
+      "guardState": "idle",
+      "honestyTrait": "truth-teller"
+    },
+    {
+      "id": "guard-liar",
+      "displayName": "Guard B",
+      "x": 15,
+      "y": 10,
+      "guardState": "idle",
+      "honestyTrait": "liar"
+    }
+  ],
+  "doors": [
+    {
+      "id": "door-safe",
+      "displayName": "Door A",
+      "x": 2,
+      "y": 10,
+      "doorState": "open",
+      "outcome": "safe"
+    },
+    {
+      "id": "door-danger",
+      "displayName": "Door B",
+      "x": 18,
+      "y": 10,
+      "doorState": "open",
+      "outcome": "danger"
+    }
+  ]
+}

--- a/public/levels/starter.json
+++ b/public/levels/starter.json
@@ -26,14 +26,16 @@
       "displayName": "West Door",
       "x": 2,
       "y": 10,
-      "doorState": "closed"
+      "doorState": "closed",
+      "outcome": "safe"
     },
     {
       "id": "door-2",
       "displayName": "North Door",
       "x": 10,
       "y": 2,
-      "doorState": "closed"
+      "doorState": "closed",
+      "outcome": "danger"
     }
   ]
 }

--- a/src/integration/riddleLevel.test.ts
+++ b/src/integration/riddleLevel.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import riddleJson from '../../public/levels/riddle.json';
+import { resolveAdjacentTarget } from '../interaction/adjacencyResolver';
+import { handleDoorInteraction } from '../interaction/doorInteraction';
+import { deserializeLevel, validateLevelData } from '../world/level';
+import type { WorldState } from '../world/types';
+
+const createRiddleState = (): WorldState => {
+  const validated = validateLevelData(riddleJson);
+  return deserializeLevel(validated);
+};
+
+describe('riddle level integration pipeline', () => {
+  it('loads riddle level into a valid WorldState with expected entity positions', () => {
+    const validated = validateLevelData(riddleJson);
+    const worldState = deserializeLevel(validated);
+
+    expect(worldState).toBeDefined();
+    expect(worldState.player.position).toEqual({ x: 10, y: 10 });
+
+    expect(worldState.guards).toHaveLength(2);
+    expect(worldState.guards.find((guard) => guard.id === 'guard-truth')?.position).toEqual({ x: 5, y: 10 });
+    expect(worldState.guards.find((guard) => guard.id === 'guard-liar')?.position).toEqual({ x: 15, y: 10 });
+
+    expect(worldState.doors).toHaveLength(2);
+    expect(worldState.doors.find((door) => door.id === 'door-safe')?.position).toEqual({ x: 2, y: 10 });
+    expect(worldState.doors.find((door) => door.id === 'door-danger')?.position).toEqual({ x: 18, y: 10 });
+  });
+
+  it('has guards with correct honestyTrait values', () => {
+    const worldState = createRiddleState();
+
+    const truthGuard = worldState.guards.find((guard) => guard.id === 'guard-truth');
+    expect(truthGuard).toBeDefined();
+    expect(truthGuard?.honestyTrait).toBe('truth-teller');
+
+    const liarGuard = worldState.guards.find((guard) => guard.id === 'guard-liar');
+    expect(liarGuard).toBeDefined();
+    expect(liarGuard?.honestyTrait).toBe('liar');
+  });
+
+  it('has doors with correct outcome values', () => {
+    const worldState = createRiddleState();
+
+    const safeDoor = worldState.doors.find((door) => door.id === 'door-safe');
+    expect(safeDoor).toBeDefined();
+    expect(safeDoor?.outcome).toBe('safe');
+
+    const dangerDoor = worldState.doors.find((door) => door.id === 'door-danger');
+    expect(dangerDoor).toBeDefined();
+    expect(dangerDoor?.outcome).toBe('danger');
+  });
+
+  it('initializes with levelOutcome as null', () => {
+    const worldState = createRiddleState();
+
+    expect(worldState.levelOutcome).toBeNull();
+  });
+
+  it('resolves adjacent safe door and returns win outcome', () => {
+    const worldState = createRiddleState();
+    worldState.player.position = { x: 3, y: 10 };
+
+    const adjacent = resolveAdjacentTarget(worldState);
+
+    expect(adjacent).not.toBeNull();
+    expect(adjacent?.kind).toBe('door');
+    expect(adjacent?.target.id).toBe('door-safe');
+
+    if (adjacent?.kind !== 'door') {
+      throw new Error('Expected door target');
+    }
+
+    const result = handleDoorInteraction({
+      door: adjacent.target,
+      player: worldState.player,
+    });
+
+    expect(result.doorId).toBe('door-safe');
+    expect(result.levelOutcome).toBe('win');
+  });
+
+  it('resolves adjacent danger door and returns lose outcome', () => {
+    const worldState = createRiddleState();
+    worldState.player.position = { x: 17, y: 10 };
+
+    const adjacent = resolveAdjacentTarget(worldState);
+
+    expect(adjacent).not.toBeNull();
+    expect(adjacent?.kind).toBe('door');
+    expect(adjacent?.target.id).toBe('door-danger');
+
+    if (adjacent?.kind !== 'door') {
+      throw new Error('Expected door target');
+    }
+
+    const result = handleDoorInteraction({
+      door: adjacent.target,
+      player: worldState.player,
+    });
+
+    expect(result.doorId).toBe('door-danger');
+    expect(result.levelOutcome).toBe('lose');
+  });
+
+  it('returns equal canonical initial states across repeated deserializations', () => {
+    const first = deserializeLevel(validateLevelData(riddleJson));
+    const second = deserializeLevel(validateLevelData(riddleJson));
+
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+  });
+
+  it('guards are idle and doors are open', () => {
+    const worldState = createRiddleState();
+
+    worldState.guards.forEach((guard) => {
+      expect(guard.guardState).toBe('idle');
+    });
+
+    worldState.doors.forEach((door) => {
+      expect(door.doorState).toBe('open');
+    });
+  });
+});

--- a/src/integration/riddleLevel.test.ts
+++ b/src/integration/riddleLevel.test.ts
@@ -16,15 +16,15 @@ describe('riddle level integration pipeline', () => {
     const worldState = deserializeLevel(validated);
 
     expect(worldState).toBeDefined();
-    expect(worldState.player.position).toEqual({ x: 10, y: 10 });
+    expect(worldState.player.position).toEqual({ x: 10, y: 15 });
 
     expect(worldState.guards).toHaveLength(2);
-    expect(worldState.guards.find((guard) => guard.id === 'guard-truth')?.position).toEqual({ x: 5, y: 10 });
-    expect(worldState.guards.find((guard) => guard.id === 'guard-liar')?.position).toEqual({ x: 15, y: 10 });
+    expect(worldState.guards.find((guard) => guard.id === 'guard-truth')?.position).toEqual({ x: 8, y: 10 });
+    expect(worldState.guards.find((guard) => guard.id === 'guard-liar')?.position).toEqual({ x: 12, y: 10 });
 
     expect(worldState.doors).toHaveLength(2);
-    expect(worldState.doors.find((door) => door.id === 'door-safe')?.position).toEqual({ x: 2, y: 10 });
-    expect(worldState.doors.find((door) => door.id === 'door-danger')?.position).toEqual({ x: 18, y: 10 });
+    expect(worldState.doors.find((door) => door.id === 'door-safe')?.position).toEqual({ x: 5, y: 5 });
+    expect(worldState.doors.find((door) => door.id === 'door-danger')?.position).toEqual({ x: 15, y: 5 });
   });
 
   it('has guards with correct honestyTrait values', () => {
@@ -59,7 +59,7 @@ describe('riddle level integration pipeline', () => {
 
   it('resolves adjacent safe door and returns win outcome', () => {
     const worldState = createRiddleState();
-    worldState.player.position = { x: 3, y: 10 };
+    worldState.player.position = { x: 4, y: 5 };
 
     const adjacent = resolveAdjacentTarget(worldState);
 
@@ -82,7 +82,7 @@ describe('riddle level integration pipeline', () => {
 
   it('resolves adjacent danger door and returns lose outcome', () => {
     const worldState = createRiddleState();
-    worldState.player.position = { x: 17, y: 10 };
+    worldState.player.position = { x: 14, y: 5 };
 
     const adjacent = resolveAdjacentTarget(worldState);
 
@@ -119,7 +119,7 @@ describe('riddle level integration pipeline', () => {
     });
 
     worldState.doors.forEach((door) => {
-      expect(door.doorState).toBe('open');
+      expect(door.doorState).toBe('closed');
     });
   });
 });

--- a/src/interaction/adjacencyResolver.test.ts
+++ b/src/interaction/adjacencyResolver.test.ts
@@ -11,6 +11,7 @@ const baseState = (): WorldState => ({
   doors: [],
   interactiveObjects: [],
   npcConversationHistoryByNpcId: {},
+  levelOutcome: null,
 });
 
 const makeGuard = (x: number, y: number): Guard => ({
@@ -25,6 +26,7 @@ const makeDoor = (x: number, y: number): Door => ({
   displayName: 'Door',
   position: { x, y },
   doorState: 'closed',
+  outcome: 'safe',
 });
 
 const makeNpc = (x: number, y: number): Npc => ({

--- a/src/interaction/doorInteraction.test.ts
+++ b/src/interaction/doorInteraction.test.ts
@@ -4,11 +4,12 @@ import type { Door, Player } from '../world/types';
 
 const player: Player = { id: 'player-1', displayName: 'Hero', position: { x: 1, y: 1 } };
 
-const makeDoor = (doorState: Door['doorState']): Door => ({
+const makeDoor = (doorState: Door['doorState'], outcome?: Door['outcome']): Door => ({
   id: 'door-1',
   displayName: 'Main Door',
   position: { x: 3, y: 1 },
   doorState,
+  outcome,
 });
 
 describe('handleDoorInteraction', () => {
@@ -35,5 +36,29 @@ describe('handleDoorInteraction', () => {
     const first = handleDoorInteraction({ door, player });
     const second = handleDoorInteraction({ door, player });
     expect(first).toEqual(second);
+  });
+
+  it('returns "win" outcome when door has outcome: "safe"', () => {
+    const door = makeDoor('open', 'safe');
+    const result = handleDoorInteraction({ door, player });
+
+    expect(result.doorId).toBe('door-1');
+    expect(result.levelOutcome).toBe('win');
+  });
+
+  it('returns "lose" outcome when door has outcome: "danger"', () => {
+    const door = makeDoor('open', 'danger');
+    const result = handleDoorInteraction({ door, player });
+
+    expect(result.doorId).toBe('door-1');
+    expect(result.levelOutcome).toBe('lose');
+  });
+
+  it('does not include levelOutcome when door lacks outcome field', () => {
+    const door = makeDoor('open', undefined);
+    const result = handleDoorInteraction({ door, player });
+
+    expect(result.doorId).toBe('door-1');
+    expect(result.levelOutcome).toBeUndefined();
   });
 });

--- a/src/interaction/doorInteraction.ts
+++ b/src/interaction/doorInteraction.ts
@@ -8,6 +8,7 @@ export interface DoorInteractionRequest {
 export interface DoorInteractionResult {
   doorId: string;
   responseText: string;
+  levelOutcome?: 'win' | 'lose';
 }
 
 const DOOR_STATE_RESPONSES: Record<Door['doorState'], string> = {
@@ -16,7 +17,16 @@ const DOOR_STATE_RESPONSES: Record<Door['doorState'], string> = {
   locked: 'The door is locked.',
 };
 
-export const handleDoorInteraction = (request: DoorInteractionRequest): DoorInteractionResult => ({
-  doorId: request.door.id,
-  responseText: DOOR_STATE_RESPONSES[request.door.doorState],
-});
+export const handleDoorInteraction = (request: DoorInteractionRequest): DoorInteractionResult => {
+  const baseResult: DoorInteractionResult = {
+    doorId: request.door.id,
+    responseText: DOOR_STATE_RESPONSES[request.door.doorState],
+  };
+
+  // Add levelOutcome if door has outcome field
+  if (request.door.outcome) {
+    baseResult.levelOutcome = request.door.outcome === 'safe' ? 'win' : 'lose';
+  }
+
+  return baseResult;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { bindKeyboardCommands } from './input/keyboard';
 import { resolveAdjacentTarget } from './interaction/adjacencyResolver';
 import { createGuardInteractionService } from './interaction/guardInteraction';
 import { createNpcInteractionService } from './interaction/npcInteraction';
+import { handleDoorInteraction } from './interaction/doorInteraction';
 import { getNpcConversationHistory } from './interaction/npcThread';
 import { createGeminiLlmClient } from './llm/client';
 import { createPixiRenderPort } from './render/scene';
@@ -134,6 +135,11 @@ const runInteractionIfRequested = async (
   worldState: WorldState,
   commands: WorldCommand[],
 ): Promise<void> => {
+  // Block all interactions if level outcome is already set
+  if (worldState.levelOutcome) {
+    return;
+  }
+
   const includesInteract = commands.some((command) => command.type === 'interact');
   if (!includesInteract) {
     return;
@@ -156,8 +162,17 @@ const runInteractionIfRequested = async (
   }
 
   if (adjacentTarget.kind === 'door') {
-    // Door interactions are currently not displayed in the chat modal.
-    // Silently ignore them or could add a separate notification system.
+    // Handle door interaction and check for level outcome
+    const doorResult = handleDoorInteraction({
+      door: adjacentTarget.target,
+      player: worldState.player,
+    });
+
+    // If door has an outcome, update worldState and trigger modal feedback
+    if (doorResult.levelOutcome) {
+      const updatedState = { ...worldState, levelOutcome: doorResult.levelOutcome };
+      world.resetToState(updatedState);
+    }
     return;
   }
 
@@ -228,10 +243,17 @@ const startRuntime = async (): Promise<void> => {
     previousFrameTime = currentTime;
 
     while (accumulatedTime >= fixedTickDurationMs) {
-      const commands = commandBuffer.drain();
-      world.applyCommands(commands);
+      const worldStateBeforeCommands = world.getState();
+      let commandsToApply = commandBuffer.drain();
+
+      // Block all commands if level outcome is already set
+      if (worldStateBeforeCommands.levelOutcome) {
+        commandsToApply = [];
+      }
+
+      world.applyCommands(commandsToApply);
       const worldState = world.getState();
-      void runInteractionIfRequested(worldState, commands);
+      void runInteractionIfRequested(worldState, commandsToApply);
       accumulatedTime -= fixedTickDurationMs;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { createGeminiLlmClient } from './llm/client';
 import { createPixiRenderPort } from './render/scene';
 import { createLevelUi } from './render/levelUi';
 import { createChatModal } from './render/chatModal';
+import { createOutcomeOverlay } from './render/outcomeOverlay';
 import { getRuntimeLayoutMarkup } from './render/runtimeLayout';
 import type { WorldCommand, WorldState } from './world/types';
 import { createWorld } from './world/world';
@@ -27,8 +28,9 @@ const viewportElement = document.querySelector<HTMLElement>('#viewport');
 const levelControlsElement = document.querySelector<HTMLElement>('#level-controls');
 const worldStateElement = document.querySelector<HTMLElement>('#world-state');
 const chatModalHostElement = document.querySelector<HTMLElement>('#chat-modal-host');
+const outcomeOverlayHostElement = document.querySelector<HTMLElement>('#outcome-overlay-host');
 
-if (!viewportElement || !levelControlsElement || !worldStateElement || !chatModalHostElement) {
+if (!viewportElement || !levelControlsElement || !worldStateElement || !chatModalHostElement || !outcomeOverlayHostElement) {
   throw new Error('Expected runtime shell elements to exist.');
 }
 
@@ -37,6 +39,7 @@ const commandBuffer = createCommandBuffer();
 const llmClient = createGeminiLlmClient();
 const guardInteractionService = createGuardInteractionService(llmClient);
 const npcInteractionService = createNpcInteractionService(llmClient);
+const outcomeOverlay = createOutcomeOverlay(outcomeOverlayHostElement);
 
 /** Tracks the current interaction in progress (for chat modal message handling). */
 interface CurrentInteraction {
@@ -188,6 +191,7 @@ const runInteractionIfRequested = async (
 const fixedTickDurationMs = 100;
 let previousFrameTime = performance.now();
 let accumulatedTime = 0;
+let levelOutcomeShown = false;
 
 const startRuntime = async (): Promise<void> => {
   const renderPort = await createPixiRenderPort({
@@ -203,6 +207,8 @@ const startRuntime = async (): Promise<void> => {
         .then((newState) => {
           world.resetToState(newState);
           levelUi.setSelectedLevel(levelId);
+          outcomeOverlay.hide();
+          levelOutcomeShown = false;
         })
         .catch((err: unknown) => {
           console.error('Failed to load level:', err);
@@ -214,6 +220,8 @@ const startRuntime = async (): Promise<void> => {
       fetchAndLoadLevel(levelUrl)
         .then((newState) => {
           world.resetToState(newState);
+          outcomeOverlay.hide();
+          levelOutcomeShown = false;
         })
         .catch((err: unknown) => {
           console.error('Failed to reset level:', err);
@@ -260,6 +268,12 @@ const startRuntime = async (): Promise<void> => {
     const currentWorldState = world.getState();
     renderPort.render(currentWorldState);
     worldStateElement.textContent = JSON.stringify(currentWorldState, null, 2);
+
+    if (currentWorldState.levelOutcome && !levelOutcomeShown) {
+      levelOutcomeShown = true;
+      outcomeOverlay.show(currentWorldState.levelOutcome);
+    }
+
     requestAnimationFrame(runFrame);
   };
 

--- a/src/render/outcomeOverlay.ts
+++ b/src/render/outcomeOverlay.ts
@@ -1,0 +1,47 @@
+import { Graphics, Text } from 'pixi.js';
+import type { WorldState } from '../world/types';
+
+/**
+ * Updates or creates the outcome overlay graphic.
+ * Shows a semi-transparent panel with win/lose message when levelOutcome is set.
+ * Returns the overlay Graphics object (may be hidden if no outcome).
+ */
+export const updateOutcomeOverlay = (
+  worldState: WorldState,
+  canvasWidth: number,
+  canvasHeight: number,
+): { graphics: Graphics; text: Text } => {
+  const overlay = new Graphics();
+
+  if (!worldState.levelOutcome) {
+    // No outcome yet, return empty overlay
+    return { graphics: overlay, text: new Text() };
+  }
+
+  // Draw semi-transparent background panel
+  overlay.rect(0, 0, canvasWidth, canvasHeight).fill({ color: 0x000000, alpha: 0.5 });
+
+  // Create outcome message
+  const message = worldState.levelOutcome === 'win' ? 'You escaped!' : 'You were captured.';
+  const messageColor = worldState.levelOutcome === 'win' ? 0x7ad17a : 0xf26b6b;
+
+  const text = new Text({
+    text: message,
+    style: {
+      fontSize: 48,
+      fill: messageColor,
+      fontFamily: 'Arial',
+      fontWeight: 'bold',
+      align: 'center',
+    },
+  });
+
+  // Center text on canvas
+  text.anchor.set(0.5, 0.5);
+  text.x = canvasWidth / 2;
+  text.y = canvasHeight / 2;
+
+  overlay.addChild(text);
+
+  return { graphics: overlay, text };
+};

--- a/src/render/outcomeOverlay.ts
+++ b/src/render/outcomeOverlay.ts
@@ -1,47 +1,38 @@
-import { Graphics, Text } from 'pixi.js';
-import type { WorldState } from '../world/types';
+export interface OutcomeOverlay {
+  show(outcome: 'win' | 'lose'): void;
+  hide(): void;
+}
 
 /**
- * Updates or creates the outcome overlay graphic.
- * Shows a semi-transparent panel with win/lose message when levelOutcome is set.
- * Returns the overlay Graphics object (may be hidden if no outcome).
+ * Creates a full-screen DOM overlay that shows a win or lose message.
+ * Pure DOM component — no game logic.
  */
-export const updateOutcomeOverlay = (
-  worldState: WorldState,
-  canvasWidth: number,
-  canvasHeight: number,
-): { graphics: Graphics; text: Text } => {
-  const overlay = new Graphics();
+export const createOutcomeOverlay = (container: HTMLElement): OutcomeOverlay => {
+  let overlayEl: HTMLElement | null = null;
 
-  if (!worldState.levelOutcome) {
-    // No outcome yet, return empty overlay
-    return { graphics: overlay, text: new Text() };
-  }
+  return {
+    show(outcome: 'win' | 'lose'): void {
+      if (overlayEl) return; // Already shown — idempotent.
 
-  // Draw semi-transparent background panel
-  overlay.rect(0, 0, canvasWidth, canvasHeight).fill({ color: 0x000000, alpha: 0.5 });
-
-  // Create outcome message
-  const message = worldState.levelOutcome === 'win' ? 'You escaped!' : 'You were captured.';
-  const messageColor = worldState.levelOutcome === 'win' ? 0x7ad17a : 0xf26b6b;
-
-  const text = new Text({
-    text: message,
-    style: {
-      fontSize: 48,
-      fill: messageColor,
-      fontFamily: 'Arial',
-      fontWeight: 'bold',
-      align: 'center',
+      const el = document.createElement('div');
+      const bg = outcome === 'win' ? 'rgba(0,120,0,0.93)' : 'rgba(160,0,0,0.93)';
+      el.style.cssText =
+        `position:fixed;inset:0;display:flex;align-items:center;justify-content:center;` +
+        `font-family:Arial,sans-serif;font-size:2.5rem;font-weight:bold;color:#fff;` +
+        `z-index:9999;background:${bg};text-align:center;padding:2rem;`;
+      el.textContent =
+        outcome === 'win'
+          ? 'You Won! 🎉 Refresh to play again.'
+          : 'You Lost! 💀 Refresh to play again.';
+      container.appendChild(el);
+      overlayEl = el;
     },
-  });
 
-  // Center text on canvas
-  text.anchor.set(0.5, 0.5);
-  text.x = canvasWidth / 2;
-  text.y = canvasHeight / 2;
-
-  overlay.addChild(text);
-
-  return { graphics: overlay, text };
+    hide(): void {
+      if (overlayEl) {
+        container.removeChild(overlayEl);
+        overlayEl = null;
+      }
+    },
+  };
 };

--- a/src/render/runtimeLayout.ts
+++ b/src/render/runtimeLayout.ts
@@ -25,5 +25,6 @@ export const getRuntimeLayoutMarkup = (): string => {
     </main>
   </div>
   <div id="chat-modal-host"></div>
+  <div id="outcome-overlay-host"></div>
 `;
 };

--- a/src/render/scene.test.ts
+++ b/src/render/scene.test.ts
@@ -36,6 +36,7 @@ const createWorldState = (): WorldState => ({
       displayName: 'West Door',
       position: { x: 2, y: 10 },
       doorState: 'closed',
+      outcome: 'safe',
     },
   ],
   interactiveObjects: [
@@ -48,6 +49,7 @@ const createWorldState = (): WorldState => ({
     },
   ],
   npcConversationHistoryByNpcId: {},
+  levelOutcome: null,
 });
 
 describe('render entity circle helpers', () => {

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,6 +1,5 @@
 import { Application, Container, Graphics } from 'pixi.js';
 import type { WorldState } from '../world/types';
-import { updateOutcomeOverlay } from './outcomeOverlay';
 
 export interface RenderPort {
   render(worldState: WorldState): void;
@@ -17,7 +16,6 @@ interface RenderContext {
   entityGraphics: Graphics;
   playerGraphics: Graphics;
   rootContainer: Container;
-  outcomeOverlayContainer: Container;
   lastWidth: number;
   lastHeight: number;
 }
@@ -241,14 +239,12 @@ export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<
   const boundaryGraphics = new Graphics();
   const entityGraphics = new Graphics();
   const playerGraphics = new Graphics();
-  const outcomeOverlayContainer = new Container();
   const rootContainer = new Container();
   rootContainer.addChild(boundaryGraphics);
   rootContainer.addChild(gridGraphics);
   rootContainer.addChild(entityGraphics);
   rootContainer.addChild(playerGraphics);
   app.stage.addChild(rootContainer);
-  app.stage.addChild(outcomeOverlayContainer);
 
   const context: RenderContext = {
     app,
@@ -257,7 +253,6 @@ export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<
     entityGraphics,
     playerGraphics,
     rootContainer,
-    outcomeOverlayContainer,
     lastWidth: 0,
     lastHeight: 0,
   };
@@ -270,13 +265,6 @@ export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<
       drawEntityMarkers(context, worldState);
       drawPlayerMarker(context, worldState);
       updateCamera(context, worldState);
-
-      // Update outcome overlay
-      context.outcomeOverlayContainer.removeChildren();
-      if (worldState.levelOutcome) {
-        const { graphics } = updateOutcomeOverlay(worldState, context.lastWidth, context.lastHeight);
-        context.outcomeOverlayContainer.addChild(graphics);
-      }
     },
   };
 };

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,5 +1,6 @@
-import { Application, Container, Graphics } from 'pixi.js';
+import { Application, Container, Graphics, Text } from 'pixi.js';
 import type { WorldState } from '../world/types';
+import { updateOutcomeOverlay } from './outcomeOverlay';
 
 export interface RenderPort {
   render(worldState: WorldState): void;
@@ -16,6 +17,7 @@ interface RenderContext {
   entityGraphics: Graphics;
   playerGraphics: Graphics;
   rootContainer: Container;
+  outcomeOverlayContainer: Container;
   lastWidth: number;
   lastHeight: number;
 }
@@ -239,12 +241,14 @@ export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<
   const boundaryGraphics = new Graphics();
   const entityGraphics = new Graphics();
   const playerGraphics = new Graphics();
+  const outcomeOverlayContainer = new Container();
   const rootContainer = new Container();
   rootContainer.addChild(boundaryGraphics);
   rootContainer.addChild(gridGraphics);
   rootContainer.addChild(entityGraphics);
   rootContainer.addChild(playerGraphics);
   app.stage.addChild(rootContainer);
+  app.stage.addChild(outcomeOverlayContainer);
 
   const context: RenderContext = {
     app,
@@ -253,6 +257,7 @@ export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<
     entityGraphics,
     playerGraphics,
     rootContainer,
+    outcomeOverlayContainer,
     lastWidth: 0,
     lastHeight: 0,
   };
@@ -265,6 +270,13 @@ export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<
       drawEntityMarkers(context, worldState);
       drawPlayerMarker(context, worldState);
       updateCamera(context, worldState);
+
+      // Update outcome overlay
+      context.outcomeOverlayContainer.removeChildren();
+      if (worldState.levelOutcome) {
+        const { graphics } = updateOutcomeOverlay(worldState, context.lastWidth, context.lastHeight);
+        context.outcomeOverlayContainer.addChild(graphics);
+      }
     },
   };
 };

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,4 +1,4 @@
-import { Application, Container, Graphics, Text } from 'pixi.js';
+import { Application, Container, Graphics } from 'pixi.js';
 import type { WorldState } from '../world/types';
 import { updateOutcomeOverlay } from './outcomeOverlay';
 

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -70,16 +70,16 @@ describe('deserializeLevel', () => {
     const level: LevelData = {
       ...minimalLevel,
       doors: [
-        { id: 'door-1', displayName: 'Main Gate', x: 0, y: 10, doorState: 'locked' },
-        { id: 'door-2', displayName: 'Side Door', x: 19, y: 0, doorState: 'open' },
+        { id: 'door-1', displayName: 'Main Gate', x: 0, y: 10, doorState: 'locked', outcome: 'safe' },
+        { id: 'door-2', displayName: 'Side Door', x: 19, y: 0, doorState: 'open', outcome: 'danger' },
       ],
     };
 
     const state = deserializeLevel(level);
 
     expect(state.doors).toEqual([
-      { id: 'door-1', displayName: 'Main Gate', position: { x: 0, y: 10 }, doorState: 'locked' },
-      { id: 'door-2', displayName: 'Side Door', position: { x: 19, y: 0 }, doorState: 'open' },
+      { id: 'door-1', displayName: 'Main Gate', position: { x: 0, y: 10 }, doorState: 'locked', outcome: 'safe' },
+      { id: 'door-2', displayName: 'Side Door', position: { x: 19, y: 0 }, doorState: 'open', outcome: 'danger' },
     ]);
   });
 
@@ -128,6 +128,7 @@ describe('deserializeLevel', () => {
           x: 2,
           y: 3,
           doorState: 'closed',
+          outcome: 'safe',
         },
       ],
     };

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -242,3 +242,112 @@ describe('starter level', () => {
     expect(state.doors.map((d) => d.id)).toEqual(['door-1', 'door-2']);
   });
 });
+
+describe('honestyTrait field', () => {
+  it('accepts guards with honestyTrait: "truth-teller"', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      guards: [{ id: 'guard-1', displayName: 'Truthful', x: 5, y: 7, guardState: 'idle', honestyTrait: 'truth-teller' }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const validated = validateLevelData(level);
+    const state = deserializeLevel(validated);
+
+    expect(state.guards[0].honestyTrait).toBe('truth-teller');
+  });
+
+  it('accepts guards with honestyTrait: "liar"', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      guards: [{ id: 'guard-1', displayName: 'Lying', x: 5, y: 7, guardState: 'idle', honestyTrait: 'liar' }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const validated = validateLevelData(level);
+    const state = deserializeLevel(validated);
+
+    expect(state.guards[0].honestyTrait).toBe('liar');
+  });
+
+  it('accepts guards without honestyTrait field', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      guards: [{ id: 'guard-1', displayName: 'Unknown', x: 5, y: 7, guardState: 'idle' }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const validated = validateLevelData(level);
+    const state = deserializeLevel(validated);
+
+    expect(state.guards[0].honestyTrait).toBeUndefined();
+  });
+
+  it('rejects guards with invalid honestyTrait value', () => {
+    const bad = {
+      ...minimalLevel,
+      guards: [{ id: 'guard-1', displayName: 'Bad', x: 5, y: 7, guardState: 'idle', honestyTrait: 'dishonest' as unknown }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 2, y: 3, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid honestyTrait');
+  });
+});
+
+describe('outcome field', () => {
+  it('accepts doors with outcome: "safe"', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      doors: [{ id: 'door-1', displayName: 'Safe', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const validated = validateLevelData(level);
+    const state = deserializeLevel(validated);
+
+    expect(state.doors[0].outcome).toBe('safe');
+  });
+
+  it('accepts doors with outcome: "danger"', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      doors: [{ id: 'door-1', displayName: 'Danger', x: 0, y: 10, doorState: 'open', outcome: 'danger' }],
+    };
+
+    const validated = validateLevelData(level);
+    const state = deserializeLevel(validated);
+
+    expect(state.doors[0].outcome).toBe('danger');
+  });
+
+  it('rejects doors without outcome field', () => {
+    const bad = {
+      ...minimalLevel,
+      doors: [{ id: 'door-1', displayName: 'No outcome', x: 0, y: 10, doorState: 'open' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('must have id, displayName, x, y, doorState, and outcome');
+  });
+
+  it('rejects doors with invalid outcome value', () => {
+    const bad = {
+      ...minimalLevel,
+      doors: [{ id: 'door-1', displayName: 'Bad', x: 0, y: 10, doorState: 'open', outcome: 'unclear' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid outcome');
+  });
+});
+
+describe('levelOutcome field', () => {
+  it('initializes to null when level is deserialized', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const state = deserializeLevel(validateLevelData(level));
+
+    expect(state.levelOutcome).toBeNull();
+  });
+});
+

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -44,8 +44,56 @@ export function validateLevelData(input: unknown): LevelData {
     throw new Error('Invalid level data: guards must be an array');
   }
 
+  for (let i = 0; i < (raw['guards'] as unknown[]).length; i++) {
+    const guard = (raw['guards'] as unknown[])[i] as Record<string, unknown>;
+    if (
+      typeof guard !== 'object' ||
+      guard === null ||
+      typeof guard['id'] !== 'string' ||
+      typeof guard['displayName'] !== 'string' ||
+      typeof guard['x'] !== 'number' ||
+      typeof guard['y'] !== 'number' ||
+      typeof guard['guardState'] !== 'string'
+    ) {
+      throw new Error(
+        `Invalid level data: guard at index ${i} must have id, displayName, x, y, and guardState`,
+      );
+    }
+    // honestyTrait is optional
+    if (guard['honestyTrait'] !== undefined) {
+      if (guard['honestyTrait'] !== 'truth-teller' && guard['honestyTrait'] !== 'liar') {
+        throw new Error(
+          `Invalid level data: guard at index ${i} has invalid honestyTrait (must be 'truth-teller' or 'liar')`,
+        );
+      }
+    }
+  }
+
   if (!Array.isArray(raw['doors'])) {
     throw new Error('Invalid level data: doors must be an array');
+  }
+
+  for (let i = 0; i < (raw['doors'] as unknown[]).length; i++) {
+    const door = (raw['doors'] as unknown[])[i] as Record<string, unknown>;
+    if (
+      typeof door !== 'object' ||
+      door === null ||
+      typeof door['id'] !== 'string' ||
+      typeof door['displayName'] !== 'string' ||
+      typeof door['x'] !== 'number' ||
+      typeof door['y'] !== 'number' ||
+      typeof door['doorState'] !== 'string' ||
+      typeof door['outcome'] !== 'string'
+    ) {
+      throw new Error(
+        `Invalid level data: door at index ${i} must have id, displayName, x, y, doorState, and outcome`,
+      );
+    }
+    if (door['outcome'] !== 'safe' && door['outcome'] !== 'danger') {
+      throw new Error(
+        `Invalid level data: door at index ${i} has invalid outcome (must be 'safe' or 'danger')`,
+      );
+    }
   }
 
   return raw as unknown as LevelData;
@@ -74,15 +122,18 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       displayName: g.displayName,
       position: { x: g.x, y: g.y },
       guardState: g.guardState,
+      honestyTrait: g.honestyTrait,
     })),
     doors: levelData.doors.map((d) => ({
       id: d.id,
       displayName: d.displayName,
       position: { x: d.x, y: d.y },
       doorState: d.doorState,
+      outcome: d.outcome,
     })),
     interactiveObjects: [],
     npcConversationHistoryByNpcId: {},
+    levelOutcome: null,
   };
   validateSpatialLayout(worldState);
   return worldState;

--- a/src/world/levelLoader.test.ts
+++ b/src/world/levelLoader.test.ts
@@ -87,6 +87,7 @@ describe('fetchAndLoadLevel', () => {
           x: 2,
           y: 3,
           doorState: 'closed',
+          outcome: 'safe',
         },
       ],
     });

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -32,6 +32,7 @@ export const createInitialWorldState = (): WorldState => ({
     },
   ],
   npcConversationHistoryByNpcId: {},
+  levelOutcome: null,
 });
 
 export const serializeWorldState = (worldState: WorldState): string => JSON.stringify(worldState);

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -33,11 +33,13 @@ export interface Interactable {
 /** A guard entity that the player can interact with. */
 export interface Guard extends Interactable {
   guardState: 'idle' | 'patrolling' | 'alert';
+  honestyTrait?: 'truth-teller' | 'liar';
 }
 
 /** A door that the player can pass through or be blocked by. */
 export interface Door extends Interactable {
   doorState: 'open' | 'closed' | 'locked';
+  outcome?: 'safe' | 'danger';
 }
 
 export interface InteractiveObject extends Interactable {
@@ -64,6 +66,7 @@ export interface LevelData {
     x: number;
     y: number;
     guardState: 'patrolling' | 'alert' | 'idle';
+    honestyTrait?: 'truth-teller' | 'liar';
   }>;
   doors: Array<{
     id: string;
@@ -71,6 +74,7 @@ export interface LevelData {
     x: number;
     y: number;
     doorState: 'open' | 'closed' | 'locked';
+    outcome: 'safe' | 'danger';
   }>;
 }
 
@@ -83,6 +87,7 @@ export interface WorldState {
   doors: Door[];
   interactiveObjects: InteractiveObject[];
   npcConversationHistoryByNpcId: NpcConversationHistoryByNpcId;
+  levelOutcome: 'win' | 'lose' | null;
 }
 
 export type WorldCommand =


### PR DESCRIPTION
## Closes #64

### Summary

Completes the riddle level implementation with the correct level manifest and a full-screen DOM outcome overlay.

### Changes

**`public/levels/riddle.json`** — Updated to the "Two Guards, Two Doors" spec:
- Name: "Two Guards, Two Doors"
- Player at (10, 15)
- Guard True (truth-teller) at (8, 10), Guard False (liar) at (12, 10)
- Left Door (safe) at (5, 5), Right Door (danger) at (15, 5) — both `closed`

**`src/render/outcomeOverlay.ts`** — Replaced PixiJS in-canvas overlay with a pure DOM component:
- Exports `createOutcomeOverlay(container)` returning `{ show(outcome), hide() }`
- `show('win')` renders green full-screen overlay: "You Won! 🎉 Refresh to play again."
- `show('lose')` renders red full-screen overlay: "You Lost! 💀 Refresh to play again."

**`src/render/scene.ts`** — Removed PixiJS `outcomeOverlayContainer` and `updateOutcomeOverlay` import (superseded by DOM overlay).

**`src/render/runtimeLayout.ts`** — Added `<div id="outcome-overlay-host"></div>` after `chat-modal-host`.

**`src/main.ts`** — Wired `createOutcomeOverlay`: queries `#outcome-overlay-host`, creates instance, calls `show()` once when `levelOutcome` is set; resets on level select/reset.

**`src/integration/riddleLevel.test.ts`** — Updated positions and door state assertions to match the new spec.

### Validation

- `npm run build` — clean ✅
- `npm test` — 119/119 tests pass ✅

### Type

ENHANCEMENT