### PR TITLE
#74 introduce npc prompt profiles by type

### DIFF
--- a/docs/ADD_NPC.md
+++ b/docs/ADD_NPC.md
@@ -4,7 +4,11 @@ This pattern describes how to introduce a new NPC to Guard Game.
 
 ## Overview
 
-NPCs are actors with a type and position. Their conversation thread is stored in the shared actor-scoped history map keyed by actor id, while their dialogue behavior is driven by `npcType` and the derived `dialogueContextKey`.
+NPCs are actors with a type and position. Their conversation thread is stored in the shared actor-scoped history map keyed by actor id.
+
+For LLM prompts, NPC behavior is now driven by `npcType` through the profile registry in `src/interaction/npcPromptContext.ts`.
+- Shared prompt policy comes from the resolved profile for the normalized `npcType`
+- Per-instance details (name/position/dialogueContextKey) come from the specific NPC entry
 
 ## Steps
 
@@ -25,155 +29,85 @@ Add the NPC to the `npcs` array in `public/levels/*.json`:
 }
 ```
 
-**Required fields:**
-- `id`: Unique identifier for the NPC
-- `displayName`: Display name shown in the UI  
-- `x`, `y`: Grid coordinates
-- `npcType`: String categorizing the NPC's role (e.g., `archive_keeper`, `scholar`, `merchant`). This determines the `dialogueContextKey`.
+Required fields:
+- `id`: unique identifier for the NPC
+- `displayName`: display name shown in the UI
+- `x`, `y`: grid coordinates
+- `npcType`: string categorizing the NPC role (for prompt profile lookup)
 
-**Deserialization:**
-When the level loads, `deserializeLevel()` automatically maps NPC entries from level JSON into runtime `Npc` objects and derives `dialogueContextKey` from `npcType`:
-
-```typescript
-// Input from level JSON
-{ id: 'archivist-1', displayName: 'The Archivist', x: 8, y: 5, npcType: 'archive_keeper' }
-
-// Becomes runtime Npc
-{
-  id: 'archivist-1',
-  displayName: 'The Archivist',
-  position: { x: 8, y: 5 },
-  npcType: 'archive_keeper',
-  dialogueContextKey: 'npc_archive_keeper'  // derived: `npc_${npcType.toLowerCase()}`
-}
-```
+Deserialization behavior:
+- `deserializeLevel()` maps level JSON entries to runtime `Npc` objects
+- `dialogueContextKey` is derived as `npc_${npcType.toLowerCase()}`
 
 At runtime, the NPC's conversation history is read and written through `actorConversationHistoryByActorId[npc.id]`.
 
 ### 2. Handle Rendering (if needed)
-NPCs are rendered as grid sprites in `src/render/scene.ts`. If you need custom rendering for a specific `npcType`:
+NPCs are rendered in `src/render/scene.ts`. Custom rendering can branch on `npcType`, but this is optional and independent from prompt profile behavior.
+
+### 3. Configure Prompt Profile Behavior
+Prompt persona/policy is resolved by `resolveNpcPromptProfile(npc.npcType)` in `src/interaction/npcPromptContext.ts`.
+
+How it works:
+- `npcType` is normalized to lowercase and trimmed
+- if present in `NPC_PROMPT_PROFILE_REGISTRY`, that profile is used
+- otherwise the deterministic `DEFAULT_NPC_PROMPT_PROFILE` is used
+- fallback sets `profileKey` to `default`
+
+To introduce a new NPC type with custom prompt behavior, add a registry entry:
 
 ```typescript
-// Example: custom sprite for archive_keeper NPCs
-function getNpcSpriteColor(npc: Npc): number {
-  switch (npc.npcType) {
-    case 'archive_keeper':
-      return 0x9933ff; // purple
-    case 'scholar':
-      return 0x0099ff; // blue
-    default:
-      return 0xcccccc; // gray
-  }
+export const NPC_PROMPT_PROFILE_REGISTRY: Record<string, NpcPromptProfile> = {
+  archive_keeper: { ... },
+  engineer: {
+    personaContract: 'You are a practical engineer focused on mechanisms and routes.',
+    knowledgePolicy: 'Discuss machinery and access points only when supported by context.',
+    responseStyleConstraints: 'Respond directly with a pragmatic tone.',
+  },
+};
+```
+
+If no registry entry exists for the NPC's type, behavior remains valid via default fallback.
+
+### 4. Understand Prompt Context Construction
+`buildNpcPromptContext(npc, player)` returns deterministic JSON with this shape:
+
+```json
+{
+  "actor": { "id": "archivist-1", "npcType": "archive_keeper" },
+  "npcProfile": {
+    "profileKey": "archive_keeper",
+    "requestedNpcType": "archive_keeper",
+    "personaContract": "...",
+    "knowledgePolicy": "...",
+    "responseStyleConstraints": "..."
+  },
+  "npcInstance": {
+    "displayName": "The Archivist",
+    "position": { "x": 8, "y": 5 },
+    "dialogueContextKey": "npc_archive_keeper"
+  },
+  "player": { "id": "player", "displayName": "Player" }
 }
 ```
 
-Rendering uses the NPC's `position` and `displayName`:
+This keeps shared type-level prompt behavior (`npcProfile`) separate from per-instance fields (`npcInstance`).
 
-```typescript
-for (const npc of state.npcs) {
-  const sprite = createOrUpdateNpcSprite(npc, getNpcSpriteColor(npc));
-  container.addChild(sprite);
-}
-```
-
-### 3. Define Interaction and Dialogue
-Define interaction behavior in `src/interaction/npcInteraction.ts`. Route interaction based on `npcType`:
-
-```typescript
-export async function resolveNpcInteraction(
-  player: Player,
-  npc: Npc,
-  direction: DirectionKey
-): Promise<InteractionResponse> {
-  // Check adjacency
-  const adjacencyResolution = resolveAdjacentNpc(player, npc, direction);
-  
-  if (!adjacencyResolution.canInteract) {
-    return { text: 'Cannot reach that NPC.' };
-  }
-  
-  // Route to NPC type handler
-  switch (npc.npcType) {
-    case 'archive_keeper':
-      return resolveArchiveKeeperInteraction(player, npc);
-    case 'scholar':
-      return resolveScholarInteraction(player, npc);
-    default:
-      return { text: `Hello, I'm a ${npc.displayName}.` };
-  }
-}
-```
-
-The NPC's `dialogueContextKey` (derived from `npcType`) is used when building LLM prompt context:
-
-```typescript
-// In guardPromptContext.ts or similar
-function buildNpcPromptContext(npc: Npc, player: Player): string {
-  return `
-You are a ${npc.npcType}. The player's key to unlock your dialogue is: ${npc.dialogueContextKey}
-NPC name: ${npc.displayName}
-Player: ${player.displayName}
-  `;
-}
-```
-
-
-### 4. Add Tests
-Test that the NPC loads correctly and can be interacted with:
-
-```typescript
-// In src/world/level.test.ts
-describe('NPC loading', () => {
-  it('deserializes level NPCs with correct dialogueContextKey', () => {
-    const level: LevelData = {
-      ...minimalLevel,
-      npcs: [{ 
-        id: 'npc-1', 
-        displayName: 'Archivist', 
-        x: 8, 
-        y: 3, 
-        npcType: 'archive_keeper' 
-      }],
-      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
-    };
-
-    const state = deserializeLevel(validateLevelData(level));
-
-    expect(state.npcs).toHaveLength(1);
-    expect(state.npcs[0].npcType).toBe('archive_keeper');
-    expect(state.npcs[0].dialogueContextKey).toBe('npc_archive_keeper');
-  });
-
-  it('derives dialogueContextKey lowercase from npcType', () => {
-    const level: LevelData = {
-      ...minimalLevel,
-      npcs: [{ 
-        id: 'npc-1', 
-        displayName: 'Captain', 
-        x: 5, 
-        y: 5, 
-        npcType: 'GUARD_CAPTAIN' 
-      }],
-      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
-    };
-
-    const state = deserializeLevel(validateLevelData(level));
-    expect(state.npcs[0].dialogueContextKey).toBe('npc_guard_captain');
-  });
-});
-```
+### 5. Add Tests
+Cover both world loading and prompt resolution behavior:
+- `src/world/level.test.ts`: NPC deserialization and derived `dialogueContextKey`
+- `src/interaction/npcPromptContext.test.ts`: same-type reuse, cross-type differentiation, deterministic fallback, and deterministic serialized context
+- `src/interaction/npcInteraction.test.ts`: context passed to LLM includes expected actor/profile/instance/player sections
 
 ## Checklist
 
 - [ ] NPC added to level JSON (`public/levels/*.json`) with `id`, `displayName`, `x`, `y`, `npcType`
-- [ ] `npcType` matches the interaction handler routing (e.g., `'archive_keeper'`)
-- [ ] Interaction handler defined in `src/interaction/npcInteraction.ts` for the `npcType`
-- [ ] Rendering (if custom) handles the `npcType` in `src/render/scene.ts`
-- [ ] Tests verify NPC loads with correct `dialogueContextKey` derived from `npcType`
-- [ ] `dialogueContextKey` is used in LLM prompt context building
+- [ ] `npcType` follows registry naming style (normalized lowercase tokens such as `archive_keeper`)
+- [ ] Prompt profile entry added to `NPC_PROMPT_PROFILE_REGISTRY` when custom behavior is required
+- [ ] Fallback behavior is acceptable if no custom profile entry is added
+- [ ] Tests cover profile resolution and prompt context serialization (`src/interaction/npcPromptContext.test.ts`)
 - [ ] Level passes `validateLevelData()` and `deserializeLevel()` without errors
 - [ ] NPC position does not overlap with other entities (validated by `validateSpatialLayout()`)
 
 ---
 
-See [World Layer](WORLD_LAYER.md), [Type Reference](TYPES_REFERENCE.md), and [Interaction Layer](INTERACTION_LAYER.md) for more context.
+See [WORLD_LAYER.md](WORLD_LAYER.md), [TYPES_REFERENCE.md](TYPES_REFERENCE.md), and [INTERACTION_LAYER.md](INTERACTION_LAYER.md) for more context.

--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -52,7 +52,7 @@ Result dispatcher keeps main-loop side effects centralized and testable.
 
 ## Main Loop Routing Pattern
 
-`runInteractionIfRequested()` in `src/main.ts` now uses one routing path:
+`runInteractionIfRequested()` in `src/main.ts` uses one routing path:
 1. Resolve adjacent target.
 2. Call `interactionDispatcher.dispatch(...)`.
 3. If promise-like, resolve asynchronously then call `resultDispatcher.dispatch(...)`.
@@ -61,6 +61,24 @@ Result dispatcher keeps main-loop side effects centralized and testable.
 This removes target-kind branching from `main.ts` and preserves behavior parity from pre-refactor logic.
 
 The runtime bridge and tests use the shared actor-neutral helper in `src/interaction/actorConversationThread.ts` to read and render conversation history.
+
+## NPC Prompt Profile Context
+
+NPC conversational turns call `buildNpcPromptContext()` from `src/interaction/npcPromptContext.ts`.
+
+Prompt profile resolution behavior:
+- `npcType` is normalized via `trim().toLowerCase()`
+- profile lookup is performed against `NPC_PROMPT_PROFILE_REGISTRY`
+- unknown, empty, or missing `npcType` values deterministically fall back to `DEFAULT_NPC_PROMPT_PROFILE`
+- fallback responses expose `profileKey: 'default'`
+
+The serialized prompt context includes four top-level sections:
+- `actor`: stable actor identifier and raw `npcType`
+- `npcProfile`: resolved shared profile (`profileKey`, `requestedNpcType`, persona/knowledge/style constraints)
+- `npcInstance`: per-instance data (`displayName`, `position`, `dialogueContextKey`)
+- `player`: player identifier and display name
+
+This split keeps shared type-level prompt policy separate from per-instance world facts.
 
 ## Behavior Parity Expectations
 
@@ -84,11 +102,14 @@ This allows multiple objects to share one behavior implementation while retainin
 
 Only conversational player-message flows route to the LLM layer (guard/NPC chat services). Chat-open flows and deterministic door/object interactions do not call the LLM client.
 
+NPC interactions build context in the interaction layer and call `llmClient.complete(...)` from `src/llm/client.ts`.
+
 See `src/interaction/guardInteraction.ts`, `src/interaction/npcInteraction.ts`, and `src/llm/client.ts`.
 
 ## Tests
 
 - `src/interaction/interactionDispatcher.test.ts`: dispatch routing by kind, sync/async behavior parity, result dispatcher timing parity
+- `src/interaction/npcPromptContext.test.ts`: profile registry resolution, deterministic fallback, context shape determinism
 - `src/interaction/objectInteraction.test.ts`: object-type dispatcher behavior, first-use outcomes, repeat interactions
 - `src/integration/starterLevel.test.ts`: end-to-end adjacent object resolution and state updates
 - `src/interaction/adjacencyResolver.test.ts`: deterministic target resolution with interactive objects

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -1,43 +1,61 @@
 # LLM Layer
 
-The LLM layer provides the integration boundary for large language model calls. It defines stubs, manages context generation, and serializes game state for prompt construction.
+The LLM layer provides the API boundary for model calls and deterministic fallback behavior when API execution fails.
 
 ## Responsibilities
-- Provide `LlmClient` interface with clear method signatures
-- Serialize world state and interaction context to JSON
-- Build prompts with relevant game context (actor persona, player state, conversation thread)
-- Return structured LLM responses (dialog text, suggested actions)
-- Maintain clean separation: LLM reasoning happens outside core game loop
-- Support optional LLM integration (game functions without LLM)
+- Provide `LlmClient` with a single `complete(request)` method
+- Accept structured request payloads from interaction services
+- Invoke external chat-completion APIs when configured
+- Return normalized text responses to the interaction layer
+- Return deterministic fallback text when configuration or network calls fail
 
-## Core Concepts
+## Core Interface
+
+Defined in `src/llm/client.ts`.
 
 ### LlmClient
-Interface that defines how the game communicates with LLM systems. Implemented as stubs initially; can be extended with real API calls.
+- Method: `complete(request: LlmRequest): Promise<LlmResponse>`
+- Response shape: `{ text: string }`
 
-### Context Serialization
-Convert world state and interaction data to JSON suitable for LLM prompts. All data must be clear and semantic.
+### LlmRequest
+Current request payload fields:
+- `actorId: string`
+- `context: string`
+- `playerMessage: string`
+- `conversationHistory: ConversationMessage[]`
 
-### Response Parsing
-Parse LLM output into structured `InteractionResponse` objects.
+The interaction layer is responsible for building `context` and maintaining conversation history.
 
-## LLM Integration Pattern
+## NPC Prompt Context Flow
 
-LLM calls are initiated by the interaction layer:
-1. Interaction layer builds `InteractionRequest` (target actor, player state, conversation thread)
-2. Interaction layer calls `llmClient.generateResponse(request)`
-3. LLM client serializes context and formats prompt
-4. LLM client calls external API (stubbed initially)
-5. LLM client parses and returns `InteractionResponse`
-6. Interaction layer applies response (dialog, state changes)
+For NPC conversational turns:
+1. `createNpcInteractionService()` in `src/interaction/npcInteraction.ts` builds context with `buildNpcPromptContext(npc, player)`.
+2. The service passes actor id, context, player message, and history into `llmClient.complete(...)`.
+3. The LLM response text is appended to actor-scoped history.
+
+`buildNpcPromptContext()` includes both:
+- shared profile information (`npcProfile`) resolved from `npcType`
+- per-instance NPC data (`npcInstance`) from world state
+
+## Deterministic Fallbacks
+
+`src/llm/client.ts` exports deterministic fallback constants:
+- `MISSING_API_KEY_FALLBACK_TEXT`
+- `REQUEST_FAILURE_FALLBACK_TEXT`
+
+When API key configuration is missing or request execution fails, `complete()` returns fallback text rather than throwing. This keeps interaction flows stable and serializable.
+
+NPC interaction also guards its call site by mapping thrown completion errors to `REQUEST_FAILURE_FALLBACK_TEXT` before appending the assistant turn.
 
 ## Constraints and Guidelines
 
-- LLM layer does NOT modify world state directly. It returns responses; the interaction layer applies them.
-- LLM calls are asynchronous. The game loop must continue while LLM calls are pending.
-- All game state in prompts must be JSON-serializable.
-- LLM layer stubs allow the game to function without real LLM integration.
+- LLM layer does not mutate world state directly
+- LLM calls are asynchronous; world updates occur in interaction services when promises resolve
+- Prompt context remains JSON-serializable
+- Deterministic fallback behavior is required for predictable tests and runtime behavior
 
----
+## Tests
 
-*Detailed context generation patterns and API client implementation will be documented as LLM features are integrated.*
+- `src/llm/client.test.ts`: API request mapping and fallback behavior
+- `src/interaction/npcInteraction.test.ts`: NPC LLM request payload and conversation history updates
+- `src/interaction/npcPromptContext.test.ts`: prompt profile resolution and deterministic context serialization

--- a/docs/TESTING_PATTERNS.md
+++ b/docs/TESTING_PATTERNS.md
@@ -30,6 +30,11 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
   - conversational open path is synchronous
   - conversational player-message path is asynchronous
   - deterministic door/object paths stay synchronous
+- **Prompt-profile checks (NPC):**
+  - same `npcType` resolves to same profile contract
+  - different `npcType` values resolve to distinct profiles
+  - unknown/missing `npcType` falls back to deterministic default profile
+  - serialized prompt context is deterministic for identical snapshots
 - **Example:** Verify that a player interaction is routed by dispatcher kind and the correct result handler callback fires in order
 
 ### Input Layer Tests
@@ -43,9 +48,9 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
   ```
 
 ### LLM Layer Tests
-- **What to test:** Context serialization, response parsing, API stubs
+- **What to test:** Context serialization, response parsing, API fallbacks
 - **Type:** Unit tests
-- **Pattern:** Mock external API, assert prompt construction and response handling
+- **Pattern:** Mock external API, assert request construction and deterministic fallback handling
 - **Caveat:** Real API integration testing is separate
 
 ## Integration Tests

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -4,6 +4,7 @@ This document tracks the core serializable types used by the runtime.
 
 Source of truth:
 - `src/world/types.ts`
+- `src/interaction/npcPromptContext.ts`
 - `src/interaction/objectInteraction.ts`
 - `src/interaction/adjacencyResolver.ts`
 
@@ -21,8 +22,8 @@ Source of truth:
 - `id: string`
 - `displayName: string`
 - `position: GridPosition`
-- `npcType: string` — Categorizes the NPC's role (e.g., `'archive_keeper'`, `'scholar'`). This field is set at level definition time.
-- `dialogueContextKey: string` — Deterministically derived from `npcType` via `npc_${npcType.toLowerCase()}`. Used for LLM prompt context routing.
+- `npcType: string` - Categorizes the NPC's role (for prompt profile resolution)
+- `dialogueContextKey: string` - Deterministically derived from `npcType` via `npc_${npcType.toLowerCase()}`
 
 ### Guard
 Extends `Interactable`:
@@ -69,6 +70,41 @@ Stores conversation history by actor id. The current conversational actors are g
 - `actorConversationHistoryByActorId: ActorConversationHistoryByActorId`
 - `levelOutcome: 'win' | 'lose' | null`
 
+## NPC Prompt Context Types
+
+Defined in `src/interaction/npcPromptContext.ts`.
+
+### NpcPromptProfile
+- `personaContract: string`
+- `knowledgePolicy?: string`
+- `responseStyleConstraints?: string`
+
+### ResolvedNpcPromptProfile
+Extends `NpcPromptProfile` with:
+- `profileKey: string` - Registry key used; `default` when fallback is applied
+- `requestedNpcType: string` - Normalized incoming type (`trim().toLowerCase()`, or `default` for missing/empty)
+
+### NPC_PROMPT_PROFILE_REGISTRY
+`Record<string, NpcPromptProfile>` keyed by normalized `npcType` values.
+
+Current built-in keys:
+- `archive_keeper`
+- `engineer`
+- `scholar`
+
+### DEFAULT_NPC_PROMPT_PROFILE
+Deterministic fallback profile used when a normalized `npcType` has no registry match.
+
+## Prompt Context Shape
+
+`buildNpcPromptContext(npc, player)` returns a serialized JSON object with:
+- `actor: { id, npcType }`
+- `npcProfile: ResolvedNpcPromptProfile`
+- `npcInstance: { displayName, position: { x, y }, dialogueContextKey }`
+- `player: { id, displayName }`
+
+This separates shared type-level prompt policy (`npcProfile`) from per-instance world facts (`npcInstance`).
+
 ## Level File Shape
 
 ### LevelData
@@ -84,7 +120,7 @@ Required fields:
 - `doors: Array<{ id, displayName, x, y, doorState, outcome }>`
 
 Optional fields:
-- `npcs: Array<{ id, displayName, x, y, npcType }>` — Level-defined NPCs. Each NPC has a `npcType` that categorizes its role (e.g., `'archive_keeper'`). During deserialization, `dialogueContextKey` is automatically derived as `npc_${npcType.toLowerCase()}`.
+- `npcs: Array<{ id, displayName, x, y, npcType }>`
 - `interactiveObjects: Array<...>` with the same object fields as `InteractiveObject`, but `x/y` instead of `position`
 
 Example NPC entry:

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -4,6 +4,7 @@ import { createNpcInteractionService } from './npcInteraction';
 import { renderActorConversationThread } from './actorConversationThread';
 import { createInitialWorldState } from '../world/state';
 import { GUARD_PERSONA_CONTRACT } from './guardPromptContext';
+import { resolveNpcPromptProfile } from './npcPromptContext';
 import type { ConversationMessage } from '../world/types';
 
 describe('createNpcInteractionService', () => {
@@ -36,6 +37,23 @@ describe('createNpcInteractionService', () => {
       throw new Error('Expected NPC LLM prompt to be provided.');
     }
     expect(calledPrompt.context).not.toContain(GUARD_PERSONA_CONTRACT);
+    const parsedContext = JSON.parse(calledPrompt.context) as {
+      actor: { id: string; npcType: string };
+      npcProfile: { profileKey: string; personaContract: string };
+      npcInstance: { displayName: string; dialogueContextKey: string };
+      player: { id: string; displayName: string };
+    };
+    expect(parsedContext.actor).toEqual({ id: npc.id, npcType: npc.npcType });
+    expect(parsedContext.npcProfile).toEqual(resolveNpcPromptProfile(npc.npcType));
+    expect(parsedContext.npcInstance).toEqual({
+      displayName: npc.displayName,
+      position: npc.position,
+      dialogueContextKey: npc.dialogueContextKey,
+    });
+    expect(parsedContext.player).toEqual({
+      id: worldState.player.id,
+      displayName: worldState.player.displayName,
+    });
     expect(result.responseText).toBe('Archivist: The archives are west of here.');
     expect(result.updatedWorldState.actorConversationHistoryByActorId[npc.id]).toEqual([
       { role: 'player', text: 'Where are the archives?' },

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -1,5 +1,6 @@
 import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
 import type { ConversationMessage, Npc, Player, WorldState } from '../world/types';
+import { buildNpcPromptContext } from './npcPromptContext';
 
 export interface NpcInteractionRequest {
   npc: Npc;
@@ -18,15 +19,6 @@ export interface NpcInteractionService {
   handleNpcInteraction(request: NpcInteractionRequest): Promise<NpcInteractionResult>;
 }
 
-const buildPromptContext = (request: NpcInteractionRequest): string => {
-  return [
-    `npc:${request.npc.id}`,
-    `npcName:${request.npc.displayName}`,
-    `dialogueContext:${request.npc.dialogueContextKey}`,
-    `player:${request.player.displayName}`,
-  ].join('|');
-};
-
 export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractionService => ({
   handleNpcInteraction: async (request: NpcInteractionRequest): Promise<NpcInteractionResult> => {
     const previousHistory =
@@ -40,7 +32,7 @@ export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractio
     const assistantText = await llmClient
       .complete({
         actorId: request.npc.id,
-        context: buildPromptContext(request),
+        context: buildNpcPromptContext(request.npc, request.player),
         playerMessage: request.playerMessage,
         conversationHistory: historyWithPlayerMessage,
       })

--- a/src/interaction/npcPromptContext.test.ts
+++ b/src/interaction/npcPromptContext.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { createInitialWorldState } from '../world/state';
+import {
+  buildNpcPromptContext,
+  DEFAULT_NPC_PROMPT_PROFILE,
+  resolveNpcPromptProfile,
+} from './npcPromptContext';
+
+describe('resolveNpcPromptProfile', () => {
+  it('returns the same profile contract for different NPCs with the same npcType', () => {
+    const firstProfile = resolveNpcPromptProfile('archive_keeper');
+    const secondProfile = resolveNpcPromptProfile('archive_keeper');
+
+    expect(firstProfile).toEqual(secondProfile);
+    expect(firstProfile.profileKey).toBe('archive_keeper');
+  });
+
+  it('resolves different npcTypes to different prompt profiles', () => {
+    const archiveKeeperProfile = resolveNpcPromptProfile('archive_keeper');
+    const engineerProfile = resolveNpcPromptProfile('engineer');
+
+    expect(archiveKeeperProfile.profileKey).toBe('archive_keeper');
+    expect(engineerProfile.profileKey).toBe('engineer');
+    expect(archiveKeeperProfile.personaContract).not.toBe(engineerProfile.personaContract);
+  });
+
+  it('falls back to a deterministic default profile for unknown or missing npcType', () => {
+    expect(resolveNpcPromptProfile('unknown_type')).toEqual({
+      profileKey: 'default',
+      requestedNpcType: 'unknown_type',
+      personaContract: DEFAULT_NPC_PROMPT_PROFILE.personaContract,
+      knowledgePolicy: DEFAULT_NPC_PROMPT_PROFILE.knowledgePolicy,
+      responseStyleConstraints: DEFAULT_NPC_PROMPT_PROFILE.responseStyleConstraints,
+    });
+
+    expect(resolveNpcPromptProfile(undefined)).toEqual({
+      profileKey: 'default',
+      requestedNpcType: 'default',
+      personaContract: DEFAULT_NPC_PROMPT_PROFILE.personaContract,
+      knowledgePolicy: DEFAULT_NPC_PROMPT_PROFILE.knowledgePolicy,
+      responseStyleConstraints: DEFAULT_NPC_PROMPT_PROFILE.responseStyleConstraints,
+    });
+  });
+});
+
+describe('buildNpcPromptContext', () => {
+  it('keeps shared profile data separate from per-instance fields', () => {
+    const worldState = createInitialWorldState();
+    const firstNpc = worldState.npcs[0];
+    const secondNpc = {
+      ...firstNpc,
+      id: 'npc-2',
+      displayName: 'Senior Archivist',
+      position: { x: 10, y: 4 },
+    };
+
+    const firstContext = JSON.parse(buildNpcPromptContext(firstNpc, worldState.player)) as {
+      npcProfile: { profileKey: string; personaContract: string };
+      npcInstance: { displayName: string; position: { x: number; y: number } };
+    };
+    const secondContext = JSON.parse(buildNpcPromptContext(secondNpc, worldState.player)) as typeof firstContext;
+
+    expect(firstContext.npcProfile).toEqual(secondContext.npcProfile);
+    expect(firstContext.npcInstance).not.toEqual(secondContext.npcInstance);
+    expect(firstContext.npcInstance.displayName).toBe('Archivist');
+    expect(secondContext.npcInstance.displayName).toBe('Senior Archivist');
+  });
+
+  it('produces deterministic serialized output for the same NPC snapshot', () => {
+    const worldState = createInitialWorldState();
+    const first = buildNpcPromptContext(worldState.npcs[0], worldState.player);
+    const second = buildNpcPromptContext(worldState.npcs[0], worldState.player);
+    const roundTrippedNpc = JSON.parse(JSON.stringify(worldState.npcs[0])) as (typeof worldState.npcs)[number];
+    const roundTrippedPlayer = JSON.parse(JSON.stringify(worldState.player)) as typeof worldState.player;
+    const third = buildNpcPromptContext(roundTrippedNpc, roundTrippedPlayer);
+
+    expect(first).toBe(second);
+    expect(first).toBe(third);
+  });
+});

--- a/src/interaction/npcPromptContext.ts
+++ b/src/interaction/npcPromptContext.ts
@@ -1,0 +1,92 @@
+import type { Npc, Player } from '../world/types';
+
+export interface NpcPromptProfile {
+  personaContract: string;
+  knowledgePolicy?: string;
+  responseStyleConstraints?: string;
+}
+
+export interface ResolvedNpcPromptProfile extends NpcPromptProfile {
+  profileKey: string;
+  requestedNpcType: string;
+}
+
+export const DEFAULT_NPC_PROMPT_PROFILE: NpcPromptProfile = {
+  personaContract:
+    'You are a grounded world character. Answer using only the provided context and do not invent facts, locations, or events.',
+  knowledgePolicy: 'Only speak about details supported by your local context and the current conversation history.',
+  responseStyleConstraints: 'Keep responses concise, clear, and in character.',
+};
+
+export const NPC_PROMPT_PROFILE_REGISTRY: Record<string, NpcPromptProfile> = {
+  archive_keeper: {
+    personaContract:
+      'You are an archive keeper who protects records, values accuracy, and treats preserved knowledge as important civic duty.',
+    knowledgePolicy:
+      'You may discuss archives, records, cataloguing, and nearby civic spaces when supported by the provided context.',
+    responseStyleConstraints: 'Respond precisely and with a measured, scholarly tone.',
+  },
+  engineer: {
+    personaContract:
+      'You are a practical engineer focused on mechanisms, access routes, and keeping infrastructure operational.',
+    knowledgePolicy:
+      'You may discuss machinery, access points, repairs, and route constraints when supported by the provided context.',
+    responseStyleConstraints: 'Respond directly with a pragmatic, technical tone.',
+  },
+  scholar: {
+    personaContract:
+      'You are a scholar who values interpretation, patterns, and careful explanation over speculation.',
+    knowledgePolicy:
+      'You may discuss research topics and observed patterns when they are supported by the provided context.',
+    responseStyleConstraints: 'Respond thoughtfully and avoid overstating certainty.',
+  },
+};
+
+const DEFAULT_PROFILE_KEY = 'default';
+
+const normalizeNpcType = (npcType: string | null | undefined): string => {
+  if (typeof npcType !== 'string') {
+    return DEFAULT_PROFILE_KEY;
+  }
+
+  const normalizedType = npcType.trim().toLowerCase();
+  return normalizedType === '' ? DEFAULT_PROFILE_KEY : normalizedType;
+};
+
+export const resolveNpcPromptProfile = (npcType: string | null | undefined): ResolvedNpcPromptProfile => {
+  const normalizedType = normalizeNpcType(npcType);
+  const profile = NPC_PROMPT_PROFILE_REGISTRY[normalizedType] ?? DEFAULT_NPC_PROMPT_PROFILE;
+  const profileKey = NPC_PROMPT_PROFILE_REGISTRY[normalizedType] ? normalizedType : DEFAULT_PROFILE_KEY;
+
+  return {
+    profileKey,
+    requestedNpcType: normalizedType,
+    personaContract: profile.personaContract,
+    knowledgePolicy: profile.knowledgePolicy,
+    responseStyleConstraints: profile.responseStyleConstraints,
+  };
+};
+
+export const buildNpcPromptContext = (npc: Npc, player: Player): string => {
+  const resolvedProfile = resolveNpcPromptProfile(npc.npcType);
+
+  return JSON.stringify({
+    actor: {
+      id: npc.id,
+      npcType: npc.npcType,
+    },
+    npcProfile: resolvedProfile,
+    npcInstance: {
+      displayName: npc.displayName,
+      position: {
+        x: npc.position.x,
+        y: npc.position.y,
+      },
+      dialogueContextKey: npc.dialogueContextKey,
+    },
+    player: {
+      id: player.id,
+      displayName: player.displayName,
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add a static NPC prompt profile registry keyed by npcType with a deterministic default profile
- build NPC prompt context from resolved shared type profiles while keeping per-instance fields separate
- add tests for shared-type reuse, different-type resolution, fallback handling, and deterministic prompt serialization

## Validation
- npm test
- npm run build

## Closes #74