### PR TITLE
#83 pause world simulation during conversations

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,12 +6,13 @@ Guard Game enforces strict layer separation to support deterministic world updat
 
 ```
 /src
-  /world          - Deterministic world model (state, command application, ticks)
-  /render         - PixiJS rendering port (grid, sprites, camera, viewport)
-  /interaction    - Interaction dispatch + result routing across target kinds
-  /input          - Input command buffering and keyboard mapping
-  /llm            - LLM client boundary and context generation stubs
-  main.ts         - Runtime bootstrap and frame/tick loop
+  /world               - Deterministic world model (state, command application, ticks)
+  /render              - PixiJS rendering port (grid, sprites, camera, viewport)
+  /interaction         - Interaction dispatch + result routing across target kinds
+  /input               - Input command buffering and keyboard mapping
+  /llm                 - LLM client boundary and context generation stubs
+  runtimeController.ts - Runtime orchestration: simulation pause/resume and conversation gating
+  main.ts              - Runtime bootstrap and frame/tick loop
 ```
 
 ## Design Principles
@@ -47,8 +48,8 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 
 ### Frame Loop
 1. **Input Phase:** Keyboard input is captured and mapped to `WorldCommand` values, enqueued into `CommandBuffer`.
-2. **Tick Phase** (fixed 100ms): Buffered commands are drained and applied to world state via `world.applyCommands(commands)`.
-3. **Interaction Dispatch:** If an `interact` command was issued, `runInteractionIfRequested()` resolves one adjacent target and calls `interactionDispatcher.dispatch(...)`.
+2. **Tick Phase** (fixed 100ms): `runtimeController.stepSimulation()` is called. It drains the command buffer, gates commands based on current pause state and level outcome, then applies the resolved command set to world state via `world.applyCommands(commands)`. If the runtime is paused (a guard or NPC conversation is open), buffered commands are discarded and no world update or interaction dispatch occurs for that tick.
+3. **Interaction Dispatch:** If an `interact` command was issued and the runtime is not paused, `runInteractionIfRequested()` resolves one adjacent target and calls `interactionDispatcher.dispatch(...)`.
 4. **Result Routing:** Returned `InteractionHandlerResult` (sync or async) is routed through `resultDispatcher.dispatch(...)` into main-loop side effects.
 5. **Render Phase:** Every animation frame renders the latest world state through the PixiJS render port.
 6. **Debug Phase:** Current JSON world state is serialized and printed to the debug panel.
@@ -57,6 +58,8 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 [Keyboard Input]
        |
 [Command Buffer]
+       |
+[RuntimeController.stepSimulation()] <- gates on pause state & level outcome
        |
 [World.applyCommands()] <- deterministic state update
        |
@@ -68,6 +71,8 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
        |
 [Debug Panel] <- serializes and displays JSON state
 ```
+
+> **Pause state is external to `WorldState`.** `RuntimeController` owns the pause flag and the active `RuntimeConversationSession`. This state is transient, non-serializable, and intentionally excluded from LLM context and replay.
 
 ## Layer Contracts
 

--- a/docs/INPUT_LAYER.md
+++ b/docs/INPUT_LAYER.md
@@ -12,7 +12,10 @@ The input layer captures keyboard input and translates it into `WorldCommand` va
 ## Core Concepts
 
 ### CommandBuffer
-A queue of `WorldCommand` values waiting to be applied to the world. Drained once per tick.
+A queue of `WorldCommand` values waiting to be applied to the world. Three operations:
+- `enqueue(command)` — adds a command to the buffer (called by the keyboard handler).
+- `drain()` — atomically returns and clears all pending commands; called once per tick by `RuntimeController.stepSimulation()`.
+- `clear()` — discards all pending commands without returning them; called by `RuntimeController` on conversation pause entry and exit to prevent buffered inputs from leaking into resumed ticks.
 
 ### WorldCommand
 Represents a player action. Examples: `MoveForward`, `MoveBackward`, `TurnLeft`, `TurnRight`, `Interact`.

--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -62,6 +62,24 @@ This removes target-kind branching from `main.ts` and preserves behavior parity 
 
 The runtime bridge and tests use the shared actor-neutral helper in `src/interaction/actorConversationThread.ts` to read and render conversation history.
 
+## Conversation Pause Lifecycle
+
+When the result dispatcher opens a guard or NPC conversation (`onConversationStarted`), it calls `runtimeController.openConversation(actorId)`, which:
+1. Sets the runtime to paused state.
+2. Records the target actor id as the active `RuntimeConversationSession`.
+3. Clears any buffered commands so pre-conversation inputs do not bleed into the first resumed tick.
+
+While paused, `runtimeController.stepSimulation()` drains and discards buffered commands each tick without updating world state or dispatching interactions.
+
+When the chat modal closes (`onClose`), it calls `runtimeController.closeConversation()`, which:
+1. Clears the active conversation session.
+2. Clears buffered commands accumulated during the conversation.
+3. Resumes normal simulation on the next tick.
+
+Door and interactive object results never trigger `onConversationStarted`, so they never cause a pause. This is enforced by the result dispatcher and verified in `src/interaction/interactionDispatcher.test.ts` under the `result dispatcher timing parity` suite.
+
+Pause state is kept outside `WorldState`. It is transient runtime orchestration state managed by `RuntimeController` and must not be serialized or included in LLM context.
+
 ## NPC Prompt Profile Context
 
 NPC conversational turns call `buildNpcPromptContext()` from `src/interaction/npcPromptContext.ts`.
@@ -108,7 +126,8 @@ See `src/interaction/guardInteraction.ts`, `src/interaction/npcInteraction.ts`, 
 
 ## Tests
 
-- `src/interaction/interactionDispatcher.test.ts`: dispatch routing by kind, sync/async behavior parity, result dispatcher timing parity
+- `src/interaction/interactionDispatcher.test.ts`: dispatch routing by kind, sync/async behavior parity, result dispatcher timing parity, door/object non-pause guarantee
+- `src/runtimeController.test.ts`: pause entry/exit lifecycle, command gating while paused, resume without command leak, level-outcome gating independent of pause state
 - `src/interaction/npcPromptContext.test.ts`: profile registry resolution, deterministic fallback, context shape determinism
 - `src/interaction/objectInteraction.test.ts`: object-type dispatcher behavior, first-use outcomes, repeat interactions
 - `src/integration/starterLevel.test.ts`: end-to-end adjacent object resolution and state updates

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -7,6 +7,7 @@ Source of truth:
 - `src/interaction/npcPromptContext.ts`
 - `src/interaction/objectInteraction.ts`
 - `src/interaction/adjacencyResolver.ts`
+- `src/runtimeController.ts`
 
 ## World Types
 
@@ -191,3 +192,28 @@ Defined in `src/interaction/objectInteraction.ts`:
 Defined in `src/world/types.ts`:
 - `{ type: 'move'; dx: number; dy: number }`
 - `{ type: 'interact' }`
+
+### CommandBuffer
+Defined in `src/input/commands.ts`:
+- `enqueue(command: WorldCommand): void` — adds a command (called by the keyboard handler)
+- `drain(): WorldCommand[]` — atomically returns and empties the buffer; called once per tick
+- `clear(): void` — discards all pending commands without returning them; called by `RuntimeController` on pause entry and exit
+
+## Runtime Controller Types
+
+Defined in `src/runtimeController.ts`. These types are **not** part of `WorldState`; pause state is transient runtime orchestration and must not be serialized or included in LLM context.
+
+### RuntimeConversationSession
+- `actorId: string` — id of the currently active conversational actor (guard or NPC)
+
+### RuntimeControllerDependencies
+- `world: Pick<World, 'getState' | 'applyCommands'>`
+- `commandBuffer: Pick<CommandBuffer, 'drain' | 'clear'>`
+- `runInteractions: (worldState: WorldState, commands: WorldCommand[]) => void`
+
+### RuntimeController
+- `stepSimulation(): void` — advances one fixed tick; if paused, drains and discards the buffer without updating world state
+- `openConversation(actorId: string): void` — pauses simulation, records active actor, and clears the command buffer
+- `closeConversation(): void` — resumes simulation, clears the active session, and clears the command buffer
+- `isPaused(): boolean` — returns current pause state
+- `getCurrentInteraction(): RuntimeConversationSession | null` — returns the active session or `null`

--- a/src/input/commands.ts
+++ b/src/input/commands.ts
@@ -3,6 +3,7 @@ import type { WorldCommand } from '../world/types';
 export interface CommandBuffer {
   enqueue(command: WorldCommand): void;
   drain(): WorldCommand[];
+  clear(): void;
 }
 
 export const createCommandBuffer = (): CommandBuffer => {
@@ -16,6 +17,9 @@ export const createCommandBuffer = (): CommandBuffer => {
       const snapshot = [...pendingCommands];
       pendingCommands.length = 0;
       return snapshot;
+    },
+    clear: () => {
+      pendingCommands.length = 0;
     },
   };
 };

--- a/src/interaction/interactionDispatcher.test.ts
+++ b/src/interaction/interactionDispatcher.test.ts
@@ -408,6 +408,31 @@ describe('InteractionDispatcher', () => {
   });
 
   describe('result dispatcher timing parity', () => {
+    it('door and interactive object results never trigger conversation start callbacks', () => {
+      const onConversationStarted = vi.fn();
+      const dispatcher = createResultDispatcher({
+        onConversationStarted,
+        onLevelOutcomeChanged: vi.fn(),
+        onWorldStateUpdated: vi.fn(),
+        getCurrentWorldState: () => createTestWorldState(),
+        getConversationHistory: () => [],
+      });
+
+      dispatcher.dispatch({
+        kind: 'door',
+        targetId: 'door-1',
+        isConversational: false,
+        levelOutcome: null,
+      });
+      dispatcher.dispatch({
+        kind: 'interactiveObject',
+        targetId: 'object-1',
+        isConversational: false,
+      });
+
+      expect(onConversationStarted).not.toHaveBeenCalled();
+    });
+
     it('applies door level outcome callback synchronously', () => {
       const callbackOrder: string[] = [];
       const dispatcher = createResultDispatcher({

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { createLevelUi } from './render/levelUi';
 import { createChatModal } from './render/chatModal';
 import { createOutcomeOverlay } from './render/outcomeOverlay';
 import { getRuntimeLayoutMarkup } from './render/runtimeLayout';
+import { createRuntimeController } from './runtimeController';
 import type { WorldCommand, WorldState, ConversationMessage } from './world/types';
 import { createWorld } from './world/world';
 import { fetchAndLoadLevel, fetchLevelManifest } from './world/levelLoader';
@@ -42,18 +43,12 @@ const llmClient = createGeminiLlmClient();
 const interactionDispatcher = createInteractionDispatcher({ llmClient });
 const outcomeOverlay = createOutcomeOverlay(outcomeOverlayHostElement);
 
-/** Tracks the current interaction in progress (for chat modal message handling). */
-interface CurrentInteraction {
-  actorId: string;
-}
-
-let currentInteraction: CurrentInteraction | null = null;
-
 /**
  * Chat modal instance with callbacks wired to game logic.
  */
 const chatModal = createChatModal(chatModalHostElement, {
   onSend(playerMessage: string): void {
+    const currentInteraction = runtimeController.getCurrentInteraction();
     if (!currentInteraction) {
       return; // Safety check.
     }
@@ -95,7 +90,7 @@ const chatModal = createChatModal(chatModalHostElement, {
   },
 
   onClose(): void {
-    currentInteraction = null;
+    runtimeController.closeConversation();
   },
 });
 
@@ -110,9 +105,7 @@ const resultDispatcher = createResultDispatcher({
     displayName: string,
     conversationHistory: ConversationMessage[],
   ) => {
-    currentInteraction = {
-      actorId: targetId,
-    };
+    runtimeController.openConversation(targetId);
     chatModal.open(targetId, displayName, conversationHistory);
   },
   onLevelOutcomeChanged: (levelOutcome: 'win' | 'lose') => {
@@ -165,6 +158,12 @@ const runInteractionIfRequested = (
 
   resultDispatcher.dispatch(dispatchResult);
 };
+
+const runtimeController = createRuntimeController({
+  world,
+  commandBuffer,
+  runInteractions: runInteractionIfRequested,
+});
 
 const fixedTickDurationMs = 100;
 let previousFrameTime = performance.now();
@@ -229,17 +228,7 @@ const startRuntime = async (): Promise<void> => {
     previousFrameTime = currentTime;
 
     while (accumulatedTime >= fixedTickDurationMs) {
-      const worldStateBeforeCommands = world.getState();
-      let commandsToApply = commandBuffer.drain();
-
-      // Block all commands if level outcome is already set
-      if (worldStateBeforeCommands.levelOutcome) {
-        commandsToApply = [];
-      }
-
-      world.applyCommands(commandsToApply);
-      const worldState = world.getState();
-      runInteractionIfRequested(worldState, commandsToApply);
+      runtimeController.stepSimulation();
       accumulatedTime -= fixedTickDurationMs;
     }
 

--- a/src/runtimeController.test.ts
+++ b/src/runtimeController.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCommandBuffer } from './input/commands';
+import { createRuntimeController } from './runtimeController';
+import type { World, WorldCommand, WorldState } from './world/types';
+
+const createTestWorldState = (overrides?: Partial<WorldState>): WorldState => ({
+  tick: 0,
+  grid: { width: 10, height: 10, tileSize: 32 },
+  player: {
+    id: 'player',
+    displayName: 'Player',
+    position: { x: 1, y: 1 },
+  },
+  guards: [],
+  doors: [],
+  npcs: [],
+  interactiveObjects: [],
+  actorConversationHistoryByActorId: {},
+  levelOutcome: null,
+  ...overrides,
+});
+
+const createTestWorld = (
+  initialState: WorldState = createTestWorldState(),
+): {
+  world: Pick<World, 'getState' | 'applyCommands'>;
+  applyCommandsSpy: ReturnType<typeof vi.fn<(commands: WorldCommand[]) => void>>;
+} => {
+  let worldState = initialState;
+  const applyCommandsSpy = vi.fn<(commands: WorldCommand[]) => void>((commands) => {
+    const moveCommand = commands.find((command) => command.type === 'move');
+    const nextPosition = moveCommand && moveCommand.type === 'move'
+      ? {
+          x: worldState.player.position.x + moveCommand.dx,
+          y: worldState.player.position.y + moveCommand.dy,
+        }
+      : worldState.player.position;
+
+    worldState = {
+      ...worldState,
+      tick: worldState.tick + 1,
+      player: {
+        ...worldState.player,
+        position: nextPosition,
+      },
+    };
+  });
+
+  return {
+    world: {
+      getState: () => worldState,
+      applyCommands: applyCommandsSpy,
+    },
+    applyCommandsSpy,
+  };
+};
+
+describe('createRuntimeController', () => {
+  it('enters paused conversation state and clears buffered commands on conversation start', () => {
+    const commandBuffer = createCommandBuffer();
+    commandBuffer.enqueue({ type: 'move', dx: 1, dy: 0 });
+    const { world } = createTestWorld();
+    const runInteractions = vi.fn();
+    const controller = createRuntimeController({ world, commandBuffer, runInteractions });
+
+    controller.openConversation('guard-1');
+
+    expect(controller.isPaused()).toBe(true);
+    expect(controller.getCurrentInteraction()).toEqual({ actorId: 'guard-1' });
+    expect(commandBuffer.drain()).toEqual([]);
+  });
+
+  it('drops gameplay commands and skips world updates while paused', () => {
+    const commandBuffer = createCommandBuffer();
+    const { world, applyCommandsSpy } = createTestWorld();
+    const runInteractions = vi.fn();
+    const controller = createRuntimeController({ world, commandBuffer, runInteractions });
+
+    controller.openConversation('npc-1');
+    commandBuffer.enqueue({ type: 'move', dx: 1, dy: 0 });
+    commandBuffer.enqueue({ type: 'interact' });
+
+    controller.stepSimulation();
+
+    expect(applyCommandsSpy).not.toHaveBeenCalled();
+    expect(runInteractions).not.toHaveBeenCalled();
+    expect(commandBuffer.drain()).toEqual([]);
+  });
+
+  it('resumes simulation after conversation close without leaking paused commands into the first resumed tick', () => {
+    const commandBuffer = createCommandBuffer();
+    const { world, applyCommandsSpy } = createTestWorld();
+    const runInteractions = vi.fn();
+    const controller = createRuntimeController({ world, commandBuffer, runInteractions });
+
+    controller.openConversation('guard-1');
+    commandBuffer.enqueue({ type: 'move', dx: 1, dy: 0 });
+    controller.stepSimulation();
+
+    controller.closeConversation();
+    controller.stepSimulation();
+
+    expect(controller.isPaused()).toBe(false);
+    expect(controller.getCurrentInteraction()).toBeNull();
+    expect(applyCommandsSpy).toHaveBeenCalledTimes(1);
+    expect(applyCommandsSpy).toHaveBeenNthCalledWith(1, []);
+    expect(runInteractions).toHaveBeenNthCalledWith(1, world.getState(), []);
+    expect(world.getState().player.position).toEqual({ x: 1, y: 1 });
+
+    commandBuffer.enqueue({ type: 'move', dx: 1, dy: 0 });
+    controller.stepSimulation();
+
+    expect(applyCommandsSpy).toHaveBeenNthCalledWith(2, [{ type: 'move', dx: 1, dy: 0 }]);
+    expect(world.getState().player.position).toEqual({ x: 2, y: 1 });
+  });
+
+  it('still blocks gameplay commands after level outcome without affecting pause state handling', () => {
+    const commandBuffer = createCommandBuffer();
+    commandBuffer.enqueue({ type: 'move', dx: 1, dy: 0 });
+    const { world, applyCommandsSpy } = createTestWorld(
+      createTestWorldState({ levelOutcome: 'win' }),
+    );
+    const runInteractions = vi.fn();
+    const controller = createRuntimeController({ world, commandBuffer, runInteractions });
+
+    controller.stepSimulation();
+
+    expect(applyCommandsSpy).toHaveBeenCalledWith([]);
+    expect(runInteractions).toHaveBeenCalledWith(world.getState(), []);
+  });
+});

--- a/src/runtimeController.ts
+++ b/src/runtimeController.ts
@@ -1,0 +1,67 @@
+import type { CommandBuffer } from './input/commands';
+import type { World, WorldCommand, WorldState } from './world/types';
+
+export interface RuntimeConversationSession {
+  actorId: string;
+}
+
+export interface RuntimeControllerDependencies {
+  world: Pick<World, 'getState' | 'applyCommands'>;
+  commandBuffer: Pick<CommandBuffer, 'drain' | 'clear'>;
+  runInteractions: (worldState: WorldState, commands: WorldCommand[]) => void;
+}
+
+export interface RuntimeController {
+  stepSimulation(): void;
+  openConversation(actorId: string): void;
+  closeConversation(): void;
+  isPaused(): boolean;
+  getCurrentInteraction(): RuntimeConversationSession | null;
+}
+
+export const createRuntimeController = (
+  dependencies: RuntimeControllerDependencies,
+): RuntimeController => {
+  let paused = false;
+  let currentInteraction: RuntimeConversationSession | null = null;
+
+  return {
+    stepSimulation(): void {
+      if (paused) {
+        dependencies.commandBuffer.drain();
+        return;
+      }
+
+      const worldStateBeforeCommands = dependencies.world.getState();
+      let commandsToApply = dependencies.commandBuffer.drain();
+
+      if (worldStateBeforeCommands.levelOutcome) {
+        commandsToApply = [];
+      }
+
+      dependencies.world.applyCommands(commandsToApply);
+      const worldState = dependencies.world.getState();
+      dependencies.runInteractions(worldState, commandsToApply);
+    },
+
+    openConversation(actorId: string): void {
+      currentInteraction = { actorId };
+      paused = true;
+      dependencies.commandBuffer.clear();
+    },
+
+    closeConversation(): void {
+      currentInteraction = null;
+      paused = false;
+      dependencies.commandBuffer.clear();
+    },
+
+    isPaused(): boolean {
+      return paused;
+    },
+
+    getCurrentInteraction(): RuntimeConversationSession | null {
+      return currentInteraction;
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- add a runtime controller that owns conversation pause/resume state outside WorldState and level JSON
- stop applying gameplay commands, fixed-tick simulation, and runtime interaction resolution while a guard or NPC chat is open
- discard buffered commands on pause and resume, and add tests that cover pause entry, paused command gating, resume behavior, and non-pausing door/object interactions

## Validation
- npm test
- npm run build

## Closes #83