### PR TITLE
#93 set guard directional sprite from player interaction approach direction

### DIFF
--- a/docs/GUARD_FACING_DIRECTION.md
+++ b/docs/GUARD_FACING_DIRECTION.md
@@ -1,0 +1,73 @@
+# Guard Facing Direction (Ticket #93)
+
+This note documents the guard-facing token flow introduced in ticket #93 and referenced by PR #96.
+
+## 1. Guard-facing world state and interaction-derived mapping
+
+Guard orientation is now represented as a world-owned, serializable token on each guard:
+
+- `guards[*].facingDirection?: SpriteDirection`
+- `SpriteDirection = 'front' | 'away' | 'left' | 'right'`
+
+The interaction layer derives this token when a guard interaction starts without a player message:
+
+- Mapping function: [src/interaction/guardFacing.ts](../src/interaction/guardFacing.ts)
+- Dispatch integration: [src/interaction/interactionDispatcher.ts](../src/interaction/interactionDispatcher.ts)
+
+Deterministic mapping from player approach position relative to the guard:
+
+- player west of guard (`deltaX = -1`, `deltaY = 0`) -> `left`
+- player east of guard (`deltaX = 1`, `deltaY = 0`) -> `right`
+- player north of guard (`deltaX = 0`, `deltaY = -1`) -> `away`
+- player south of guard (`deltaX = 0`, `deltaY = 1`) -> `front`
+
+Fallback behavior for non-orthogonal or unexpected positions:
+
+1. Keep existing `guard.facingDirection` when present.
+2. Otherwise default to `front`.
+
+On conversational open, the dispatcher returns `updatedWorldState` with the guard's facing token updated immutably before conversation UI side effects run (through result-dispatch world update ordering).
+
+## 2. Render consumption of guard-facing token
+
+Render now consumes `guard.facingDirection` for both sprite mode selection and sprite load requests.
+
+Primary entry points:
+
+- [src/render/scene.ts](../src/render/scene.ts)
+
+Behavior:
+
+- Guard sprite path resolution calls `resolveCharacterSpriteAssetPath(guard, guard.facingDirection ?? DEFAULT_RENDER_DIRECTION)`.
+- If a direction-specific sprite exists in `spriteSet`, that directional sprite is requested/used.
+- If directional key is missing, deterministic fallback order still applies in `resolveSpriteAssetPathForDirection(...)`.
+- If resolved assets are unavailable or failed, guard rendering falls back to marker mode without mutating world state.
+
+This preserves layer boundaries:
+
+- Interaction/world author the orientation token.
+- Render only consumes the token to resolve visual assets.
+
+## 3. Testing coverage updates for guard-facing behavior
+
+New and relevant tests:
+
+- [src/interaction/guardFacing.test.ts](../src/interaction/guardFacing.test.ts)
+- [src/interaction/interactionDispatcher.test.ts](../src/interaction/interactionDispatcher.test.ts)
+- [src/render/scene.test.ts](../src/render/scene.test.ts)
+
+Coverage highlights:
+
+- Full mapping validation for all four approach directions (`left`, `right`, `away`, `front`).
+- Guard facing is written on interaction start (sync chat-open path).
+- Guard facing stays stable across active conversational turns.
+- Render selects guard directional sprite mode from `guard.facingDirection` when directional assets are available.
+
+## Cross-layer summary
+
+Ticket #93 introduced a deterministic cross-layer contract:
+
+1. Interaction derives and stores guard-facing token in world state.
+2. Result dispatcher applies updated world state before opening conversation UI.
+3. Render uses the token to choose directional guard sprites.
+4. Tests cover mapping correctness, persistence timing, and render consumption.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory contains architecture guides, layer-specific documentation, and d
 ## Fundamentals
 - [System Architecture](ARCHITECTURE.md) - Layered architecture overview, design principles, and data flow
 - [Type Reference](TYPES_REFERENCE.md) - Complete reference for key interfaces and data structures used throughout the codebase
+- [Guard Facing Direction (Ticket #93)](GUARD_FACING_DIRECTION.md) - Guard-facing world token, interaction approach-direction mapping, render consumption, and test coverage
 
 ## Layer Guides
 Deep dives into each architectural layer and its responsibilities:

--- a/src/interaction/guardFacing.test.ts
+++ b/src/interaction/guardFacing.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { resolveGuardFacingFromApproach } from './guardFacing';
+
+describe('resolveGuardFacingFromApproach', () => {
+  const guard = { x: 5, y: 5 };
+
+  it('maps player west of guard to left', () => {
+    expect(resolveGuardFacingFromApproach({ x: 4, y: 5 }, guard)).toBe('left');
+  });
+
+  it('maps player east of guard to right', () => {
+    expect(resolveGuardFacingFromApproach({ x: 6, y: 5 }, guard)).toBe('right');
+  });
+
+  it('maps player north of guard to away', () => {
+    expect(resolveGuardFacingFromApproach({ x: 5, y: 4 }, guard)).toBe('away');
+  });
+
+  it('maps player south of guard to front', () => {
+    expect(resolveGuardFacingFromApproach({ x: 5, y: 6 }, guard)).toBe('front');
+  });
+
+  it('returns undefined for non-adjacent or diagonal positions', () => {
+    expect(resolveGuardFacingFromApproach({ x: 7, y: 5 }, guard)).toBeUndefined();
+    expect(resolveGuardFacingFromApproach({ x: 4, y: 4 }, guard)).toBeUndefined();
+  });
+});

--- a/src/interaction/guardFacing.ts
+++ b/src/interaction/guardFacing.ts
@@ -1,0 +1,28 @@
+import type { GridPosition, SpriteDirection } from '../world/types';
+
+/**
+ * Maps player approach position relative to a guard into the guard-facing token.
+ * Returns undefined for non-orthogonal or non-adjacent positions.
+ */
+export const resolveGuardFacingFromApproach = (
+  playerPosition: GridPosition,
+  guardPosition: GridPosition,
+): SpriteDirection | undefined => {
+  const deltaX = playerPosition.x - guardPosition.x;
+  const deltaY = playerPosition.y - guardPosition.y;
+
+  if (deltaX === -1 && deltaY === 0) {
+    return 'left';
+  }
+  if (deltaX === 1 && deltaY === 0) {
+    return 'right';
+  }
+  if (deltaX === 0 && deltaY === -1) {
+    return 'away';
+  }
+  if (deltaX === 0 && deltaY === 1) {
+    return 'front';
+  }
+
+  return undefined;
+};

--- a/src/interaction/interactionDispatcher.test.ts
+++ b/src/interaction/interactionDispatcher.test.ts
@@ -94,6 +94,111 @@ describe('InteractionDispatcher', () => {
       expect(result.isConversational).toBe(false); // Initial interaction
     });
 
+    it('sets guard facing on interaction start from player approach direction', () => {
+      const dispatcher = createInteractionDispatcher({ llmClient });
+
+      const westGuard = createTestGuard('guard-west');
+      const eastGuard = createTestGuard('guard-east');
+      const northGuard = createTestGuard('guard-north');
+      const southGuard = createTestGuard('guard-south');
+
+      const fromWestState = createTestWorldState({
+        player: { id: 'player', displayName: 'Player', position: { x: 0, y: 0 } },
+        guards: [{ ...westGuard, position: { x: 1, y: 0 } }],
+      });
+      const fromEastState = createTestWorldState({
+        player: { id: 'player', displayName: 'Player', position: { x: 2, y: 0 } },
+        guards: [{ ...eastGuard, position: { x: 1, y: 0 } }],
+      });
+      const fromNorthState = createTestWorldState({
+        player: { id: 'player', displayName: 'Player', position: { x: 1, y: -1 } },
+        guards: [{ ...northGuard, position: { x: 1, y: 0 } }],
+      });
+      const fromSouthState = createTestWorldState({
+        player: { id: 'player', displayName: 'Player', position: { x: 1, y: 1 } },
+        guards: [{ ...southGuard, position: { x: 1, y: 0 } }],
+      });
+
+      const westResult = dispatcher.dispatch(
+        { kind: 'guard' as const, target: fromWestState.guards[0] },
+        fromWestState,
+      );
+      const eastResult = dispatcher.dispatch(
+        { kind: 'guard' as const, target: fromEastState.guards[0] },
+        fromEastState,
+      );
+      const northResult = dispatcher.dispatch(
+        { kind: 'guard' as const, target: fromNorthState.guards[0] },
+        fromNorthState,
+      );
+      const southResult = dispatcher.dispatch(
+        { kind: 'guard' as const, target: fromSouthState.guards[0] },
+        fromSouthState,
+      );
+
+      expect(isPromiseLike(westResult)).toBe(false);
+      expect(isPromiseLike(eastResult)).toBe(false);
+      expect(isPromiseLike(northResult)).toBe(false);
+      expect(isPromiseLike(southResult)).toBe(false);
+      if (
+        isPromiseLike(westResult) ||
+        isPromiseLike(eastResult) ||
+        isPromiseLike(northResult) ||
+        isPromiseLike(southResult)
+      ) {
+        throw new Error('Expected guard interaction start to remain synchronous.');
+      }
+
+      expect(westResult.updatedWorldState?.guards[0]?.facingDirection).toBe('left');
+      expect(eastResult.updatedWorldState?.guards[0]?.facingDirection).toBe('right');
+      expect(northResult.updatedWorldState?.guards[0]?.facingDirection).toBe('away');
+      expect(southResult.updatedWorldState?.guards[0]?.facingDirection).toBe('front');
+    });
+
+    it('keeps guard facing stable during an active interaction turn', async () => {
+      const complete = llmClient.complete as ReturnType<typeof vi.fn>;
+      complete.mockResolvedValue({ text: 'At your service.' });
+
+      const dispatcher = createInteractionDispatcher({ llmClient });
+      const guard = { ...createTestGuard('guard-1'), position: { x: 1, y: 0 } };
+      const initialState = createTestWorldState({
+        player: { id: 'player', displayName: 'Player', position: { x: 0, y: 0 } },
+        guards: [guard],
+        actorConversationHistoryByActorId: { 'guard-1': [] },
+      });
+
+      const openResult = dispatcher.dispatch({ kind: 'guard', target: guard }, initialState);
+      if (isPromiseLike(openResult)) {
+        throw new Error('Expected interaction start to be synchronous.');
+      }
+
+      const openUpdatedState = openResult.updatedWorldState;
+      expect(openUpdatedState?.guards[0]?.facingDirection).toBe('left');
+      if (!openUpdatedState) {
+        throw new Error('Expected interaction start to provide updated world state.');
+      }
+
+      const movedPlayerState = {
+        ...openUpdatedState,
+        player: {
+          ...openUpdatedState.player,
+          position: { x: 1, y: 1 },
+        },
+      };
+
+      const conversationalResult = dispatcher.dispatch(
+        { kind: 'guard', target: movedPlayerState.guards[0] },
+        movedPlayerState,
+        'hello',
+      );
+      if (!isPromiseLike(conversationalResult)) {
+        throw new Error('Expected conversational guard interaction to be async.');
+      }
+
+      const resolved = await conversationalResult;
+      expect(resolved.updatedWorldState?.guards[0]?.facingDirection).toBe('left');
+    });
+
     it('dispatches door interactions', async () => {
       const dispatcher = createInteractionDispatcher({ llmClient });
       const door = createTestDoor('door-1');

--- a/src/interaction/interactionDispatcher.ts
+++ b/src/interaction/interactionDispatcher.ts
@@ -2,6 +2,7 @@ import type { LlmClient } from '../llm/client';
 import type { WorldState, ConversationMessage } from '../world/types';
 import type { AdjacentTarget } from './adjacencyResolver';
 import { handleDoorInteraction } from './doorInteraction';
+import { resolveGuardFacingFromApproach } from './guardFacing';
 import { createGuardInteractionService } from './guardInteraction';
 import { createNpcInteractionService } from './npcInteraction';
 import { handleInteractiveObjectInteraction } from './objectInteraction';
@@ -172,11 +173,23 @@ const createGuardHandler = (llmClient: LlmClient): ConditionalInteractionHandler
 
     // If no player message, just return initial state response (not conversational).
     if (!playerMessage) {
+      const guardFacingDirection =
+        resolveGuardFacingFromApproach(worldState.player.position, target.target.position) ??
+        target.target.facingDirection ??
+        'front';
+      const updatedWorldState: WorldState = {
+        ...worldState,
+        guards: worldState.guards.map((guard) =>
+          guard.id === target.target.id ? { ...guard, facingDirection: guardFacingDirection } : guard,
+        ),
+      };
+
       return {
         kind: 'guard',
         targetId: target.target.id,
         displayName: target.target.displayName,
         responseText: target.target.displayName, // Initial greeting in chat modal
+        updatedWorldState,
         isConversational: false,
       };
     }
@@ -356,8 +369,12 @@ const createConversationalResultHandler = (): ResultHandler => {
       throw new Error('Conversational result handler called with non-conversational result');
     }
 
-    const worldState = config.getCurrentWorldState();
-    const history = config.getConversationHistory(worldState, result.targetId);
+    const worldStateForConversation = result.updatedWorldState ?? config.getCurrentWorldState();
+    if (result.updatedWorldState) {
+      config.onWorldStateUpdated(result.updatedWorldState);
+    }
+
+    const history = config.getConversationHistory(worldStateForConversation, result.targetId);
 
     config.onConversationStarted(
       result.targetId,

--- a/src/render/scene.test.ts
+++ b/src/render/scene.test.ts
@@ -224,6 +224,31 @@ describe('render entity circle helpers', () => {
     expect(modes.npcsById['npc-1']).toBe('sprite');
   });
 
+  it('selects guard directional sprite from guard facing token', () => {
+    const worldState: WorldState = {
+      ...createWorldState(),
+      guards: [
+        {
+          ...createWorldState().guards[0],
+          facingDirection: 'right',
+          spriteSet: {
+            default: '/assets/medieval_guard_front.svg',
+            right: '/assets/medieval_guard_right.svg',
+          },
+        },
+      ],
+    };
+
+    const spriteStatuses = new Map([
+      ['/assets/medieval_guard_front.svg', 'failed' as const],
+      ['/assets/medieval_guard_right.svg', 'loaded' as const],
+    ]);
+
+    const modes = buildCharacterRenderModes(worldState, spriteStatuses);
+
+    expect(modes.guardsById['guard-1']).toBe('sprite');
+  });
+
   it('defaults player sprite direction selection to front when no directional input has occurred', () => {
     const worldState: WorldState = {
       ...createWorldState(),

--- a/src/render/scene.ts
+++ b/src/render/scene.ts
@@ -94,7 +94,7 @@ export const buildCharacterRenderModes = (
   const guardsById: Record<string, CharacterRenderMode> = {};
   for (const guard of worldState.guards) {
     guardsById[guard.id] = getCharacterRenderMode(
-      resolveCharacterSpriteAssetPath(guard),
+      resolveCharacterSpriteAssetPath(guard, guard.facingDirection ?? DEFAULT_RENDER_DIRECTION),
       spriteLoadStatusByPath,
     );
   }
@@ -212,7 +212,10 @@ const requestCharacterSpriteLoads = (context: RenderContext, worldState: WorldSt
     characterSpritePaths.add(playerSpritePath);
   }
   for (const guard of worldState.guards) {
-    const spritePath = resolveCharacterSpriteAssetPath(guard);
+    const spritePath = resolveCharacterSpriteAssetPath(
+      guard,
+      guard.facingDirection ?? DEFAULT_RENDER_DIRECTION,
+    );
     if (spritePath !== undefined) {
       characterSpritePaths.add(spritePath);
     }
@@ -288,7 +291,10 @@ const syncCharacterSprites = (
   }
 
   for (const guard of worldState.guards) {
-    const spritePath = resolveCharacterSpriteAssetPath(guard);
+    const spritePath = resolveCharacterSpriteAssetPath(
+      guard,
+      guard.facingDirection ?? DEFAULT_RENDER_DIRECTION,
+    );
     if (characterRenderModes.guardsById[guard.id] !== 'sprite' || spritePath === undefined) {
       continue;
     }

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -54,6 +54,7 @@ export interface Interactable {
 export interface Guard extends Interactable {
   guardState: 'idle' | 'patrolling' | 'alert';
   honestyTrait?: 'truth-teller' | 'liar';
+  facingDirection?: SpriteDirection;
   spriteAssetPath?: string;
   spriteSet?: SpriteSet;
 }


### PR DESCRIPTION
## Summary
- add deterministic interaction-layer mapping from player approach side to guard facing token (`left`, `right`, `away`, `front`)
- set and persist guard `facingDirection` in world state at guard interaction start
- apply updated world state before opening conversational UI so render sees the facing token immediately
- make render guard sprite selection/path loading respect guard-facing token
- add tests for all four mappings, interaction-start update + stability during active interaction, and render directional selection

## Validation
- `npm test -- src/interaction/guardFacing.test.ts src/interaction/interactionDispatcher.test.ts src/render/scene.test.ts`
- `npm run build`
- `npm test` (one existing unrelated failure in `src/integration/starterLevel.test.ts`: expected `door-1` at `{x:2,y:10}` but level data resolves `{x:4,y:10}`)

## Closes #93