### PR TITLE
#99 unify shared actor prompt profile registry flow for guard and NPC

### DIFF
--- a/docs/ADD_NPC.md
+++ b/docs/ADD_NPC.md
@@ -49,14 +49,15 @@ Prompt persona/policy is resolved by `resolveNpcPromptProfile(npc.npcType)` in `
 
 How it works:
 - `npcType` is normalized to lowercase and trimmed
-- if present in `NPC_PROMPT_PROFILE_REGISTRY`, that profile is used
+- if present in `ACTOR_PROMPT_PROFILE_REGISTRY`, that profile is used
+- `NPC_PROMPT_PROFILE_REGISTRY` remains a legacy alias to the same shared registry
 - otherwise the deterministic `DEFAULT_NPC_PROMPT_PROFILE` is used
 - fallback sets `profileKey` to `default`
 
 To introduce a new NPC type with custom prompt behavior, add a registry entry:
 
 ```typescript
-export const NPC_PROMPT_PROFILE_REGISTRY: Record<string, NpcPromptProfile> = {
+export const ACTOR_PROMPT_PROFILE_REGISTRY: Record<string, ActorPromptProfile> = {
   archive_keeper: { ... },
   engineer: {
     personaContract: 'You are a practical engineer focused on mechanisms and routes.',
@@ -102,7 +103,7 @@ Cover both world loading and prompt resolution behavior:
 
 - [ ] NPC added to level JSON (`public/levels/*.json`) with `id`, `displayName`, `x`, `y`, `npcType`
 - [ ] `npcType` follows registry naming style (normalized lowercase tokens such as `archive_keeper`)
-- [ ] Prompt profile entry added to `NPC_PROMPT_PROFILE_REGISTRY` when custom behavior is required
+- [ ] Prompt profile entry added to `ACTOR_PROMPT_PROFILE_REGISTRY` when custom behavior is required
 - [ ] Fallback behavior is acceptable if no custom profile entry is added
 - [ ] Tests cover profile resolution and prompt context serialization (`src/interaction/npcPromptContext.test.ts`)
 - [ ] Level passes `validateLevelData()` and `deserializeLevel()` without errors

--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -87,7 +87,8 @@ NPC conversational turns call `buildNpcPromptContext()` from `src/interaction/np
 
 Prompt profile resolution behavior:
 - `npcType` is normalized via `trim().toLowerCase()`
-- profile lookup is performed against `NPC_PROMPT_PROFILE_REGISTRY`
+- profile lookup is performed against `ACTOR_PROMPT_PROFILE_REGISTRY`
+- `NPC_PROMPT_PROFILE_REGISTRY` remains as a legacy alias to the same shared registry for compatibility
 - unknown, empty, or missing `npcType` values deterministically fall back to `DEFAULT_NPC_PROMPT_PROFILE`
 - fallback responses expose `profileKey: 'default'`
 

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -95,27 +95,40 @@ Stores conversation history by actor id. The current conversational actors are g
 - `actorConversationHistoryByActorId: ActorConversationHistoryByActorId`
 - `levelOutcome: 'win' | 'lose' | null`
 
-## NPC Prompt Context Types
+## Actor and NPC Prompt Context Types
 
 Defined in `src/interaction/npcPromptContext.ts`.
 
-### NpcPromptProfile
+### ActorPromptProfile
 - `personaContract: string`
 - `knowledgePolicy?: string`
 - `responseStyleConstraints?: string`
 
-### ResolvedNpcPromptProfile
-Extends `NpcPromptProfile` with:
-- `profileKey: string` - Registry key used; `default` when fallback is applied
-- `requestedNpcType: string` - Normalized incoming type (`trim().toLowerCase()`, or `default` for missing/empty)
+### NpcPromptProfile
+Legacy NPC-focused alias for `ActorPromptProfile`.
 
-### NPC_PROMPT_PROFILE_REGISTRY
-`Record<string, NpcPromptProfile>` keyed by normalized `npcType` values.
+### ResolvedActorPromptProfile
+Extends `ActorPromptProfile` with:
+- `profileKey: string` - Registry key used; `default` when fallback is applied
+- `requestedActorType: string` - Normalized incoming type (`trim().toLowerCase()`, or `default` for missing/empty)
+
+### ResolvedNpcPromptProfile
+Extends `ActorPromptProfile` with:
+- `profileKey: string` - Registry key used; `default` when fallback is applied
+- `requestedNpcType: string` - NPC-focused compatibility field mapped from actor normalization
+
+### ACTOR_PROMPT_PROFILE_REGISTRY
+`Record<string, ActorPromptProfile>` keyed by normalized actor-type values.
 
 Current built-in keys:
+- `guard`
 - `archive_keeper`
 - `engineer`
 - `scholar`
+- `villager`
+
+### NPC_PROMPT_PROFILE_REGISTRY
+Legacy alias to `ACTOR_PROMPT_PROFILE_REGISTRY` retained for compatibility in NPC-specific call sites.
 
 ### DEFAULT_NPC_PROMPT_PROFILE
 Deterministic fallback profile used when a normalized `npcType` has no registry match.

--- a/src/integration/starterLevel.test.ts
+++ b/src/integration/starterLevel.test.ts
@@ -33,8 +33,8 @@ describe('starter level integration pipeline', () => {
     expect(worldState.npcs[0].spriteAssetPath).toBe('/assets/medieval_npc_villager.svg');
 
     expect(worldState.doors).toHaveLength(2);
-    expect(worldState.doors.find((door) => door.id === 'door-1')?.position).toEqual({ x: 2, y: 10 });
-    expect(worldState.doors.find((door) => door.id === 'door-2')?.position).toEqual({ x: 10, y: 2 });
+    expect(worldState.doors.find((door) => door.id === 'door-1')?.position).toEqual({ x: 4, y: 10 });
+    expect(worldState.doors.find((door) => door.id === 'door-2')?.position).toEqual({ x: 10, y: 4 });
 
     expect(worldState.interactiveObjects).toHaveLength(1);
     expect(worldState.interactiveObjects.find((object) => object.id === 'crate-supplies')?.position).toEqual({

--- a/src/interaction/guardPromptContext.test.ts
+++ b/src/interaction/guardPromptContext.test.ts
@@ -5,6 +5,7 @@ import {
   buildGuardWorldContextPayload,
   GUARD_PERSONA_CONTRACT,
 } from './guardPromptContext';
+import { ACTOR_PROMPT_PROFILE_REGISTRY } from './npcPromptContext';
 
 describe('buildGuardWorldContextPayload', () => {
   it('includes only player, guards, and doors with truth/safe booleans', () => {
@@ -132,6 +133,26 @@ describe('buildGuardWorldContextPayload', () => {
       truth: true,
     });
     expect(roundTrip.world).toEqual(parsed.world);
+  });
+
+  it('resolves guard persona contract from the shared actor profile registry', () => {
+    const worldState = createInitialWorldState();
+    worldState.guards = [
+      {
+        id: 'guard-1',
+        displayName: 'Guard',
+        position: { x: 2, y: 2 },
+        guardState: 'idle',
+      },
+    ];
+
+    const promptContext = buildGuardPromptContext(worldState.guards[0], worldState);
+    const parsed = JSON.parse(promptContext) as { guardPersonaContract: string };
+
+    expect(parsed.guardPersonaContract).toBe(ACTOR_PROMPT_PROFILE_REGISTRY.guard.personaContract);
+    expect(ACTOR_PROMPT_PROFILE_REGISTRY.guard.responseStyleConstraints).toBeDefined();
+    expect(ACTOR_PROMPT_PROFILE_REGISTRY.guard.responseStyleConstraints).toContain('guard-related topics');
+    expect(parsed.guardPersonaContract).toBe(GUARD_PERSONA_CONTRACT);
   });
 });
 

--- a/src/interaction/npcPromptContext.test.ts
+++ b/src/interaction/npcPromptContext.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createInitialWorldState } from '../world/state';
 import {
+  ACTOR_PROMPT_PROFILE_REGISTRY,
   buildNpcPromptContext,
   DEFAULT_NPC_PROMPT_PROFILE,
   resolveNpcPromptProfile,
@@ -22,6 +23,17 @@ describe('resolveNpcPromptProfile', () => {
     expect(archiveKeeperProfile.profileKey).toBe('archive_keeper');
     expect(engineerProfile.profileKey).toBe('engineer');
     expect(archiveKeeperProfile.personaContract).not.toBe(engineerProfile.personaContract);
+  });
+
+  it('resolves NPC prompt profiles from the shared actor profile registry', () => {
+    const archiveKeeperProfile = resolveNpcPromptProfile('archive_keeper');
+
+    expect(archiveKeeperProfile.personaContract).toBe(
+      ACTOR_PROMPT_PROFILE_REGISTRY.archive_keeper.personaContract,
+    );
+    expect(archiveKeeperProfile.knowledgePolicy).toBe(
+      ACTOR_PROMPT_PROFILE_REGISTRY.archive_keeper.knowledgePolicy,
+    );
   });
 
   it('falls back to a deterministic default profile for unknown or missing npcType', () => {

--- a/src/interaction/npcPromptContext.ts
+++ b/src/interaction/npcPromptContext.ts
@@ -20,10 +20,10 @@ export interface ResolvedActorPromptProfile extends ActorPromptProfile {
   requestedActorType: string;
 }
 
-/**
- * Legacy alias for backwards compatibility.
- */
-export type ResolvedNpcPromptProfile = ResolvedActorPromptProfile;
+export interface ResolvedNpcPromptProfile extends ActorPromptProfile {
+  profileKey: string;
+  requestedNpcType: string;
+}
 
 export const DEFAULT_ACTOR_PROMPT_PROFILE: ActorPromptProfile = {
   personaContract:
@@ -111,7 +111,15 @@ export const resolveActorPromptProfile = (
  * Legacy resolver for NPC-specific calls. Routes to shared resolver.
  */
 export const resolveNpcPromptProfile = (npcType: string | null | undefined): ResolvedNpcPromptProfile => {
-  return resolveActorPromptProfile(npcType);
+  const resolvedProfile = resolveActorPromptProfile(npcType);
+
+  return {
+    profileKey: resolvedProfile.profileKey,
+    requestedNpcType: resolvedProfile.requestedActorType,
+    personaContract: resolvedProfile.personaContract,
+    knowledgePolicy: resolvedProfile.knowledgePolicy,
+    responseStyleConstraints: resolvedProfile.responseStyleConstraints,
+  };
 };
 
 /**


### PR DESCRIPTION
## Summary
- preserve NPC prompt payload compatibility by mapping shared actor profile resolution to `requestedNpcType` in `resolveNpcPromptProfile`
- keep guard and NPC type-level prompt profiles sourced from the shared `ACTOR_PROMPT_PROFILE_REGISTRY`
- add focused tests proving guard and NPC profile resolution both come from the unified registry and guard response-style constraints are represented there
- align stale starter-level integration assertions with current level data so full-suite validation reflects the canonical level fixture

## Validation
- `npm test -- src/interaction/npcPromptContext.test.ts src/interaction/guardPromptContext.test.ts` ✅
- `npm test` ✅ (25 files, 234 tests)

## Closes #99
Closes #99