### PR TITLE
#92 select player sprite direction from last directional input

### DIFF
--- a/docs/EXTEND_STATE.md
+++ b/docs/EXTEND_STATE.md
@@ -27,7 +27,7 @@ Update type interfaces in `src/world/types.ts` (for example `InteractiveObject` 
 
 Prefer explicit unions over free-form strings when the allowed values are known.
 
-### 2. Update level JSON schema enforcement
+### 2. Update level JSON schema enforcement (if level-authored)
 If fields originate in level JSON, update `validateLevelData()` in `src/world/level.ts`.
 
 Typical checks:
@@ -35,8 +35,12 @@ Typical checks:
 - allowed enum literals
 - cross-field validity when needed
 
+If fields are runtime-derived (for example from command intent), keep them out of level JSON schema and initialize them deterministically in world state creation/deserialization paths.
+
 ### 3. Update deserialization mapping
 Map every validated field in `deserializeLevel()` so runtime state exactly reflects level data.
+
+For runtime-derived fields that are not authored in level JSON, initialize deterministic defaults in deserialization (for example `player.facingDirection: 'front'`).
 
 ### 4. Update deterministic handlers
 If the new field changes interaction behavior, update deterministic handlers (for example in `src/interaction/objectInteraction.ts`) to produce immutable next state.
@@ -82,11 +86,28 @@ Boundary reminder:
 - world layer validates serializable shape only
 - sprite loading success/failure and fallback rendering remain render-layer responsibilities
 
+## Example: Player Facing Direction (Ticket #92)
+
+Added optional world field:
+- `Player.facingDirection?: SpriteDirection`
+
+Why optional:
+- preserves backward compatibility with existing serialized snapshots
+- render can still default to `front` if the field is absent
+
+Required follow-up updates:
+- type update in `src/world/types.ts`
+- deterministic default in world initialization (`src/world/state.ts`) and level deserialization (`src/world/level.ts`)
+- deterministic command-intent mapping in `src/world/world.ts` (`dx/dy` -> `left/right/away/front`)
+- blocked movement still updates facing direction from intent
+- render consumption of world-facing token in `src/render/scene.ts`
+- regression tests in `src/world/world.test.ts`, `src/world/level.test.ts`, `src/render/scene.test.ts`, and `src/integration/riddleLevel.test.ts`
+
 ## Checklist
 
 - [ ] Type changes are explicit and serializable
-- [ ] Validation updated for incoming level JSON
-- [ ] Deserializer maps all new fields
+- [ ] Validation updated for incoming level JSON (if level-authored)
+- [ ] Deserializer maps all new fields or initializes deterministic defaults for runtime-derived fields
 - [ ] Deterministic logic updated immutably
 - [ ] Fixtures/tests updated across impacted layers
 - [ ] Relevant docs updated (`WORLD_LAYER.md`, `RENDER_LAYER.md`, `TYPES_REFERENCE.md`, and pattern docs)

--- a/docs/RENDER_LAYER.md
+++ b/docs/RENDER_LAYER.md
@@ -7,6 +7,7 @@ The render layer translates `WorldState` into visual state and DOM-only runtime 
 - Render grid, boundary band, character sprites (when available), and marker fallbacks
 - Keep viewport/camera centered around player with clamped world bounds
 - Map world entities to deterministic visuals by type and optional asset metadata
+- Consume world-owned player-facing direction when choosing player directional sprites
 - Manage DOM-only render utilities for runtime layout, chat UI, viewport pause presentation, and level-outcome presentation
 
 Implementation entry points:
@@ -23,7 +24,7 @@ Implementation entry points:
 `createPixiRenderPort()` returns a render port with `render(worldState)`.
 
 Per render pass:
-1. Resolve character asset paths from `spriteSet` and legacy `spriteAssetPath` metadata.
+1. Resolve character asset paths from `spriteSet`, legacy `spriteAssetPath`, and world-provided player facing direction.
 2. Request sprite loads for player, guards, and NPCs using resolved character asset paths.
 3. Resolve character render mode (`sprite` or `marker`) from sprite load status.
 4. Ensure canvas size from tile-grid viewport config.
@@ -37,7 +38,7 @@ Per render pass:
 
 `scene.ts` resolves directional assets through `resolveSpriteAssetPathForDirection(spriteSet, requestedDirection)` with deterministic fallback order.
 
-Current requested direction is fixed to `front`, and fallback order is:
+For player rendering, the requested direction is read from `worldState.player.facingDirection` and defaults to `front` when missing. Fallback order is:
 - `front`
 - `default`
 - `away`
@@ -45,6 +46,8 @@ Current requested direction is fixed to `front`, and fallback order is:
 - `right`
 
 If no `spriteSet` key resolves, renderer falls back to legacy `spriteAssetPath`, then to marker circles if loading fails or no path exists.
+
+World owns direction intent; render owns visual resolution and fallback behavior.
 
 This keeps rendering deterministic even with partially configured sprite sets.
 
@@ -97,12 +100,13 @@ Character and object entities can carry sprite metadata in world state:
 - `spriteSet` for optional directional/default usage
 
 Current character contract:
-- `player.spriteAssetPath?: string`, `player.spriteSet?: SpriteSet`
+- `player.spriteAssetPath?: string`, `player.spriteSet?: SpriteSet`, `player.facingDirection?: SpriteDirection`
 - `guard.spriteAssetPath?: string`, `guard.spriteSet?: SpriteSet`
 - `npc.spriteAssetPath?: string`, `npc.spriteSet?: SpriteSet`
 
 Current renderer behavior:
 - attempts to load resolved character sprite assets via Pixi asset loading
+- resolves player sprite direction from world-facing state, defaulting to `front` when absent
 - renders characters as sprites only when the resolved asset has loaded
 - falls back to deterministic marker circles when metadata is missing, loading is in progress, or loading failed
 - keeps door and interactive-object rendering marker-based
@@ -126,7 +130,7 @@ Source and verification:
 
 ## Tests
 
-- `src/render/scene.test.ts`: color mapping, marker specs, sprite-mode behavior, and deterministic directional fallback order
+- `src/render/scene.test.ts`: color mapping, marker specs, sprite-mode behavior, player directional sprite selection from world-facing state, and deterministic directional fallback order
 - `src/render/runtimeLayout.test.ts`: viewport/layout behavior
 - `src/render/viewportOverlay.test.ts`: overlay visibility, `inert` toggling, focus blocking, and pointer blocking
 - `src/render/chatModal.test.ts`: close button and Escape exit behavior, modal visibility, and focus cleanup

--- a/docs/TESTING_PATTERNS.md
+++ b/docs/TESTING_PATTERNS.md
@@ -19,6 +19,10 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
   - `spriteSet` is accepted for player/guards/doors (and optional entities sharing the same schema)
   - invalid `spriteSet` shapes throw descriptive errors (non-object, non-string directional values, empty object)
   - deserialized world state keeps sprite metadata JSON-serializable via round-trip assertion
+  - player-facing direction defaults to `front` on level load
+- **Movement intent regression checks (`src/world/world.test.ts`):**
+  - directional movement intents deterministically map to `player.facingDirection` (`left`, `right`, `away`, `front`)
+  - facing direction still updates from directional intent when movement is blocked
 
 ### Render Layer Tests
 - **What to test:** Sprite positioning, sprite lifecycle, viewport math, deterministic asset fallback, and DOM render utility behavior
@@ -28,6 +32,7 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
 - **Directional fallback regression checks (`src/render/scene.test.ts`):**
   - `resolveSpriteAssetPathForDirection` honors deterministic fallback order for missing keys
   - mixed contracts (`spriteSet` and legacy `spriteAssetPath`) still resolve to stable render behavior
+  - player sprite selection uses world-owned `player.facingDirection` and defaults to `front` when not present
   - marker fallback still applies when resolved sprite path is unavailable or failed to load
 - **Paused-world UI regression checks:**
   - pause overlay starts hidden and becomes visible only after `show()`
@@ -88,7 +93,7 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
 ## Integration Tests
 
 When features cross layer boundaries, write integration tests:
-- **Player movement + rendering:** World updates position, render layer reflects it
+- **Player movement + rendering:** World updates position and facing direction, render layer reflects the selected sprite orientation
 - **Input + world:** Keyboard input flows through buffer and updates world state
 - **Interaction + result routing:** Interact command resolves target, dispatcher returns result, result dispatcher applies side effect
 - **NPC interaction + LLM:** Player message triggers LLM call and updates conversation thread

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -32,6 +32,7 @@ Serializable optional directional sprite metadata:
 - `id: string`
 - `displayName: string`
 - `position: GridPosition`
+- `facingDirection?: SpriteDirection` - world-owned orientation token derived from latest directional movement intent
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`
 

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -7,6 +7,7 @@ The world layer owns deterministic, JSON-serializable state and validation/deser
 - Validate flat level JSON payloads (`LevelData`)
 - Deserialize level data into runtime world state
 - Preserve determinism for interaction and movement outcomes
+- Derive player-facing direction from movement intent as deterministic world data
 - Keep world state independent from rendering and LLM infrastructure
 
 ## Current Deterministic State Model
@@ -25,6 +26,18 @@ The world layer owns deterministic, JSON-serializable state and validation/deser
 All fields are serializable primitives, arrays, or plain objects.
 
 `actorConversationHistoryByActorId` stores chat history keyed by actor id. It remains JSON-serializable and actor-neutral even though the current conversational actors are guards and NPCs.
+
+### Player Facing Direction State
+
+`player.facingDirection` is a serializable directional token (`front | away | left | right`) owned by the world layer.
+
+Deterministic rules:
+- New runtime state initializes `player.facingDirection` to `front` (`createInitialWorldState()` in `src/world/state.ts`)
+- Level deserialization initializes loaded player state to `front` (`deserializeLevel()` in `src/world/level.ts`)
+- Move commands map input intent to facing direction in world update logic (`src/world/world.ts`)
+- Facing direction updates even when movement is blocked, so intent is still represented in world state
+
+Render consumes this token but does not author it.
 
 ## Level JSON Validation
 
@@ -65,7 +78,10 @@ Deserialization now passes through both optional sprite forms:
 - `spriteAssetPath`
 - `spriteSet`
 
-The world layer does not resolve directional variants. It preserves serializable metadata only; render chooses final visual assets.
+It also initializes player-facing state for loaded levels:
+- `player.facingDirection: 'front'`
+
+The world layer does not resolve directional variants. It preserves serializable metadata and deterministic orientation tokens only; render chooses final visual assets.
 
 ### NPC Deserialization
 NPCs from level JSON are transformed to runtime `Npc` objects with deterministically derived `dialogueContextKey`:
@@ -127,11 +143,14 @@ References:
 
 Conversational interactions write immutable updates into `actorConversationHistoryByActorId`, keyed by the interacting actor id. Object interactions return immutable state updates (for `interactiveObjects` and optional `levelOutcome`) and are then committed through world reset in `src/main.ts`.
 
+Movement commands also update immutable player-facing state in `src/world/world.ts`, coupling orientation to input intent while preserving deterministic world transitions.
+
 ## Testing Strategy
 
-- `src/world/level.test.ts`: schema validation + deserialization coverage for `spriteAssetPath` and `spriteSet`
+- `src/world/level.test.ts`: schema validation + deserialization coverage for `spriteAssetPath` and `spriteSet`, including player default `facingDirection` on load
+- `src/world/world.test.ts`: deterministic movement mapping from command intent to `player.facingDirection`, including blocked movement intent
 - `src/integration/starterLevel.test.ts`: starter level pipeline and sprite metadata assertions
-- `src/integration/riddleLevel.test.ts`: riddle-level sprite-set wiring assertions for player/guards/doors
-- `src/world/spatialRules.test.ts` and `src/world/world.test.ts`: occupancy and world invariants with interactive objects
+- `src/integration/riddleLevel.test.ts`: riddle-level sprite-set wiring assertions for player/guards/doors and player default `facingDirection`
+- `src/world/spatialRules.test.ts`: occupancy invariants
 
 Determinism rule remains unchanged: identical starting state + identical command/interaction sequence => identical resulting state.

--- a/src/integration/riddleLevel.test.ts
+++ b/src/integration/riddleLevel.test.ts
@@ -17,6 +17,7 @@ describe('riddle level integration pipeline', () => {
 
     expect(worldState).toBeDefined();
     expect(worldState.player.position).toEqual({ x: 10, y: 15 });
+    expect(worldState.player.facingDirection).toBe('front');
 
     expect(worldState.guards).toHaveLength(2);
     expect(worldState.guards.find((guard) => guard.id === 'guard-truth')?.position).toEqual({ x: 8, y: 10 });

--- a/src/render/scene.test.ts
+++ b/src/render/scene.test.ts
@@ -187,9 +187,11 @@ describe('render entity circle helpers', () => {
       ...createWorldState(),
       player: {
         ...createWorldState().player,
+        facingDirection: 'right',
         spriteSet: {
           default: '/assets/medieval_player_town_guard.svg',
           front: '/assets/medieval_player_town_guard.svg',
+          right: '/assets/medieval_player_town_guard_right.svg',
         },
       },
       guards: [
@@ -210,7 +212,7 @@ describe('render entity circle helpers', () => {
     };
 
     const spriteStatuses = new Map([
-      ['/assets/medieval_player_town_guard.svg', 'loaded' as const],
+      ['/assets/medieval_player_town_guard_right.svg', 'loaded' as const],
       ['/assets/medieval_guard_spear.svg', 'loaded' as const],
       ['/assets/medieval_npc_villager.svg', 'loaded' as const],
     ]);
@@ -220,6 +222,25 @@ describe('render entity circle helpers', () => {
     expect(modes.player).toBe('sprite');
     expect(modes.guardsById['guard-1']).toBe('sprite');
     expect(modes.npcsById['npc-1']).toBe('sprite');
+  });
+
+  it('defaults player sprite direction selection to front when no directional input has occurred', () => {
+    const worldState: WorldState = {
+      ...createWorldState(),
+      player: {
+        ...createWorldState().player,
+        spriteSet: {
+          front: '/assets/medieval_player_front.svg',
+          away: '/assets/medieval_player_away.svg',
+        },
+      },
+    };
+
+    const spriteStatuses = new Map([['/assets/medieval_player_front.svg', 'loaded' as const]]);
+
+    const modes = buildCharacterRenderModes(worldState, spriteStatuses);
+
+    expect(modes.player).toBe('sprite');
   });
 
   it('falls back to marker mode for player, guard, and npc when loading fails or is unresolved', () => {

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -40,7 +40,7 @@ export interface EntityCircleSpec {
   color: number;
 }
 
-const RENDER_DIRECTION: SpriteDirection = 'front';
+const DEFAULT_RENDER_DIRECTION: SpriteDirection = 'front';
 
 const DIRECTION_FALLBACK_ORDER: Record<SpriteDirection, Array<keyof SpriteSet>> = {
   front: ['front', 'default', 'away', 'left', 'right'],
@@ -69,8 +69,9 @@ export const resolveSpriteAssetPathForDirection = (
 
 const resolveCharacterSpriteAssetPath = (
   entity: { spriteAssetPath?: string; spriteSet?: SpriteSet },
+  requestedDirection: SpriteDirection = DEFAULT_RENDER_DIRECTION,
 ): string | undefined => {
-  const directionalSpritePath = resolveSpriteAssetPathForDirection(entity.spriteSet, RENDER_DIRECTION);
+  const directionalSpritePath = resolveSpriteAssetPathForDirection(entity.spriteSet, requestedDirection);
   return directionalSpritePath ?? entity.spriteAssetPath;
 };
 
@@ -104,7 +105,10 @@ export const buildCharacterRenderModes = (
   }
 
   return {
-    player: getCharacterRenderMode(resolveCharacterSpriteAssetPath(worldState.player), spriteLoadStatusByPath),
+    player: getCharacterRenderMode(
+      resolveCharacterSpriteAssetPath(worldState.player, worldState.player.facingDirection ?? DEFAULT_RENDER_DIRECTION),
+      spriteLoadStatusByPath,
+    ),
     guardsById,
     npcsById,
   };
@@ -200,7 +204,10 @@ export const buildEntityCircleSpecs = (worldState: WorldState): EntityCircleSpec
 
 const requestCharacterSpriteLoads = (context: RenderContext, worldState: WorldState): void => {
   const characterSpritePaths = new Set<string>();
-  const playerSpritePath = resolveCharacterSpriteAssetPath(worldState.player);
+  const playerSpritePath = resolveCharacterSpriteAssetPath(
+    worldState.player,
+    worldState.player.facingDirection ?? DEFAULT_RENDER_DIRECTION,
+  );
   if (playerSpritePath !== undefined) {
     characterSpritePaths.add(playerSpritePath);
   }
@@ -271,7 +278,10 @@ const syncCharacterSprites = (
     centerY: y * tileSize + tileSize / 2,
   });
 
-  const playerSpritePath = resolveCharacterSpriteAssetPath(worldState.player);
+  const playerSpritePath = resolveCharacterSpriteAssetPath(
+    worldState.player,
+    worldState.player.facingDirection ?? DEFAULT_RENDER_DIRECTION,
+  );
   if (characterRenderModes.player === 'sprite' && playerSpritePath !== undefined) {
     const center = toCenter(worldState.player.position.x, worldState.player.position.y);
     upsert('player', playerSpritePath, center.centerX, center.centerY);

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -22,6 +22,7 @@ describe('deserializeLevel', () => {
       id: 'player',
       displayName: 'Player',
       position: { x: 2, y: 3 },
+      facingDirection: 'front',
     });
   });
 

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -257,6 +257,7 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       id: 'player',
       displayName: 'Player',
       position: { x: levelData.player.x, y: levelData.player.y },
+      facingDirection: 'front',
       ...(levelData.player.spriteAssetPath !== undefined
         ? { spriteAssetPath: levelData.player.spriteAssetPath }
         : {}),

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -11,6 +11,7 @@ export const createInitialWorldState = (): WorldState => ({
     id: 'player-1',
     displayName: 'Guard',
     position: { x: 1, y: 1 },
+    facingDirection: 'front',
   },
   npcs: [
     {

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -21,6 +21,7 @@ export interface Player {
   id: string;
   displayName: string;
   position: GridPosition;
+  facingDirection?: SpriteDirection;
   spriteAssetPath?: string;
   spriteSet?: SpriteSet;
 }

--- a/src/world/world.test.ts
+++ b/src/world/world.test.ts
@@ -13,7 +13,50 @@ describe('createWorld', () => {
     ]);
 
     expect(world.getState().player.position).toEqual({ x: 1, y: 2 });
+    expect(world.getState().player.facingDirection).toBe('left');
     expect(world.getState().tick).toBe(1);
+  });
+
+  it('maps directional movement input to facing direction deterministically', () => {
+    const world = createWorld();
+
+    world.applyCommands([{ type: 'move', dx: -1, dy: 0 }]);
+    expect(world.getState().player.facingDirection).toBe('left');
+
+    world.applyCommands([{ type: 'move', dx: 1, dy: 0 }]);
+    expect(world.getState().player.facingDirection).toBe('right');
+
+    world.applyCommands([{ type: 'move', dx: 0, dy: -1 }]);
+    expect(world.getState().player.facingDirection).toBe('away');
+
+    world.applyCommands([{ type: 'move', dx: 0, dy: 1 }]);
+    expect(world.getState().player.facingDirection).toBe('front');
+  });
+
+  it('updates facing direction from movement intent even when movement is blocked', () => {
+    const world = createWorld();
+
+    world.resetToState({
+      ...world.getState(),
+      player: {
+        ...world.getState().player,
+        position: { x: 2, y: 2 },
+      },
+      npcs: [
+        {
+          id: 'npc-blocker',
+          displayName: 'Npc blocker',
+          npcType: 'blocker',
+          dialogueContextKey: 'npc-blocker',
+          position: { x: 2, y: 1 },
+        },
+      ],
+    });
+
+    world.applyCommands([{ type: 'move', dx: 0, dy: -1 }]);
+
+    expect(world.getState().player.position).toEqual({ x: 2, y: 2 });
+    expect(world.getState().player.facingDirection).toBe('away');
   });
 
   it('keeps player position unchanged when movement goes out of bounds', () => {

--- a/src/world/world.ts
+++ b/src/world/world.ts
@@ -1,16 +1,40 @@
 import { createInitialWorldState } from './state';
 import { canMovePlayerTo } from './spatialRules';
-import type { World, WorldCommand, WorldState } from './types';
+import type { SpriteDirection, World, WorldCommand, WorldState } from './types';
+
+const toFacingDirectionFromMove = (dx: number, dy: number): SpriteDirection | undefined => {
+  if (dx < 0) {
+    return 'left';
+  }
+  if (dx > 0) {
+    return 'right';
+  }
+  if (dy < 0) {
+    return 'away';
+  }
+  if (dy > 0) {
+    return 'front';
+  }
+  return undefined;
+};
 
 const applyCommand = (worldState: WorldState, command: WorldCommand): WorldState => {
   if (command.type === 'move') {
+    const nextFacingDirection =
+      toFacingDirectionFromMove(command.dx, command.dy) ?? worldState.player.facingDirection ?? 'front';
     const nextPosition = {
       x: worldState.player.position.x + command.dx,
       y: worldState.player.position.y + command.dy,
     };
 
     if (!canMovePlayerTo(worldState, nextPosition)) {
-      return worldState;
+      return {
+        ...worldState,
+        player: {
+          ...worldState.player,
+          facingDirection: nextFacingDirection,
+        },
+      };
     }
 
     return {
@@ -18,6 +42,7 @@ const applyCommand = (worldState: WorldState, command: WorldCommand): WorldState
       player: {
         ...worldState.player,
         position: nextPosition,
+        facingDirection: nextFacingDirection,
       },
     };
   }


### PR DESCRIPTION
## Summary
- adds a deterministic `player.facingDirection` token in world state and initializes it to `front` for new sessions/level loads
- maps movement input intent to facing direction in world update logic (`left`, `right`, `away`, `front`), including blocked movement attempts
- updates render player sprite selection to consume the world-provided facing direction token while keeping non-player facing behavior unchanged
- adds tests for input-to-facing mapping, default front state, and player sprite selection outcomes

## Validation
- `npm test -- src/world/world.test.ts src/world/level.test.ts src/render/scene.test.ts src/integration/riddleLevel.test.ts`
- `npm run build`
- `npm test` *(currently fails in existing baseline test: `src/integration/starterLevel.test.ts` door position expectation mismatch unrelated to #92 changes)*

## Closes #92