### PR TITLE
#86 add character sprite assets with deterministic fallback rendering

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,6 +33,7 @@ All world state must serialize to JSON. This enables LLM systems to reason about
 - Input layer maps keyboard to commands; it does not modify world state.
 - Interaction layer orchestrates dispatch and result handling; it does not directly call render code.
 - LLM layer provides client access and context only; it is invoked only through interaction handlers.
+- Character sprite fallback decisions belong to render code; world code only stores optional `spriteAssetPath` metadata.
 
 **Implication:** Any feature can be tested by manipulating world state; rendering changes never require testing game logic.
 
@@ -51,7 +52,7 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 2. **Tick Phase** (fixed 100ms): `runtimeController.stepSimulation()` is called. It drains the command buffer, gates commands based on current pause state and level outcome, then applies the resolved command set to world state via `world.applyCommands(commands)`. If the runtime is paused (a guard or NPC conversation is open), buffered commands are discarded and no world update or interaction dispatch occurs for that tick.
 3. **Interaction Dispatch:** If an `interact` command was issued and the runtime is not paused, `runInteractionIfRequested()` resolves one adjacent target and calls `interactionDispatcher.dispatch(...)`.
 4. **Result Routing:** Returned `InteractionHandlerResult` (sync or async) is routed through `resultDispatcher.dispatch(...)` into main-loop side effects. Conversational open results synchronously call `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`. Door and interactive-object results stay local to world-state reset and level-outcome callbacks.
-5. **Render Phase:** Every animation frame renders the latest world state through the PixiJS render port. Separate DOM render utilities manage the chat modal, paused-viewport overlay, and level-outcome overlay.
+5. **Render Phase:** Every animation frame renders the latest world state through the PixiJS render port. Character sprite assets are loaded and resolved to sprite/marker mode inside the render layer only. Separate DOM render utilities manage the chat modal, paused-viewport overlay, and level-outcome overlay.
 6. **Debug Phase:** Current JSON world state is serialized and printed to the debug panel.
 
 ```
@@ -86,7 +87,7 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 - **Responsibility:** Translate world state into visual representation.
 - **Input:** `WorldState` (read-only reference) plus runtime UI callbacks.
 - **Output:** PixiJS display objects, DOM overlay state, and viewport positioning.
-- **Guarantee:** No game logic; only read and draw.
+- **Guarantee:** No game logic; only read and draw. Sprite load status maps and Pixi sprite instances are transient render concerns and are never written into `WorldState`.
 
 ### Interaction Layer
 - **Responsibility:**

--- a/docs/EXTEND_STATE.md
+++ b/docs/EXTEND_STATE.md
@@ -64,6 +64,24 @@ Required follow-up updates:
 - deterministic use in `src/interaction/objectInteraction.ts`
 - fixture updates in tests such as `src/world/state.ts` and `src/world/world.test.ts`
 
+## Example: Character Sprite Metadata (Ticket #86)
+
+Added optional metadata fields:
+- `Player.spriteAssetPath?: string`
+- `Guard.spriteAssetPath?: string`
+- `Npc.spriteAssetPath?: string`
+- matching optional fields in `LevelData.player`, `LevelData.guards[*]`, and `LevelData.npcs[*]`
+
+Required follow-up updates:
+- type updates in `src/world/types.ts`
+- optional string validation in `validateLevelData()` for player/guard/NPC
+- passthrough mapping in `deserializeLevel()`
+- integration proof via `public/levels/starter.json` + `src/integration/starterLevel.test.ts`
+
+Boundary reminder:
+- world layer validates serializable shape only
+- sprite loading success/failure and fallback rendering remain render-layer responsibilities
+
 ## Checklist
 
 - [ ] Type changes are explicit and serializable
@@ -71,4 +89,4 @@ Required follow-up updates:
 - [ ] Deserializer maps all new fields
 - [ ] Deterministic logic updated immutably
 - [ ] Fixtures/tests updated across impacted layers
-- [ ] Relevant docs updated (`WORLD_LAYER.md`, `TYPES_REFERENCE.md`, and pattern docs)
+- [ ] Relevant docs updated (`WORLD_LAYER.md`, `RENDER_LAYER.md`, `TYPES_REFERENCE.md`, and pattern docs)

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,26 +3,26 @@
 This directory contains architecture guides, layer-specific documentation, and development patterns for Guard Game. New and existing developers should start here to understand system structure and find answers to common implementation questions.
 
 ## Fundamentals
-- [System Architecture](ARCHITECTURE.md) — Layered architecture overview, design principles, and data flow
-- [Type Reference](TYPES_REFERENCE.md) — Complete reference for key interfaces and data structures used throughout the codebase
+- [System Architecture](ARCHITECTURE.md) - Layered architecture overview, design principles, and data flow
+- [Type Reference](TYPES_REFERENCE.md) - Complete reference for key interfaces and data structures used throughout the codebase
 
 ## Layer Guides
 Deep dives into each architectural layer and its responsibilities:
-- [World Layer](WORLD_LAYER.md) — Deterministic world model, commands, state updates, level schema, and serialization boundaries
-- [Render Layer](RENDER_LAYER.md) — PixiJS rendering, viewport management, entity markers, and asset metadata usage
-- [Interaction Layer](INTERACTION_LAYER.md) — Deterministic target resolution, routing, object interactions, and LLM chat boundary
-- [Input Layer](INPUT_LAYER.md) — Command buffering, keyboard input mapping, and command creation
-- [LLM Layer](LLM_LAYER.md) — LLM client boundary, API stubs, and context serialization
+- [World Layer](WORLD_LAYER.md) - Deterministic world model, commands, state updates, level schema, serialization boundaries, and starter-level sprite metadata flow
+- [Render Layer](RENDER_LAYER.md) - PixiJS rendering, viewport management, character sprite fallback behavior, and asset metadata usage
+- [Interaction Layer](INTERACTION_LAYER.md) - Deterministic target resolution, routing, object interactions, and LLM chat boundary
+- [Input Layer](INPUT_LAYER.md) - Command buffering, keyboard input mapping, and command creation
+- [LLM Layer](LLM_LAYER.md) - LLM client boundary, API stubs, and context serialization
 
 ## Development Patterns
 Recipes and walkthroughs for common extension tasks:
-- [Add a Command](ADD_COMMAND.md) — How to add a new player action
-- [Add an NPC](ADD_NPC.md) — How to introduce a new NPC with behavior
-- [Add an Interaction](ADD_INTERACTION.md) — How to add conversational and deterministic object interaction flows
-- [Extend World State](EXTEND_STATE.md) — How to expand world state while preserving JSON serializability
+- [Add a Command](ADD_COMMAND.md) - How to add a new player action
+- [Add an NPC](ADD_NPC.md) - How to introduce a new NPC with behavior
+- [Add an Interaction](ADD_INTERACTION.md) - How to add conversational and deterministic object interaction flows
+- [Extend World State](EXTEND_STATE.md) - How to expand world state while preserving JSON serializability
 
 ## Testing & Debugging
-- [Testing Patterns](TESTING_PATTERNS.md) — Test architecture, layer testing strategies, determinism verification, and debug tools
+- [Testing Patterns](TESTING_PATTERNS.md) - Test architecture, layer testing strategies, determinism verification, and debug tools
 
 ## Quick Navigation
 

--- a/docs/RENDER_LAYER.md
+++ b/docs/RENDER_LAYER.md
@@ -4,9 +4,9 @@ The render layer translates `WorldState` into visual state and DOM-only runtime 
 
 ## Responsibilities
 - Initialize and own PixiJS app/container setup
-- Render grid, boundary band, entity markers, and player marker
+- Render grid, boundary band, character sprites (when available), and marker fallbacks
 - Keep viewport/camera centered around player with clamped world bounds
-- Map world entities to deterministic marker visuals by type
+- Map world entities to deterministic visuals by type and optional asset metadata
 - Manage DOM-only render utilities for runtime layout, chat UI, viewport pause presentation, and level-outcome presentation
 
 Implementation entry points:
@@ -25,9 +25,10 @@ Implementation entry points:
 Per render pass:
 1. Ensure canvas size from tile-grid viewport config.
 2. Update camera offset from player center and world bounds.
-3. Draw boundary band and grid.
-4. Build and draw entity circles for NPCs, guards, doors, and interactive objects.
-5. Draw player marker.
+3. Request sprite loads for player, guards, and NPCs with configured `spriteAssetPath`.
+4. Draw boundary band and grid.
+5. Draw character sprites that have loaded successfully.
+6. Draw marker circles for doors, interactive objects, and any character still in fallback mode.
 
 ### DOM Render Utilities
 
@@ -73,13 +74,20 @@ Current behavior:
 
 ## Asset Metadata and Usage
 
-Interactive objects can carry `spriteAssetPath` metadata in world state (for example, `/assets/medieval_supply_crate_inspect.svg`).
+Character and object entities can carry `spriteAssetPath` metadata in world state (for example, `/assets/medieval_player_town_guard.svg` or `/assets/medieval_supply_crate_inspect.svg`).
+
+Current character contract:
+- `player.spriteAssetPath?: string`
+- `guard.spriteAssetPath?: string`
+- `npc.spriteAssetPath?: string`
 
 Current renderer behavior:
-- Uses marker circles only.
-- Does not yet load or draw `spriteAssetPath`.
+- Attempts to load configured character sprite assets via Pixi asset loading.
+- Renders characters as sprites only when the asset has loaded.
+- Falls back to deterministic marker circles when path metadata is missing, loading is in progress, or loading failed.
+- Keeps door and interactive-object rendering marker-based.
 
-This is intentional for now and keeps rendering decoupled from interaction logic while preserving forward-compatible asset metadata in level files.
+This preserves render-only ownership of visual decisions while keeping gameplay logic and world determinism unchanged.
 
 ## Tests
 

--- a/docs/RENDER_LAYER.md
+++ b/docs/RENDER_LAYER.md
@@ -23,12 +23,14 @@ Implementation entry points:
 `createPixiRenderPort()` returns a render port with `render(worldState)`.
 
 Per render pass:
-1. Ensure canvas size from tile-grid viewport config.
-2. Update camera offset from player center and world bounds.
-3. Request sprite loads for player, guards, and NPCs with configured `spriteAssetPath`.
+1. Request sprite loads for player, guards, and NPCs with configured `spriteAssetPath`.
+2. Resolve character render mode (`sprite` or `marker`) from sprite load status.
+3. Ensure canvas size from tile-grid viewport config.
 4. Draw boundary band and grid.
 5. Draw character sprites that have loaded successfully.
 6. Draw marker circles for doors, interactive objects, and any character still in fallback mode.
+7. Draw player marker only when the player is in fallback mode.
+8. Update camera offset from player center and world bounds.
 
 ### DOM Render Utilities
 
@@ -87,7 +89,23 @@ Current renderer behavior:
 - Falls back to deterministic marker circles when path metadata is missing, loading is in progress, or loading failed.
 - Keeps door and interactive-object rendering marker-based.
 
+Render-layer boundary:
+- Sprite load status (`loading` | `loaded` | `failed`) and Pixi `Sprite` instances are transient render state only.
+- No sprite loading status is written back into `WorldState`.
+
 This preserves render-only ownership of visual decisions while keeping gameplay logic and world determinism unchanged.
+
+## Shipped Starter Level Demonstration
+
+The shipped starter level now demonstrates configured character sprite paths for all character kinds:
+- Player: `/assets/medieval_player_town_guard.svg`
+- Guards: `/assets/medieval_guard_spear.svg`
+- NPC: `/assets/medieval_npc_villager.svg`
+
+Source and verification:
+- Level data: [public/levels/starter.json](../public/levels/starter.json)
+- Integration assertions: [src/integration/starterLevel.test.ts](../src/integration/starterLevel.test.ts)
+- Render mode/fallback assertions: [src/render/scene.test.ts](../src/render/scene.test.ts)
 
 ## Tests
 

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -19,6 +19,7 @@ Source of truth:
 - `id: string`
 - `displayName: string`
 - `position: GridPosition`
+- `spriteAssetPath?: string`
 
 ### Npc
 - `id: string`
@@ -26,11 +27,13 @@ Source of truth:
 - `position: GridPosition`
 - `npcType: string` - Categorizes the NPC's role (for prompt profile resolution)
 - `dialogueContextKey: string` - Deterministically derived from `npcType` via `npc_${npcType.toLowerCase()}`
+- `spriteAssetPath?: string`
 
 ### Guard
 Extends `Interactable`:
 - `guardState: 'idle' | 'patrolling' | 'alert'`
 - `honestyTrait?: 'truth-teller' | 'liar'`
+- `spriteAssetPath?: string`
 
 ### Door
 Extends `Interactable`:
@@ -118,11 +121,12 @@ Required fields:
 - `width: number`
 - `height: number`
 - `player: { x: number; y: number }`
-- `guards: Array<{ id, displayName, x, y, guardState, honestyTrait? }>`
+- `guards: Array<{ id, displayName, x, y, guardState, honestyTrait?, spriteAssetPath? }>`
 - `doors: Array<{ id, displayName, x, y, doorState, outcome }>`
 
 Optional fields:
-- `npcs: Array<{ id, displayName, x, y, npcType }>`
+- `player.spriteAssetPath?: string`
+- `npcs: Array<{ id, displayName, x, y, npcType, spriteAssetPath? }>`
 - `interactiveObjects: Array<...>` with the same object fields as `InteractiveObject`, but `x/y` instead of `position`
 
 Example NPC entry:

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -120,14 +120,18 @@ Required fields:
 - `name: string`
 - `width: number`
 - `height: number`
-- `player: { x: number; y: number }`
+- `player: { x: number; y: number; spriteAssetPath?: string }`
 - `guards: Array<{ id, displayName, x, y, guardState, honestyTrait?, spriteAssetPath? }>`
 - `doors: Array<{ id, displayName, x, y, doorState, outcome }>`
 
 Optional fields:
-- `player.spriteAssetPath?: string`
 - `npcs: Array<{ id, displayName, x, y, npcType, spriteAssetPath? }>`
 - `interactiveObjects: Array<...>` with the same object fields as `InteractiveObject`, but `x/y` instead of `position`
+
+Shipped starter-level character sprite examples:
+- `player.spriteAssetPath: /assets/medieval_player_town_guard.svg`
+- `guards[*].spriteAssetPath: /assets/medieval_guard_spear.svg`
+- `npcs[*].spriteAssetPath: /assets/medieval_npc_villager.svg`
 
 Example NPC entry:
 

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -34,6 +34,13 @@ All fields are serializable primitives, arrays, or plain objects.
 - Optional `npcs` — array of level-defined NPCs with required `id`, `displayName`, `x`, `y`, and `npcType` fields
 - Optional `interactiveObjects`
 
+Character entities now support optional sprite metadata in serializable level JSON:
+- `player.spriteAssetPath?: string`
+- `guard.spriteAssetPath?: string`
+- `npc.spriteAssetPath?: string`
+
+Validation follows existing typing-only schema patterns: when present, each `spriteAssetPath` must be a string. Path format correctness is intentionally handled by render fallback behavior, not world-level rejection.
+
 For `npcs`, validation enforces:
 - required identity/position fields (`id`, `displayName`, `x`, `y`)
 - required `npcType: string` — categorizes the NPC's role (e.g., `'archive_keeper'`, `'scholar'`)
@@ -62,7 +69,8 @@ NPCs from level JSON are transformed to runtime `Npc` objects with deterministic
   displayName: 'Archivist',
   position: { x: 8, y: 5 },
   npcType: 'archive_keeper',
-  dialogueContextKey: 'npc_archive_keeper'  // deterministically derived: npc_${npcType.toLowerCase()}
+  dialogueContextKey: 'npc_archive_keeper', // deterministically derived: npc_${npcType.toLowerCase()}
+  spriteAssetPath: '/assets/medieval_npc_villager.svg' // optional passthrough metadata
 }
 ```
 

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -31,7 +31,7 @@ All fields are serializable primitives, arrays, or plain objects.
 `validateLevelData()` in `src/world/level.ts` validates:
 - Required level metadata (`version`, `name`, dimensions)
 - `player`, `guards`, and `doors`
-- Optional `npcs` — array of level-defined NPCs with required `id`, `displayName`, `x`, `y`, and `npcType` fields
+- Optional `npcs` - array of level-defined NPCs with required `id`, `displayName`, `x`, `y`, and `npcType` fields
 - Optional `interactiveObjects`
 
 Character entities now support optional sprite metadata in serializable level JSON:
@@ -39,11 +39,11 @@ Character entities now support optional sprite metadata in serializable level JS
 - `guard.spriteAssetPath?: string`
 - `npc.spriteAssetPath?: string`
 
-Validation follows existing typing-only schema patterns: when present, each `spriteAssetPath` must be a string. Path format correctness is intentionally handled by render fallback behavior, not world-level rejection.
+Validation follows existing typing-only schema patterns: when present, each `spriteAssetPath` must be a string. Path format correctness and loadability are intentionally handled by render fallback behavior, not world-level rejection.
 
 For `npcs`, validation enforces:
 - required identity/position fields (`id`, `displayName`, `x`, `y`)
-- required `npcType: string` — categorizes the NPC's role (e.g., `'archive_keeper'`, `'scholar'`)
+- required `npcType: string` - categorizes the NPC's role (for example, `'archive_keeper'`, `'scholar'`)
 
 For `interactiveObjects`, validation enforces:
 - required identity/position fields
@@ -61,7 +61,14 @@ NPCs from level JSON are transformed to runtime `Npc` objects with deterministic
 
 ```typescript
 // Input from level JSON
-{ id: 'npc-1', displayName: 'Archivist', x: 8, y: 5, npcType: 'archive_keeper' }
+{
+  id: 'npc-1',
+  displayName: 'Archivist',
+  x: 8,
+  y: 5,
+  npcType: 'archive_keeper',
+  spriteAssetPath: '/assets/medieval_npc_villager.svg'
+}
 
 // Output at runtime
 {
@@ -69,12 +76,12 @@ NPCs from level JSON are transformed to runtime `Npc` objects with deterministic
   displayName: 'Archivist',
   position: { x: 8, y: 5 },
   npcType: 'archive_keeper',
-  dialogueContextKey: 'npc_archive_keeper', // deterministically derived: npc_${npcType.toLowerCase()}
+  dialogueContextKey: 'npc_archive_keeper', // deterministic derivation: npc_${npcType.toLowerCase()}
   spriteAssetPath: '/assets/medieval_npc_villager.svg' // optional passthrough metadata
 }
 ```
 
-**Deserialization is deterministic:** The same `npcType` always produces the same `dialogueContextKey`, enabling consistent LLM prompt context routing and reproducible conversation flows.
+Deserialization remains deterministic: the same `npcType` always produces the same `dialogueContextKey`, enabling consistent LLM prompt context routing and reproducible conversation flows.
 
 ### Interactive Object Deserialization
 
@@ -86,6 +93,17 @@ Interactive object instance fields now deserialize directly:
 
 This enables shared behavior per object type while preserving instance-specific text, outcomes, and asset metadata.
 
+## Shipped Starter Level Demonstration
+
+The shipped starter level demonstrates the optional character sprite metadata flowing through world validation and deserialization:
+- `player.spriteAssetPath: /assets/medieval_player_town_guard.svg`
+- `guards[*].spriteAssetPath: /assets/medieval_guard_spear.svg`
+- `npcs[*].spriteAssetPath: /assets/medieval_npc_villager.svg`
+
+References:
+- Level JSON: [public/levels/starter.json](../public/levels/starter.json)
+- Integration proof: [src/integration/starterLevel.test.ts](../src/integration/starterLevel.test.ts)
+
 ## Interaction State Updates
 
 Conversational interactions write immutable updates into `actorConversationHistoryByActorId`, keyed by the interacting actor id. Object interactions return immutable state updates (for `interactiveObjects` and optional `levelOutcome`) and are then committed through world reset in `src/main.ts`.
@@ -93,7 +111,7 @@ Conversational interactions write immutable updates into `actorConversationHisto
 ## Testing Strategy
 
 - `src/world/level.test.ts`: schema validation + deserialization coverage
-- `src/integration/starterLevel.test.ts`: full level pipeline including interactive object behavior
+- `src/integration/starterLevel.test.ts`: full level pipeline including sprite metadata assertions
 - `src/world/spatialRules.test.ts` and `src/world/world.test.ts`: occupancy and world invariants with interactive objects
 
 Determinism rule remains unchanged: identical starting state + identical command/interaction sequence => identical resulting state.

--- a/public/assets/medieval_guard_spear.svg
+++ b/public/assets/medieval_guard_spear.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Medieval Guard Spear</title>
+  <desc id="desc">A stern castle guard with spear and red tabard.</desc>
+  <ellipse cx="32" cy="57" rx="15" ry="4" fill="#1f1a15" opacity="0.35"/>
+  <circle cx="32" cy="16" r="7" fill="#caa27f" stroke="#2d1f14" stroke-width="2"/>
+  <path d="M22 25c1-6 6-10 10-10s9 4 10 10v8H22z" fill="#6a6f76" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="24" y="31" width="16" height="18" rx="3" fill="#7b3e32" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="20" y="31" width="6" height="15" rx="2" fill="#6a6f76" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="38" y="31" width="6" height="15" rx="2" fill="#6a6f76" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="25" y="48" width="5" height="10" rx="2" fill="#4a3526" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="34" y="48" width="5" height="10" rx="2" fill="#4a3526" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="45" y="11" width="3" height="43" rx="1" fill="#91633c" stroke="#2d1f14" stroke-width="1.5"/>
+  <path d="M46.5 7l4 6h-8z" fill="#aeb4bb" stroke="#2d1f14" stroke-width="1.5"/>
+  <path d="M32 33v16" stroke="#c9b07a" stroke-width="2"/>
+</svg>

--- a/public/assets/medieval_npc_villager.svg
+++ b/public/assets/medieval_npc_villager.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Medieval NPC Villager</title>
+  <desc id="desc">A friendly village resident in a simple tunic.</desc>
+  <ellipse cx="32" cy="57" rx="14" ry="4" fill="#1f1a15" opacity="0.35"/>
+  <circle cx="32" cy="16" r="7" fill="#caa27f" stroke="#2d1f14" stroke-width="2"/>
+  <path d="M23 25c1-6 5-10 9-10s8 4 9 10v6H23z" fill="#6b513a" stroke="#2d1f14" stroke-width="2"/>
+  <path d="M22 31h20l-3 18H25z" fill="#8a6a45" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="20" y="31" width="5" height="14" rx="2" fill="#6b513a" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="39" y="31" width="5" height="14" rx="2" fill="#6b513a" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="26" y="49" width="5" height="9" rx="2" fill="#4a3526" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="33" y="49" width="5" height="9" rx="2" fill="#4a3526" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="29" y="34" width="6" height="9" rx="1" fill="#91633c" stroke="#2d1f14" stroke-width="1.5"/>
+</svg>

--- a/public/assets/medieval_player_town_guard.svg
+++ b/public/assets/medieval_player_town_guard.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Medieval Player Town Guard</title>
+  <desc id="desc">A readable top-down medieval guard character for player control.</desc>
+  <ellipse cx="32" cy="57" rx="14" ry="4" fill="#1f1a15" opacity="0.35"/>
+  <circle cx="32" cy="16" r="7" fill="#caa27f" stroke="#2d1f14" stroke-width="2"/>
+  <path d="M22 25c1-6 6-10 10-10s9 4 10 10v8H22z" fill="#4f5358" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="24" y="31" width="16" height="17" rx="3" fill="#3d5f73" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="20" y="30" width="6" height="16" rx="2" fill="#4f5358" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="38" y="30" width="6" height="16" rx="2" fill="#4f5358" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="25" y="47" width="5" height="11" rx="2" fill="#6a4a33" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="34" y="47" width="5" height="11" rx="2" fill="#6a4a33" stroke="#2d1f14" stroke-width="2"/>
+  <rect x="28" y="34" width="8" height="7" rx="1" fill="#91633c" stroke="#2d1f14" stroke-width="1.5"/>
+  <path d="M24 26h16" stroke="#aeb4bb" stroke-width="1.5" opacity="0.8"/>
+</svg>

--- a/public/levels/starter.json
+++ b/public/levels/starter.json
@@ -3,21 +3,27 @@
   "name": "Starter",
   "width": 20,
   "height": 20,
-  "player": { "x": 10, "y": 10 },
+  "player": {
+    "x": 10,
+    "y": 10,
+    "spriteAssetPath": "/assets/medieval_player_town_guard.svg"
+  },
   "guards": [
     {
       "id": "guard-1",
       "displayName": "West Guard",
       "x": 5,
       "y": 10,
-      "guardState": "patrolling"
+      "guardState": "patrolling",
+      "spriteAssetPath": "/assets/medieval_guard_spear.svg"
     },
     {
       "id": "guard-2",
       "displayName": "North Guard",
       "x": 10,
       "y": 5,
-      "guardState": "patrolling"
+      "guardState": "patrolling",
+      "spriteAssetPath": "/assets/medieval_guard_spear.svg"
     }
   ],
   "doors": [
@@ -38,7 +44,16 @@
       "outcome": "danger"
     }
   ],
-  "npcs": [],
+  "npcs": [
+    {
+      "id": "npc-villager-1",
+      "displayName": "Village Elder",
+      "x": 15,
+      "y": 14,
+      "npcType": "villager",
+      "spriteAssetPath": "/assets/medieval_npc_villager.svg"
+    }
+  ],
   "interactiveObjects": [
     {
       "id": "crate-supplies",

--- a/src/integration/starterLevel.test.ts
+++ b/src/integration/starterLevel.test.ts
@@ -19,10 +19,18 @@ describe('starter level integration pipeline', () => {
 
     expect(worldState).toBeDefined();
     expect(worldState.player.position).toEqual({ x: 10, y: 10 });
+    expect(worldState.player.spriteAssetPath).toBe('/assets/medieval_player_town_guard.svg');
 
     expect(worldState.guards).toHaveLength(2);
     expect(worldState.guards.find((guard) => guard.id === 'guard-1')?.position).toEqual({ x: 5, y: 10 });
     expect(worldState.guards.find((guard) => guard.id === 'guard-2')?.position).toEqual({ x: 10, y: 5 });
+    expect(worldState.guards.every((guard) => guard.spriteAssetPath === '/assets/medieval_guard_spear.svg')).toBe(
+      true,
+    );
+
+    expect(worldState.npcs).toHaveLength(1);
+    expect(worldState.npcs[0].id).toBe('npc-villager-1');
+    expect(worldState.npcs[0].spriteAssetPath).toBe('/assets/medieval_npc_villager.svg');
 
     expect(worldState.doors).toHaveLength(2);
     expect(worldState.doors.find((door) => door.id === 'door-1')?.position).toEqual({ x: 2, y: 10 });

--- a/src/render/scene.test.ts
+++ b/src/render/scene.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildEntityCircleSpecs, getColorForEntityType } from './scene';
+import { buildCharacterRenderModes, buildEntityCircleSpecs, getColorForEntityType } from './scene';
 import type { WorldState } from '../world/types';
 
 const createWorldState = (): WorldState => ({
@@ -144,5 +144,72 @@ describe('render entity circle helpers', () => {
         }),
       ]),
     );
+  });
+
+  it('selects sprite mode for player, guard, and npc only when the path is loaded', () => {
+    const worldState: WorldState = {
+      ...createWorldState(),
+      player: {
+        ...createWorldState().player,
+        spriteAssetPath: '/assets/medieval_player_town_guard.svg',
+      },
+      guards: [
+        {
+          ...createWorldState().guards[0],
+          spriteAssetPath: '/assets/medieval_guard_spear.svg',
+        },
+      ],
+      npcs: [
+        {
+          ...createWorldState().npcs[0],
+          spriteAssetPath: '/assets/medieval_npc_villager.svg',
+        },
+      ],
+    };
+
+    const spriteStatuses = new Map([
+      ['/assets/medieval_player_town_guard.svg', 'loaded' as const],
+      ['/assets/medieval_guard_spear.svg', 'loaded' as const],
+      ['/assets/medieval_npc_villager.svg', 'loaded' as const],
+    ]);
+
+    const modes = buildCharacterRenderModes(worldState, spriteStatuses);
+
+    expect(modes.player).toBe('sprite');
+    expect(modes.guardsById['guard-1']).toBe('sprite');
+    expect(modes.npcsById['npc-1']).toBe('sprite');
+  });
+
+  it('falls back to marker mode for player, guard, and npc when loading fails or is unresolved', () => {
+    const worldState: WorldState = {
+      ...createWorldState(),
+      player: {
+        ...createWorldState().player,
+        spriteAssetPath: '/assets/medieval_player_town_guard.svg',
+      },
+      guards: [
+        {
+          ...createWorldState().guards[0],
+          spriteAssetPath: '/assets/medieval_guard_spear.svg',
+        },
+      ],
+      npcs: [
+        {
+          ...createWorldState().npcs[0],
+          spriteAssetPath: '/assets/medieval_npc_villager.svg',
+        },
+      ],
+    };
+
+    const spriteStatuses = new Map([
+      ['/assets/medieval_player_town_guard.svg', 'failed' as const],
+      ['/assets/medieval_guard_spear.svg', 'loading' as const],
+    ]);
+
+    const modes = buildCharacterRenderModes(worldState, spriteStatuses);
+
+    expect(modes.player).toBe('marker');
+    expect(modes.guardsById['guard-1']).toBe('marker');
+    expect(modes.npcsById['npc-1']).toBe('marker');
   });
 });

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -1,4 +1,4 @@
-import { Application, Container, Graphics } from 'pixi.js';
+import { Application, Assets, Container, Graphics, Sprite } from 'pixi.js';
 import type { WorldState } from '../world/types';
 
 export interface RenderPort {
@@ -15,9 +15,21 @@ interface RenderContext {
   gridGraphics: Graphics;
   entityGraphics: Graphics;
   playerGraphics: Graphics;
+  characterSpritesContainer: Container;
+  characterSpritesByEntityId: Map<string, { sprite: Sprite; spriteAssetPath: string }>;
+  spriteLoadStatusByPath: Map<string, SpriteLoadStatus>;
   rootContainer: Container;
   lastWidth: number;
   lastHeight: number;
+}
+
+export type CharacterRenderMode = 'sprite' | 'marker';
+export type SpriteLoadStatus = 'loading' | 'loaded' | 'failed';
+
+export interface CharacterRenderModes {
+  player: CharacterRenderMode;
+  guardsById: Record<string, CharacterRenderMode>;
+  npcsById: Record<string, CharacterRenderMode>;
 }
 
 export interface EntityCircleSpec {
@@ -27,6 +39,39 @@ export interface EntityCircleSpec {
   radius: number;
   color: number;
 }
+
+const getCharacterRenderMode = (
+  spriteAssetPath: string | undefined,
+  spriteLoadStatusByPath: ReadonlyMap<string, SpriteLoadStatus>,
+): CharacterRenderMode => {
+  if (spriteAssetPath === undefined) {
+    return 'marker';
+  }
+
+  const status = spriteLoadStatusByPath.get(spriteAssetPath);
+  return status === 'loaded' ? 'sprite' : 'marker';
+};
+
+export const buildCharacterRenderModes = (
+  worldState: WorldState,
+  spriteLoadStatusByPath: ReadonlyMap<string, SpriteLoadStatus>,
+): CharacterRenderModes => {
+  const guardsById: Record<string, CharacterRenderMode> = {};
+  for (const guard of worldState.guards) {
+    guardsById[guard.id] = getCharacterRenderMode(guard.spriteAssetPath, spriteLoadStatusByPath);
+  }
+
+  const npcsById: Record<string, CharacterRenderMode> = {};
+  for (const npc of worldState.npcs) {
+    npcsById[npc.id] = getCharacterRenderMode(npc.spriteAssetPath, spriteLoadStatusByPath);
+  }
+
+  return {
+    player: getCharacterRenderMode(worldState.player.spriteAssetPath, spriteLoadStatusByPath),
+    guardsById,
+    npcsById,
+  };
+};
 
 const VIEWPORT_TILE_WIDTH = 6;
 const VIEWPORT_TILE_HEIGHT = 10;
@@ -116,6 +161,107 @@ export const buildEntityCircleSpecs = (worldState: WorldState): EntityCircleSpec
   return [...npcCircles, ...guardCircles, ...doorCircles, ...objectCircles];
 };
 
+const requestCharacterSpriteLoads = (context: RenderContext, worldState: WorldState): void => {
+  const characterSpritePaths = new Set<string>();
+  if (worldState.player.spriteAssetPath !== undefined) {
+    characterSpritePaths.add(worldState.player.spriteAssetPath);
+  }
+  for (const guard of worldState.guards) {
+    if (guard.spriteAssetPath !== undefined) {
+      characterSpritePaths.add(guard.spriteAssetPath);
+    }
+  }
+  for (const npc of worldState.npcs) {
+    if (npc.spriteAssetPath !== undefined) {
+      characterSpritePaths.add(npc.spriteAssetPath);
+    }
+  }
+
+  for (const spriteAssetPath of characterSpritePaths) {
+    if (context.spriteLoadStatusByPath.has(spriteAssetPath)) {
+      continue;
+    }
+
+    context.spriteLoadStatusByPath.set(spriteAssetPath, 'loading');
+    void Assets.load(spriteAssetPath)
+      .then(() => {
+        context.spriteLoadStatusByPath.set(spriteAssetPath, 'loaded');
+      })
+      .catch(() => {
+        context.spriteLoadStatusByPath.set(spriteAssetPath, 'failed');
+      });
+  }
+};
+
+const syncCharacterSprites = (
+  context: RenderContext,
+  worldState: WorldState,
+  characterRenderModes: CharacterRenderModes,
+): void => {
+  const tileSize = worldState.grid.tileSize;
+  const spriteSize = Math.max(8, tileSize * 0.82);
+  const activeEntityIds = new Set<string>();
+
+  const upsert = (entityId: string, spriteAssetPath: string, centerX: number, centerY: number): void => {
+    activeEntityIds.add(entityId);
+
+    const existing = context.characterSpritesByEntityId.get(entityId);
+    if (existing !== undefined && existing.spriteAssetPath !== spriteAssetPath) {
+      context.characterSpritesContainer.removeChild(existing.sprite);
+      existing.sprite.destroy();
+      context.characterSpritesByEntityId.delete(entityId);
+    }
+
+    let entry = context.characterSpritesByEntityId.get(entityId);
+    if (entry === undefined) {
+      const sprite = Sprite.from(spriteAssetPath);
+      sprite.anchor.set(0.5);
+      context.characterSpritesContainer.addChild(sprite);
+      entry = { sprite, spriteAssetPath };
+      context.characterSpritesByEntityId.set(entityId, entry);
+    }
+
+    entry.sprite.width = spriteSize;
+    entry.sprite.height = spriteSize;
+    entry.sprite.position.set(centerX, centerY);
+  };
+
+  const toCenter = (x: number, y: number): { centerX: number; centerY: number } => ({
+    centerX: x * tileSize + tileSize / 2,
+    centerY: y * tileSize + tileSize / 2,
+  });
+
+  if (characterRenderModes.player === 'sprite' && worldState.player.spriteAssetPath !== undefined) {
+    const center = toCenter(worldState.player.position.x, worldState.player.position.y);
+    upsert('player', worldState.player.spriteAssetPath, center.centerX, center.centerY);
+  }
+
+  for (const guard of worldState.guards) {
+    if (characterRenderModes.guardsById[guard.id] !== 'sprite' || guard.spriteAssetPath === undefined) {
+      continue;
+    }
+    const center = toCenter(guard.position.x, guard.position.y);
+    upsert(`guard:${guard.id}`, guard.spriteAssetPath, center.centerX, center.centerY);
+  }
+
+  for (const npc of worldState.npcs) {
+    if (characterRenderModes.npcsById[npc.id] !== 'sprite' || npc.spriteAssetPath === undefined) {
+      continue;
+    }
+    const center = toCenter(npc.position.x, npc.position.y);
+    upsert(`npc:${npc.id}`, npc.spriteAssetPath, center.centerX, center.centerY);
+  }
+
+  for (const [entityId, entry] of context.characterSpritesByEntityId.entries()) {
+    if (activeEntityIds.has(entityId)) {
+      continue;
+    }
+    context.characterSpritesContainer.removeChild(entry.sprite);
+    entry.sprite.destroy();
+    context.characterSpritesByEntityId.delete(entityId);
+  }
+};
+
 const clamp = (value: number, min: number, max: number): number => {
   return Math.max(min, Math.min(max, value));
 };
@@ -199,8 +345,62 @@ const drawGrid = (context: RenderContext, worldState: WorldState): void => {
   }
 };
 
-const drawEntityMarkers = (context: RenderContext, worldState: WorldState): void => {
-  const circles = buildEntityCircleSpecs(worldState);
+const drawEntityMarkers = (
+  context: RenderContext,
+  worldState: WorldState,
+  characterRenderModes: CharacterRenderModes,
+): void => {
+  const tileSize = worldState.grid.tileSize;
+  const radius = Math.max(5, tileSize * 0.22);
+  const toCenter = (x: number, y: number): { centerX: number; centerY: number } => ({
+    centerX: x * tileSize + tileSize / 2,
+    centerY: y * tileSize + tileSize / 2,
+  });
+
+  const circles: EntityCircleSpec[] = [];
+
+  for (const npc of worldState.npcs) {
+    if (characterRenderModes.npcsById[npc.id] === 'sprite') {
+      continue;
+    }
+    circles.push({
+      typeKey: 'npc',
+      ...toCenter(npc.position.x, npc.position.y),
+      radius,
+      color: getColorForEntityType('npc'),
+    });
+  }
+
+  for (const guard of worldState.guards) {
+    if (characterRenderModes.guardsById[guard.id] === 'sprite') {
+      continue;
+    }
+    circles.push({
+      typeKey: 'guard',
+      ...toCenter(guard.position.x, guard.position.y),
+      radius,
+      color: getColorForEntityType('guard'),
+    });
+  }
+
+  for (const door of worldState.doors) {
+    circles.push({
+      typeKey: 'door',
+      ...toCenter(door.position.x, door.position.y),
+      radius,
+      color: getColorForEntityType('door'),
+    });
+  }
+
+  for (const interactiveObject of worldState.interactiveObjects) {
+    const typeKey = `interactive-object:${interactiveObject.interactionType}`;
+    circles.push({
+      typeKey,
+      ...toCenter(interactiveObject.position.x, interactiveObject.position.y),
+      radius,
+      color: getColorForEntityType(typeKey),
+    });
+  }
 
   context.entityGraphics.clear();
   for (const circle of circles) {
@@ -211,7 +411,16 @@ const drawEntityMarkers = (context: RenderContext, worldState: WorldState): void
   }
 };
 
-const drawPlayerMarker = (context: RenderContext, worldState: WorldState): void => {
+const drawPlayerMarker = (
+  context: RenderContext,
+  worldState: WorldState,
+  characterRenderModes: CharacterRenderModes,
+): void => {
+  if (characterRenderModes.player === 'sprite') {
+    context.playerGraphics.clear();
+    return;
+  }
+
   const tileSize = worldState.grid.tileSize;
   const centerX = worldState.player.position.x * tileSize + tileSize / 2;
   const centerY = worldState.player.position.y * tileSize + tileSize / 2;
@@ -239,9 +448,11 @@ export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<
   const boundaryGraphics = new Graphics();
   const entityGraphics = new Graphics();
   const playerGraphics = new Graphics();
+  const characterSpritesContainer = new Container();
   const rootContainer = new Container();
   rootContainer.addChild(boundaryGraphics);
   rootContainer.addChild(gridGraphics);
+  rootContainer.addChild(characterSpritesContainer);
   rootContainer.addChild(entityGraphics);
   rootContainer.addChild(playerGraphics);
   app.stage.addChild(rootContainer);
@@ -252,6 +463,9 @@ export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<
     gridGraphics,
     entityGraphics,
     playerGraphics,
+    characterSpritesContainer,
+    characterSpritesByEntityId: new Map(),
+    spriteLoadStatusByPath: new Map(),
     rootContainer,
     lastWidth: 0,
     lastHeight: 0,
@@ -259,11 +473,14 @@ export const createPixiRenderPort = async (targets: PixiRenderTargets): Promise<
 
   return {
     render: (worldState: WorldState) => {
+      requestCharacterSpriteLoads(context, worldState);
+      const characterRenderModes = buildCharacterRenderModes(worldState, context.spriteLoadStatusByPath);
       ensureCanvasSize(context, worldState);
       drawBoundaryBand(context, worldState);
       drawGrid(context, worldState);
-      drawEntityMarkers(context, worldState);
-      drawPlayerMarker(context, worldState);
+      syncCharacterSprites(context, worldState, characterRenderModes);
+      drawEntityMarkers(context, worldState, characterRenderModes);
+      drawPlayerMarker(context, worldState, characterRenderModes);
       updateCamera(context, worldState);
     },
   };

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -25,6 +25,15 @@ describe('deserializeLevel', () => {
     });
   });
 
+  it('maps optional player spriteAssetPath when configured', () => {
+    const state = deserializeLevel({
+      ...minimalLevel,
+      player: { x: 2, y: 3, spriteAssetPath: '/assets/medieval_player_town_guard.svg' },
+    });
+
+    expect(state.player.spriteAssetPath).toBe('/assets/medieval_player_town_guard.svg');
+  });
+
   it('sets grid dimensions from level width/height and preserves a fixed tileSize', () => {
     const state = deserializeLevel(minimalLevel);
 
@@ -64,6 +73,24 @@ describe('deserializeLevel', () => {
       { id: 'guard-1', displayName: 'North Guard', position: { x: 5, y: 7 }, guardState: 'patrolling' },
       { id: 'guard-2', displayName: 'South Guard', position: { x: 10, y: 15 }, guardState: 'idle' },
     ]);
+  });
+
+  it('maps optional guard spriteAssetPath when configured', () => {
+    const state = deserializeLevel({
+      ...minimalLevel,
+      guards: [
+        {
+          id: 'guard-1',
+          displayName: 'North Guard',
+          x: 5,
+          y: 7,
+          guardState: 'patrolling',
+          spriteAssetPath: '/assets/medieval_guard_spear.svg',
+        },
+      ],
+    });
+
+    expect(state.guards[0].spriteAssetPath).toBe('/assets/medieval_guard_spear.svg');
   });
 
   it('maps door flat fields to nested Door with correct position and doorState', () => {
@@ -175,6 +202,11 @@ describe('validateLevelData', () => {
   it('throws when player is missing x or y', () => {
     const bad = { ...minimalLevel, player: { x: 1 } };
     expect(() => validateLevelData(bad)).toThrowError('player must have numeric x and y');
+  });
+
+  it('throws when player spriteAssetPath is not a string', () => {
+    const bad = { ...minimalLevel, player: { x: 2, y: 3, spriteAssetPath: 42 } };
+    expect(() => validateLevelData(bad)).toThrowError('player spriteAssetPath must be a string');
   });
 
   it('throws when guards is not an array', () => {
@@ -292,6 +324,16 @@ describe('honestyTrait field', () => {
     };
 
     expect(() => validateLevelData(bad)).toThrowError('invalid honestyTrait');
+  });
+
+  it('rejects guards with non-string spriteAssetPath', () => {
+    const bad = {
+      ...minimalLevel,
+      guards: [{ id: 'guard-1', displayName: 'Bad', x: 5, y: 7, guardState: 'idle', spriteAssetPath: 42 }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 2, y: 3, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid spriteAssetPath');
   });
 });
 
@@ -538,6 +580,38 @@ describe('npcs field', () => {
     const state = deserializeLevel(validated);
 
     expect(state.npcs[0].npcType).toBe('gate_guardian');
+  });
+
+  it('maps optional npc spriteAssetPath when configured', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      npcs: [
+        {
+          id: 'npc-1',
+          displayName: 'Villager',
+          x: 5,
+          y: 5,
+          npcType: 'villager',
+          spriteAssetPath: '/assets/medieval_npc_villager.svg',
+        },
+      ],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const validated = validateLevelData(level);
+    const state = deserializeLevel(validated);
+
+    expect(state.npcs[0].spriteAssetPath).toBe('/assets/medieval_npc_villager.svg');
+  });
+
+  it('rejects NPC with non-string spriteAssetPath', () => {
+    const bad = {
+      ...minimalLevel,
+      npcs: [{ id: 'npc-1', displayName: 'Npc', x: 5, y: 5, npcType: 'archivist', spriteAssetPath: 123 }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid spriteAssetPath');
   });
 });
 

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -40,6 +40,13 @@ export function validateLevelData(input: unknown): LevelData {
     throw new Error('Invalid level data: player must have numeric x and y');
   }
 
+  if (
+    (player as Record<string, unknown>)['spriteAssetPath'] !== undefined &&
+    typeof (player as Record<string, unknown>)['spriteAssetPath'] !== 'string'
+  ) {
+    throw new Error('Invalid level data: player spriteAssetPath must be a string when provided');
+  }
+
   if (!Array.isArray(raw['guards'])) {
     throw new Error('Invalid level data: guards must be an array');
   }
@@ -66,6 +73,12 @@ export function validateLevelData(input: unknown): LevelData {
           `Invalid level data: guard at index ${i} has invalid honestyTrait (must be 'truth-teller' or 'liar')`,
         );
       }
+    }
+
+    if (guard['spriteAssetPath'] !== undefined && typeof guard['spriteAssetPath'] !== 'string') {
+      throw new Error(
+        `Invalid level data: guard at index ${i} has invalid spriteAssetPath (must be a string when provided)`,
+      );
     }
   }
 
@@ -114,6 +127,12 @@ export function validateLevelData(input: unknown): LevelData {
       ) {
         throw new Error(
           `Invalid level data: npc at index ${i} must have id, displayName, x, y, and npcType`,
+        );
+      }
+
+      if (npc['spriteAssetPath'] !== undefined && typeof npc['spriteAssetPath'] !== 'string') {
+        throw new Error(
+          `Invalid level data: npc at index ${i} has invalid spriteAssetPath (must be a string when provided)`,
         );
       }
     }
@@ -175,6 +194,9 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       id: 'player',
       displayName: 'Player',
       position: { x: levelData.player.x, y: levelData.player.y },
+      ...(levelData.player.spriteAssetPath !== undefined
+        ? { spriteAssetPath: levelData.player.spriteAssetPath }
+        : {}),
     },
     npcs: (levelData.npcs ?? []).map((n) => ({
       id: n.id,
@@ -182,6 +204,7 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       position: { x: n.x, y: n.y },
       npcType: n.npcType,
       dialogueContextKey: `npc_${n.npcType.toLowerCase()}`,
+      ...(n.spriteAssetPath !== undefined ? { spriteAssetPath: n.spriteAssetPath } : {}),
     })),
     guards: levelData.guards.map((g) => ({
       id: g.id,
@@ -189,6 +212,7 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       position: { x: g.x, y: g.y },
       guardState: g.guardState,
       honestyTrait: g.honestyTrait,
+      ...(g.spriteAssetPath !== undefined ? { spriteAssetPath: g.spriteAssetPath } : {}),
     })),
     doors: levelData.doors.map((d) => ({
       id: d.id,

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -7,6 +7,7 @@ export interface Player {
   id: string;
   displayName: string;
   position: GridPosition;
+  spriteAssetPath?: string;
 }
 
 export interface Npc {
@@ -15,6 +16,7 @@ export interface Npc {
   position: GridPosition;
   npcType: string;
   dialogueContextKey: string;
+  spriteAssetPath?: string;
 }
 
 export interface ConversationMessage {
@@ -35,6 +37,7 @@ export interface Interactable {
 export interface Guard extends Interactable {
   guardState: 'idle' | 'patrolling' | 'alert';
   honestyTrait?: 'truth-teller' | 'liar';
+  spriteAssetPath?: string;
 }
 
 /** A door that the player can pass through or be blocked by. */
@@ -65,7 +68,7 @@ export interface LevelData {
   name: string;
   width: number;
   height: number;
-  player: { x: number; y: number };
+  player: { x: number; y: number; spriteAssetPath?: string };
   guards: Array<{
     id: string;
     displayName: string;
@@ -73,6 +76,7 @@ export interface LevelData {
     y: number;
     guardState: 'patrolling' | 'alert' | 'idle';
     honestyTrait?: 'truth-teller' | 'liar';
+    spriteAssetPath?: string;
   }>;
   doors: Array<{
     id: string;
@@ -88,6 +92,7 @@ export interface LevelData {
     x: number;
     y: number;
     npcType: string;
+    spriteAssetPath?: string;
   }>;
   interactiveObjects?: Array<{
     id: string;


### PR DESCRIPTION
## Summary
- extend serializable world and level character contracts with optional `spriteAssetPath` for player, guards, and NPCs
- render player/guard/npc sprites when configured and loaded, with deterministic marker fallback when absent, loading, or failed
- add shipped starter level demonstration using configured player, guard, and NPC sprite asset paths
- add focused tests for sprite-mode and fallback-mode selection for player/guard/npc, plus starter integration assertions for configured sprite paths
- document the new asset metadata contract and fallback behavior in world/render/type references

## Validation
- `npm test`
- `npm run build`

## Closes #86