### PR TITLE
#65 Guard LLM persona: enforce honestyTrait for truth-teller and liar behavior

### DIFF
--- a/src/interaction/guardPromptContext.test.ts
+++ b/src/interaction/guardPromptContext.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { createInitialWorldState } from '../world/state';
-import { buildGuardPromptContext, buildGuardWorldContextPayload, GUARD_PERSONA_CONTRACT } from './guardPromptContext';
+import {
+  buildGuardPromptContext,
+  buildGuardWorldContextPayload,
+  buildGuardPersonaContract,
+  GUARD_PERSONA_CONTRACT,
+  TRUTH_TELLER_PERSONA_CONTRACT,
+  LIAR_PERSONA_CONTRACT,
+} from './guardPromptContext';
 
 describe('buildGuardWorldContextPayload', () => {
   it('includes player, guard, npc, and interactive object positions including doors', () => {
@@ -128,5 +135,72 @@ describe('buildGuardWorldContextPayload', () => {
 
     expect(parsed.guardPersonaContract).toBe(GUARD_PERSONA_CONTRACT);
     expect(roundTrip.worldContext).toEqual(parsed.worldContext);
+  });
+});
+
+describe('buildGuardPersonaContract', () => {
+  it('returns TRUTH_TELLER_PERSONA_CONTRACT when honestyTrait is truth-teller', () => {
+    const guard = {
+      id: 'g1',
+      displayName: 'Honest Guard',
+      position: { x: 0, y: 0 },
+      guardState: 'idle' as const,
+      honestyTrait: 'truth-teller' as const,
+    };
+    expect(buildGuardPersonaContract(guard)).toBe(TRUTH_TELLER_PERSONA_CONTRACT);
+  });
+
+  it('returns LIAR_PERSONA_CONTRACT when honestyTrait is liar', () => {
+    const guard = {
+      id: 'g2',
+      displayName: 'Liar Guard',
+      position: { x: 0, y: 0 },
+      guardState: 'idle' as const,
+      honestyTrait: 'liar' as const,
+    };
+    expect(buildGuardPersonaContract(guard)).toBe(LIAR_PERSONA_CONTRACT);
+  });
+
+  it('falls back to GUARD_PERSONA_CONTRACT when honestyTrait is absent', () => {
+    const guard = {
+      id: 'g3',
+      displayName: 'Generic Guard',
+      position: { x: 0, y: 0 },
+      guardState: 'idle' as const,
+    };
+    expect(buildGuardPersonaContract(guard)).toBe(GUARD_PERSONA_CONTRACT);
+  });
+
+  it('embeds the correct persona contract in the serialized prompt context', () => {
+    const worldState = createInitialWorldState();
+
+    const truthTeller = {
+      id: 'g-truth',
+      displayName: 'Truth Guard',
+      position: { x: 1, y: 1 },
+      guardState: 'idle' as const,
+      honestyTrait: 'truth-teller' as const,
+    };
+    const liar = {
+      id: 'g-liar',
+      displayName: 'Liar Guard',
+      position: { x: 2, y: 2 },
+      guardState: 'idle' as const,
+      honestyTrait: 'liar' as const,
+    };
+    const generic = {
+      id: 'g-generic',
+      displayName: 'Generic Guard',
+      position: { x: 3, y: 3 },
+      guardState: 'idle' as const,
+    };
+
+    const parsedTruth = JSON.parse(buildGuardPromptContext(truthTeller, worldState)) as { guardPersonaContract: string };
+    const parsedLiar = JSON.parse(buildGuardPromptContext(liar, worldState)) as { guardPersonaContract: string };
+    const parsedGeneric = JSON.parse(buildGuardPromptContext(generic, worldState)) as { guardPersonaContract: string };
+
+    expect(parsedTruth.guardPersonaContract).toBe(TRUTH_TELLER_PERSONA_CONTRACT);
+    expect(parsedLiar.guardPersonaContract).toBe(LIAR_PERSONA_CONTRACT);
+    expect(parsedGeneric.guardPersonaContract).toBe(GUARD_PERSONA_CONTRACT);
   });
 });

--- a/src/interaction/guardPromptContext.ts
+++ b/src/interaction/guardPromptContext.ts
@@ -3,6 +3,18 @@ import type { Guard, WorldState } from '../world/types';
 export const GUARD_PERSONA_CONTRACT =
   'You are a vigilant city guard. Keep responses concise, factual, and grounded in the provided world context. Do not invent positions or events not present in context.';
 
+export const TRUTH_TELLER_PERSONA_CONTRACT =
+  'You are a vigilant city guard who always speaks the truth. You must answer all questions truthfully and never deceive or mislead the player under any circumstances. Keep responses concise and grounded in the provided world context.';
+
+export const LIAR_PERSONA_CONTRACT =
+  'You are a vigilant city guard. You must always answer with the logical opposite of the truth. You will never reveal that you are lying. If asked whether you are a liar or whether you lie, you must deny it and claim you always tell the truth. Keep responses concise and grounded in the provided world context.';
+
+export const buildGuardPersonaContract = (guard: Guard): string => {
+  if (guard.honestyTrait === 'truth-teller') return TRUTH_TELLER_PERSONA_CONTRACT;
+  if (guard.honestyTrait === 'liar') return LIAR_PERSONA_CONTRACT;
+  return GUARD_PERSONA_CONTRACT;
+};
+
 export interface GuardWorldContextPayload {
   player: {
     id: string;
@@ -84,7 +96,7 @@ export const buildGuardPromptContext = (guard: Guard, worldState: WorldState): s
       id: guard.id,
       guardState: guard.guardState,
     },
-    guardPersonaContract: GUARD_PERSONA_CONTRACT,
+    guardPersonaContract: buildGuardPersonaContract(guard),
     worldContext: buildGuardWorldContextPayload(worldState),
   });
 };


### PR DESCRIPTION
## Closes #65

### Summary

Extends the guard LLM prompt system so each guard's `honestyTrait` drives its system prompt persona contract.

**Changes:**

- `src/interaction/guardPromptContext.ts`
  - Added `TRUTH_TELLER_PERSONA_CONTRACT`: instructs the LLM to always answer truthfully and never deceive.
  - Added `LIAR_PERSONA_CONTRACT`: instructs the LLM to always answer with the logical opposite of the truth, never reveal it is lying, and deny being a liar if asked.
  - Added `buildGuardPersonaContract(guard)`: selects the correct contract based on `guard.honestyTrait`; falls back to `GUARD_PERSONA_CONTRACT` when the trait is absent/undefined.
  - `buildGuardPromptContext` now calls `buildGuardPersonaContract` instead of hard-coding `GUARD_PERSONA_CONTRACT`.

- `src/interaction/guardPromptContext.test.ts`
  - Extended imports to include new exports.
  - Added `describe('buildGuardPersonaContract')` with 4 tests covering: truth-teller, liar, no trait (fallback), and end-to-end serialized context embedding.

### Validation

- `npx vitest run src/interaction/guardPromptContext.test.ts` — 7/7 tests pass (3 existing + 4 new).
- `npx vitest run` — 102/102 tests pass, no regressions.

### Work Package
CHANGE