### PR TITLE
#87 add bounded tests for level UI, outcome overlay, and command buffer

### DIFF
--- a/docs/TESTING_PATTERNS.md
+++ b/docs/TESTING_PATTERNS.md
@@ -27,6 +27,18 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
   - paused viewport cannot gain focus and paused viewport click handlers do not fire
   - close button and Escape both call `onClose` and close the modal
   - closing the modal restores focus to `document.body`
+- **Level UI control checks** (`src/render/levelUi.test.ts`):
+  - controls start disabled with a single empty placeholder option before any levels are loaded
+  - empty level list passed to `populateLevels` keeps controls disabled
+  - non-empty level list enables select and reset button and populates one option per entry
+  - `onLevelSelect` fires with the selected level id on `change` event; `onReset` fires on button click
+  - `setSelectedLevel` updates the select value without triggering `onLevelSelect`
+- **Outcome overlay checks** (`src/render/outcomeOverlay.test.ts`):
+  - overlay starts with no DOM children in the container
+  - `show()` inserts one child element; `hide()` removes it
+  - `show('win')` renders "You Won!" text; `show('lose')` renders "You Lost!" text
+  - repeated `show()` calls are idempotent — does not add additional elements or change the existing element reference
+  - `hide()` is safe to call when already hidden (no error, no children remain)
 
 ### Interaction Layer Tests
 - **What to test:** Interaction orchestration, dispatcher routing, prompt context building, thread updates
@@ -53,6 +65,11 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
   input.onKeyDown({ key: 'ArrowUp' });
   expect(commandBuffer.dequeue()).toBe(MoveForward);
   ```
+- **Command buffer checks** (`src/input/commands.test.ts`):
+  - `drain()` returns enqueued commands in FIFO order
+  - `drain()` returns a snapshot — mutating the returned array does not affect the buffer
+  - a second `drain()` after the first returns an empty array until new commands are enqueued
+  - `clear()` discards all pending commands without preventing future `enqueue()` operations
 
 ### LLM Layer Tests
 - **What to test:** Context serialization, response parsing, API fallbacks

--- a/src/input/commands.test.ts
+++ b/src/input/commands.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { createCommandBuffer } from './commands';
+
+describe('createCommandBuffer', () => {
+  it('drains commands in enqueue order', () => {
+    const buffer = createCommandBuffer();
+
+    buffer.enqueue({ type: 'move', dx: 1, dy: 0 });
+    buffer.enqueue({ type: 'interact' });
+    buffer.enqueue({ type: 'move', dx: 0, dy: -1 });
+
+    expect(buffer.drain()).toEqual([
+      { type: 'move', dx: 1, dy: 0 },
+      { type: 'interact' },
+      { type: 'move', dx: 0, dy: -1 },
+    ]);
+  });
+
+  it('resets drained commands so subsequent drains are empty until enqueued again', () => {
+    const buffer = createCommandBuffer();
+
+    buffer.enqueue({ type: 'interact' });
+
+    const firstDrain = buffer.drain();
+    const secondDrain = buffer.drain();
+
+    expect(firstDrain).toEqual([{ type: 'interact' }]);
+    expect(secondDrain).toEqual([]);
+
+    firstDrain.push({ type: 'move', dx: 5, dy: 5 });
+    expect(buffer.drain()).toEqual([]);
+  });
+
+  it('clears pending commands without affecting future enqueue operations', () => {
+    const buffer = createCommandBuffer();
+
+    buffer.enqueue({ type: 'move', dx: -1, dy: 0 });
+    buffer.enqueue({ type: 'interact' });
+    buffer.clear();
+
+    expect(buffer.drain()).toEqual([]);
+
+    buffer.enqueue({ type: 'move', dx: 0, dy: 1 });
+    expect(buffer.drain()).toEqual([{ type: 'move', dx: 0, dy: 1 }]);
+  });
+});

--- a/src/render/levelUi.test.ts
+++ b/src/render/levelUi.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLevelUi } from './levelUi';
+
+describe('createLevelUi', () => {
+  let container: HTMLDivElement;
+  const onLevelSelect = vi.fn();
+  const onReset = vi.fn();
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    onLevelSelect.mockReset();
+    onReset.mockReset();
+  });
+
+  it('starts disabled with an empty placeholder option', () => {
+    createLevelUi(container, { onLevelSelect, onReset });
+
+    const select = container.querySelector<HTMLSelectElement>('#level-select');
+    const resetButton = container.querySelector<HTMLButtonElement>('button');
+
+    expect(select).not.toBeNull();
+    expect(select?.disabled).toBe(true);
+    expect(select?.options).toHaveLength(1);
+    expect(select?.options[0]?.value).toBe('');
+    expect(select?.options[0]?.textContent).toBe('No levels available');
+
+    expect(resetButton).not.toBeNull();
+    expect(resetButton?.disabled).toBe(true);
+  });
+
+  it('keeps controls disabled when populated with an empty level list', () => {
+    const handle = createLevelUi(container, { onLevelSelect, onReset });
+
+    handle.populateLevels([]);
+
+    const select = container.querySelector<HTMLSelectElement>('#level-select');
+    const resetButton = container.querySelector<HTMLButtonElement>('button');
+
+    expect(select?.disabled).toBe(true);
+    expect(resetButton?.disabled).toBe(true);
+    expect(select?.options).toHaveLength(1);
+    expect(select?.options[0]?.value).toBe('');
+    expect(select?.options[0]?.textContent).toBe('No levels available');
+  });
+
+  it('populates levels and enables controls for non-empty lists', () => {
+    const handle = createLevelUi(container, { onLevelSelect, onReset });
+
+    handle.populateLevels([
+      { id: 'starter', name: 'Starter' },
+      { id: 'riddle', name: 'Riddle' },
+    ]);
+
+    const select = container.querySelector<HTMLSelectElement>('#level-select');
+    const resetButton = container.querySelector<HTMLButtonElement>('button');
+
+    expect(select?.disabled).toBe(false);
+    expect(resetButton?.disabled).toBe(false);
+    expect(select?.options).toHaveLength(2);
+    expect(select?.options[0]?.value).toBe('starter');
+    expect(select?.options[0]?.textContent).toBe('Starter');
+    expect(select?.options[1]?.value).toBe('riddle');
+    expect(select?.options[1]?.textContent).toBe('Riddle');
+  });
+
+  it('fires callbacks for level selection and reset', () => {
+    const handle = createLevelUi(container, { onLevelSelect, onReset });
+    handle.populateLevels([{ id: 'starter', name: 'Starter' }]);
+
+    const select = container.querySelector<HTMLSelectElement>('#level-select');
+    const resetButton = container.querySelector<HTMLButtonElement>('button');
+
+    if (!select || !resetButton) {
+      throw new Error('Expected level UI controls to exist');
+    }
+
+    select.value = 'starter';
+    select.dispatchEvent(new Event('change'));
+    resetButton.click();
+
+    expect(onLevelSelect).toHaveBeenCalledWith('starter');
+    expect(onLevelSelect).toHaveBeenCalledTimes(1);
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates selected level without triggering onLevelSelect', () => {
+    const handle = createLevelUi(container, { onLevelSelect, onReset });
+    handle.populateLevels([
+      { id: 'starter', name: 'Starter' },
+      { id: 'riddle', name: 'Riddle' },
+    ]);
+
+    handle.setSelectedLevel('riddle');
+
+    const select = container.querySelector<HTMLSelectElement>('#level-select');
+    expect(select?.value).toBe('riddle');
+    expect(onLevelSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/render/outcomeOverlay.test.ts
+++ b/src/render/outcomeOverlay.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createOutcomeOverlay } from './outcomeOverlay';
+
+describe('createOutcomeOverlay', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  it('shows and hides the overlay lifecycle correctly', () => {
+    const overlay = createOutcomeOverlay(container);
+
+    expect(container.children).toHaveLength(0);
+
+    overlay.show('win');
+    expect(container.children).toHaveLength(1);
+
+    overlay.hide();
+    expect(container.children).toHaveLength(0);
+  });
+
+  it('renders win and lose specific messages', () => {
+    const overlay = createOutcomeOverlay(container);
+
+    overlay.show('win');
+    const winText = container.textContent ?? '';
+    expect(winText).toContain('You Won!');
+    overlay.hide();
+
+    overlay.show('lose');
+    const loseText = container.textContent ?? '';
+    expect(loseText).toContain('You Lost!');
+  });
+
+  it('is idempotent when show is called repeatedly and cleans up on hide', () => {
+    const overlay = createOutcomeOverlay(container);
+
+    overlay.show('win');
+    const firstEl = container.firstElementChild;
+
+    overlay.show('lose');
+    expect(container.children).toHaveLength(1);
+    expect(container.firstElementChild).toBe(firstEl);
+    expect(container.textContent ?? '').toContain('You Won!');
+
+    overlay.hide();
+    expect(container.children).toHaveLength(0);
+
+    overlay.hide();
+    expect(container.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated behavior tests for level UI control state, population, and callback wiring
- add dedicated behavior tests for outcome overlay show/hide lifecycle, outcome messaging, and idempotent show behavior
- add dedicated behavior tests for command buffer enqueue/drain ordering and reset/clear semantics
- keep implementation test-only with no production runtime behavior changes

## Validation
- `npm test`
- `npm run build`

## Closes #87