### PR TITLE
#98 add actor-type world-knowledge builder registry

### DIFF
--- a/docs/ADD_NPC.md
+++ b/docs/ADD_NPC.md
@@ -69,8 +69,10 @@ export const ACTOR_PROMPT_PROFILE_REGISTRY: Record<string, ActorPromptProfile> =
 
 If no registry entry exists for the NPC's type, behavior remains valid via default fallback.
 
+**World knowledge builders are separate from prompt profiles.** If the new NPC type needs type-specific world facts in its prompt context (e.g., knowledge of other nearby actors), add a builder entry to `ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS` in `src/interaction/npcPromptContext.ts`. If the new type should share world knowledge with an existing type, add an alias entry to `ACTOR_WORLD_KNOWLEDGE_BUILDER_ALIASES` instead (e.g., `new_type: 'villager'`). NPC types without a builder or alias receive no `typeWorldKnowledge` in their prompt context, which is valid default behavior.
+
 ### 4. Understand Prompt Context Construction
-`buildNpcPromptContext(npc, player)` returns deterministic JSON with this shape:
+`buildNpcPromptContext(npc, player, worldState)` returns deterministic JSON with this shape:
 
 ```json
 {
@@ -87,17 +89,23 @@ If no registry entry exists for the NPC's type, behavior remains valid via defau
     "position": { "x": 8, "y": 5 },
     "dialogueContextKey": "npc_archive_keeper"
   },
+  "typeWorldKnowledge": {
+    "player": { "id": "player", "position": { "x": 1, "y": 1 } },
+    "otherVillagers": []
+  },
   "player": { "id": "player", "displayName": "Player" }
 }
 ```
 
-This keeps shared type-level prompt behavior (`npcProfile`) separate from per-instance fields (`npcInstance`).
+`typeWorldKnowledge` is present here because `archive_keeper` is aliased to the `villager` builder via `ACTOR_WORLD_KNOWLEDGE_BUILDER_ALIASES`. The `villager` builder provides a `{ player, otherVillagers[] }` payload, excluding the requesting actor from `otherVillagers`.
+
+This keeps shared type-level prompt behavior (`npcProfile`) separate from per-instance fields (`npcInstance`) and type-scoped world context (`typeWorldKnowledge`).
 
 ### 5. Add Tests
 Cover both world loading and prompt resolution behavior:
 - `src/world/level.test.ts`: NPC deserialization and derived `dialogueContextKey`
 - `src/interaction/npcPromptContext.test.ts`: same-type reuse, cross-type differentiation, deterministic fallback, and deterministic serialized context
-- `src/interaction/npcInteraction.test.ts`: context passed to LLM includes expected actor/profile/instance/player sections
+- `src/interaction/npcInteraction.test.ts`: context passed to LLM includes expected actor/profile/instance/typeWorldKnowledge/player sections
 
 ## Checklist
 
@@ -105,6 +113,7 @@ Cover both world loading and prompt resolution behavior:
 - [ ] `npcType` follows registry naming style (normalized lowercase tokens such as `archive_keeper`)
 - [ ] Prompt profile entry added to `ACTOR_PROMPT_PROFILE_REGISTRY` when custom behavior is required
 - [ ] Fallback behavior is acceptable if no custom profile entry is added
+- [ ] World knowledge builder added to `ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS`, or alias added to `ACTOR_WORLD_KNOWLEDGE_BUILDER_ALIASES`, when type-specific world context is required; omitting both is valid when no world context is needed
 - [ ] Tests cover profile resolution and prompt context serialization (`src/interaction/npcPromptContext.test.ts`)
 - [ ] Level passes `validateLevelData()` and `deserializeLevel()` without errors
 - [ ] NPC position does not overlap with other entities (validated by `validateSpatialLayout()`)

--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -81,24 +81,48 @@ Door and interactive object results never trigger `onConversationStarted`, so th
 
 Gameplay pause state is kept outside `WorldState`. UI pause presentation is also transient render-layer DOM state. Neither belongs in serialized world state or LLM context.
 
-## NPC Prompt Profile Context
+## Actor Prompt Context
 
-NPC conversational turns call `buildNpcPromptContext()` from `src/interaction/npcPromptContext.ts`.
+NPC and guard conversational turns build prompt context through `src/interaction/npcPromptContext.ts` (shared builders) and `src/interaction/guardPromptContext.ts`.
 
-Prompt profile resolution behavior:
+### Prompt Profile Resolution
+
+Prompt profile resolution behavior (shared by all actor types):
 - `npcType` is normalized via `trim().toLowerCase()`
 - profile lookup is performed against `ACTOR_PROMPT_PROFILE_REGISTRY`
 - `NPC_PROMPT_PROFILE_REGISTRY` remains as a legacy alias to the same shared registry for compatibility
 - unknown, empty, or missing `npcType` values deterministically fall back to `DEFAULT_NPC_PROMPT_PROFILE`
 - fallback responses expose `profileKey: 'default'`
 
-The serialized prompt context includes four top-level sections:
+### World Knowledge Builder Registry
+
+World knowledge is resolved separately from prompt profiles via `buildActorTypeWorldKnowledge(actorType, worldState, actorId)` in `src/interaction/npcPromptContext.ts`. Both `buildGuardPromptContext` and `buildNpcPromptContext` route through this function.
+
+Resolution order:
+1. Normalize `actorType` via `trim().toLowerCase()`
+2. Look up a builder directly in `ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS`
+3. If not found, check `ACTOR_WORLD_KNOWLEDGE_BUILDER_ALIASES` and resolve to the alias target's builder
+4. If neither resolves, return `null` — `typeWorldKnowledge` is omitted from the context deterministically
+
+Current registry keys and payload shapes:
+- `guard`: `{ player, guards[], doors[] }` — all guards/doors with truth and outcome flags
+- `villager`: `{ player, otherVillagers[] }` — other villagers in the level, excluding the requesting actor by `actorId`
+
+Current aliases:
+- `archive_keeper → villager`
+
+Unknown actor types produce `null` and omit `typeWorldKnowledge` without throwing.
+
+### NPC Prompt Context Shape
+
+`buildNpcPromptContext(npc, player, worldState)` returns serialized JSON with up to five sections:
 - `actor`: stable actor identifier and raw `npcType`
 - `npcProfile`: resolved shared profile (`profileKey`, `requestedNpcType`, persona/knowledge/style constraints)
 - `npcInstance`: per-instance data (`displayName`, `position`, `dialogueContextKey`)
+- `typeWorldKnowledge` _(conditional)_: actor-type-specific world facts; present only when `buildActorTypeWorldKnowledge` returns a non-null value
 - `player`: player identifier and display name
 
-This split keeps shared type-level prompt policy separate from per-instance world facts.
+This split keeps shared type-level prompt policy (`npcProfile`) separate from per-instance world facts (`npcInstance`) and type-scoped world context (`typeWorldKnowledge`).
 
 ## Behavior Parity Expectations
 
@@ -130,7 +154,7 @@ See `src/interaction/guardInteraction.ts`, `src/interaction/npcInteraction.ts`, 
 
 - `src/interaction/interactionDispatcher.test.ts`: dispatch routing by kind, sync/async behavior parity, result dispatcher timing parity, door/object non-pause guarantee
 - `src/runtimeController.test.ts`: pause entry/exit lifecycle, command gating while paused, resume without command leak, level-outcome gating independent of pause state
-- `src/interaction/npcPromptContext.test.ts`: profile registry resolution, deterministic fallback, context shape determinism
+- `src/interaction/npcPromptContext.test.ts`: profile registry resolution, deterministic fallback, world knowledge builder registry keys, alias resolution (`archive_keeper → villager`), self-exclusion from `otherVillagers`, unknown-type `null` fallback, context shape determinism
 - `src/interaction/objectInteraction.test.ts`: object-type dispatcher behavior, first-use outcomes, repeat interactions
 - `src/integration/starterLevel.test.ts`: end-to-end adjacent object resolution and state updates
 - `src/interaction/adjacencyResolver.test.ts`: deterministic target resolution with interactive objects

--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -29,13 +29,14 @@ The interaction layer is responsible for building `context` and maintaining conv
 ## NPC Prompt Context Flow
 
 For NPC conversational turns:
-1. `createNpcInteractionService()` in `src/interaction/npcInteraction.ts` builds context with `buildNpcPromptContext(npc, player)`.
+1. `createNpcInteractionService()` in `src/interaction/npcInteraction.ts` builds context with `buildNpcPromptContext(npc, player, worldState)`.
 2. The service passes actor id, context, player message, and history into `llmClient.complete(...)`.
 3. The LLM response text is appended to actor-scoped history.
 
-`buildNpcPromptContext()` includes both:
+`buildNpcPromptContext()` includes:
 - shared profile information (`npcProfile`) resolved from `npcType`
 - per-instance NPC data (`npcInstance`) from world state
+- actor-type world context (`typeWorldKnowledge`) when a builder resolves for the `npcType`
 
 ## Deterministic Fallbacks
 

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -135,13 +135,35 @@ Deterministic fallback profile used when a normalized `npcType` has no registry 
 
 ## Prompt Context Shape
 
-`buildNpcPromptContext(npc, player)` returns a serialized JSON object with:
+`buildNpcPromptContext(npc, player, worldState)` returns a serialized JSON object with:
 - `actor: { id, npcType }`
 - `npcProfile: ResolvedNpcPromptProfile`
 - `npcInstance: { displayName, position: { x, y }, dialogueContextKey }`
+- `typeWorldKnowledge?: unknown` — actor-type-specific world facts; omitted when `buildActorTypeWorldKnowledge` returns `null`
 - `player: { id, displayName }`
 
-This separates shared type-level prompt policy (`npcProfile`) from per-instance world facts (`npcInstance`).
+This separates shared type-level prompt policy (`npcProfile`) from per-instance world facts (`npcInstance`) and type-scoped world context (`typeWorldKnowledge`).
+
+### ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS
+
+`Record<string, ActorTypeWorldKnowledgeBuilder>` — registry of world knowledge builders keyed by normalized actor-type values.
+
+Current entries and payload shapes:
+- `guard`: `{ player, guards[], doors[] }` — all guards/doors with truth and outcome flags
+- `villager`: `{ player, otherVillagers[] }` — other villagers in the level, excluding the requesting actor
+
+### ACTOR_WORLD_KNOWLEDGE_BUILDER_ALIASES
+
+`Record<string, string>` — maps actor types without a direct registry entry to an existing builder key.
+
+Current entries:
+- `archive_keeper → villager`
+
+### buildActorTypeWorldKnowledge
+
+`buildActorTypeWorldKnowledge(actorType, worldState, actorId): unknown | null`
+
+Resolves the world knowledge builder for `actorType` (checking `ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS` first, then `ACTOR_WORLD_KNOWLEDGE_BUILDER_ALIASES`) and invokes it with `worldState` and `actorId`. Returns `null` when no builder resolves. Called by both `buildGuardPromptContext` and `buildNpcPromptContext`.
 
 ## Level File Shape
 

--- a/src/interaction/guardPromptContext.ts
+++ b/src/interaction/guardPromptContext.ts
@@ -1,5 +1,9 @@
 import type { Guard, WorldState } from '../world/types';
-import { resolveActorPromptProfile, ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS } from './npcPromptContext';
+import {
+  ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS,
+  buildActorTypeWorldKnowledge,
+  resolveActorPromptProfile,
+} from './npcPromptContext';
 
 /**
  * Legacy export for backwards compatibility.
@@ -38,8 +42,6 @@ export interface GuardWorldContextPayload {
   }>;
 }
 
-const compareById = <T extends { id: string }>(a: T, b: T): number => a.id.localeCompare(b.id);
-
 /**
  * Legacy function for backwards compatibility.
  * Now wraps the guard world knowledge builder from the registry.
@@ -61,13 +63,11 @@ export const buildGuardWorldContextPayload = (worldState: WorldState): GuardWorl
 
 export const buildGuardPromptContext = (guard: Guard, worldState: WorldState): string => {
   const guardProfile = resolveActorPromptProfile('guard');
-  const worldKnowledgeBuilder = ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS['guard'];
+  const worldKnowledge = buildActorTypeWorldKnowledge('guard', worldState, guard.id);
 
-  if (!worldKnowledgeBuilder) {
+  if (worldKnowledge === null) {
     throw new Error('Guard world knowledge builder not found in registry');
   }
-
-  const worldKnowledge = worldKnowledgeBuilder(worldState, guard.id);
 
   return JSON.stringify({
     guard: {

--- a/src/interaction/npcPromptContext.test.ts
+++ b/src/interaction/npcPromptContext.test.ts
@@ -106,6 +106,21 @@ describe('buildNpcPromptContext', () => {
 
     expect(context.typeWorldKnowledge).toBeDefined();
     expect(context.typeWorldKnowledge?.otherVillagers).toBeDefined();
+    expect(context.typeWorldKnowledge?.otherVillagers).toHaveLength(1);
+  });
+
+  it('reuses the non-guard world-knowledge builder for active runtime archive_keeper NPCs', () => {
+    const worldState = createInitialWorldState();
+    const archiveKeeper = worldState.npcs[0];
+
+    const context = JSON.parse(buildNpcPromptContext(archiveKeeper, worldState.player, worldState)) as {
+      actor: { npcType: string };
+      typeWorldKnowledge?: { player: unknown; otherVillagers: unknown[] };
+    };
+
+    expect(context.actor.npcType).toBe('archive_keeper');
+    expect(context.typeWorldKnowledge).toBeDefined();
+    expect(context.typeWorldKnowledge?.otherVillagers).toEqual([]);
   });
 
   it('uses a deterministic unknown-type fallback with no typeWorldKnowledge payload', () => {
@@ -183,5 +198,30 @@ describe('buildNpcPromptContext', () => {
 
   it('contains exactly guard and one non-guard builder in the actor-type world-knowledge registry', () => {
     expect(Object.keys(ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS).sort()).toEqual(['guard', 'villager']);
+  });
+
+  it('excludes the requesting villager from otherVillagers world knowledge', () => {
+    const worldState = createInitialWorldState();
+    const requestingVillager = {
+      ...worldState.npcs[0],
+      id: 'npc-villager-1',
+      npcType: 'villager',
+    };
+    const otherVillager = {
+      ...requestingVillager,
+      id: 'npc-villager-2',
+      displayName: 'Neighbor Villager',
+      position: { x: 3, y: 2 },
+    };
+    worldState.npcs = [requestingVillager, otherVillager];
+
+    const worldKnowledge = buildActorTypeWorldKnowledge(
+      requestingVillager.npcType,
+      worldState,
+      requestingVillager.id,
+    ) as { otherVillagers: Array<{ id: string }> };
+
+    expect(worldKnowledge.otherVillagers).toHaveLength(1);
+    expect(worldKnowledge.otherVillagers[0].id).toBe('npc-villager-2');
   });
 });

--- a/src/interaction/npcPromptContext.test.ts
+++ b/src/interaction/npcPromptContext.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { createInitialWorldState } from '../world/state';
 import {
+  ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS,
   ACTOR_PROMPT_PROFILE_REGISTRY,
+  buildActorTypeWorldKnowledge,
   buildNpcPromptContext,
   DEFAULT_NPC_PROMPT_PROFILE,
   resolveNpcPromptProfile,
 } from './npcPromptContext';
+import { buildGuardPromptContext } from './guardPromptContext';
 
 describe('resolveNpcPromptProfile', () => {
   it('returns the same profile contract for different NPCs with the same npcType', () => {
@@ -80,14 +83,89 @@ describe('buildNpcPromptContext', () => {
 
   it('includes typeWorldKnowledge in context for known actor types', () => {
     const worldState = createInitialWorldState();
-    const archiveKeeperNpc = worldState.npcs[0]; // archive_keeper type
+    const villagerNpc = {
+      ...worldState.npcs[0],
+      id: 'npc-villager-1',
+      displayName: 'Local Villager',
+      npcType: 'villager',
+      dialogueContextKey: 'villager_intro',
+    };
+    worldState.npcs = [
+      villagerNpc,
+      {
+        ...villagerNpc,
+        id: 'npc-villager-2',
+        displayName: 'Neighbor Villager',
+        position: { x: 3, y: 2 },
+      },
+    ];
 
-    const context = JSON.parse(buildNpcPromptContext(archiveKeeperNpc, worldState.player, worldState)) as {
-      typeWorldKnowledge?: { player: unknown; archives: unknown[] };
+    const context = JSON.parse(buildNpcPromptContext(villagerNpc, worldState.player, worldState)) as {
+      typeWorldKnowledge?: { player: unknown; otherVillagers: unknown[] };
     };
 
     expect(context.typeWorldKnowledge).toBeDefined();
-    expect(context.typeWorldKnowledge?.archives).toBeDefined();
+    expect(context.typeWorldKnowledge?.otherVillagers).toBeDefined();
+  });
+
+  it('uses a deterministic unknown-type fallback with no typeWorldKnowledge payload', () => {
+    const worldState = createInitialWorldState();
+    const unknownNpc = {
+      ...worldState.npcs[0],
+      id: 'npc-unknown-1',
+      npcType: 'mystery_type',
+    };
+
+    const first = buildNpcPromptContext(unknownNpc, worldState.player, worldState);
+    const second = buildNpcPromptContext(unknownNpc, worldState.player, worldState);
+    const parsed = JSON.parse(first) as { typeWorldKnowledge?: unknown };
+
+    expect(first).toBe(second);
+    expect(parsed.typeWorldKnowledge).toBeUndefined();
+    expect(buildActorTypeWorldKnowledge('mystery_type', worldState, unknownNpc.id)).toBeNull();
+  });
+
+  it('provides different world payload shapes for guard and villager actor types', () => {
+    const worldState = createInitialWorldState();
+    worldState.guards = [
+      {
+        id: 'guard-1',
+        displayName: 'City Guard',
+        position: { x: 1, y: 1 },
+        guardState: 'idle',
+      },
+    ];
+    worldState.doors = [
+      {
+        id: 'door-1',
+        displayName: 'North Door',
+        position: { x: 2, y: 1 },
+        doorState: 'closed',
+        outcome: 'safe',
+      },
+    ];
+
+    const villagerNpc = {
+      ...worldState.npcs[0],
+      id: 'npc-villager-1',
+      npcType: 'villager',
+    };
+    worldState.npcs = [villagerNpc];
+
+    const guardContext = JSON.parse(buildGuardPromptContext(worldState.guards[0], worldState)) as {
+      world: { guards?: unknown[]; doors?: unknown[]; otherVillagers?: unknown[] };
+    };
+    const villagerContext = JSON.parse(buildNpcPromptContext(villagerNpc, worldState.player, worldState)) as {
+      typeWorldKnowledge?: { guards?: unknown[]; doors?: unknown[]; otherVillagers?: unknown[] };
+    };
+
+    expect(guardContext.world.guards).toBeDefined();
+    expect(guardContext.world.doors).toBeDefined();
+    expect(guardContext.world.otherVillagers).toBeUndefined();
+
+    expect(villagerContext.typeWorldKnowledge?.otherVillagers).toBeDefined();
+    expect(villagerContext.typeWorldKnowledge?.guards).toBeUndefined();
+    expect(villagerContext.typeWorldKnowledge?.doors).toBeUndefined();
   });
 
   it('produces deterministic serialized output for the same NPC snapshot', () => {
@@ -101,5 +179,9 @@ describe('buildNpcPromptContext', () => {
 
     expect(first).toBe(second);
     expect(first).toBe(third);
+  });
+
+  it('contains exactly guard and one non-guard builder in the actor-type world-knowledge registry', () => {
+    expect(Object.keys(ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS).sort()).toEqual(['guard', 'villager']);
   });
 });

--- a/src/interaction/npcPromptContext.ts
+++ b/src/interaction/npcPromptContext.ts
@@ -167,10 +167,10 @@ export const ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS: Record<string, ActorTypeWorldK
     };
   },
 
-  villager: (worldState: WorldState): unknown => {
+  villager: (worldState: WorldState, actorId: string): unknown => {
     // Villagers know about other NPCs in the world
     const npcs = [...worldState.npcs]
-      .filter((npc) => npc.npcType === 'villager')
+      .filter((npc) => npc.npcType === 'villager' && npc.id !== actorId)
       .sort((a, b) => a.id.localeCompare(b.id))
       .map((npc) => ({
         id: npc.id,
@@ -189,6 +189,10 @@ export const ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS: Record<string, ActorTypeWorldK
   },
 };
 
+const ACTOR_WORLD_KNOWLEDGE_BUILDER_ALIASES: Record<string, string> = {
+  archive_keeper: 'villager',
+};
+
 /**
  * Resolve world knowledge for an actor type. Returns a builder function or undefined if not found.
  */
@@ -196,7 +200,12 @@ const resolveActorWorldKnowledgeBuilder = (
   actorType: string | null | undefined,
 ): ActorTypeWorldKnowledgeBuilder | undefined => {
   const normalizedType = normalizeActorType(actorType);
-  return ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS[normalizedType];
+  const actorTypeKey =
+    ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS[normalizedType] !== undefined
+      ? normalizedType
+      : ACTOR_WORLD_KNOWLEDGE_BUILDER_ALIASES[normalizedType];
+
+  return actorTypeKey ? ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS[actorTypeKey] : undefined;
 };
 
 export const buildActorTypeWorldKnowledge = (

--- a/src/interaction/npcPromptContext.ts
+++ b/src/interaction/npcPromptContext.ts
@@ -139,7 +139,7 @@ export type ActorTypeWorldKnowledgeBuilder = (
 export const ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS: Record<string, ActorTypeWorldKnowledgeBuilder> = {
   guard: (worldState: WorldState): unknown => {
     // Guards know about other guards, doors, and the player
-    const guides = [...worldState.guards]
+    const guards = [...worldState.guards]
       .sort((a, b) => a.id.localeCompare(b.id))
       .map((guard) => ({
         id: guard.id,
@@ -162,7 +162,7 @@ export const ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS: Record<string, ActorTypeWorldK
         id: worldState.player.id,
         position: { x: worldState.player.position.x, y: worldState.player.position.y },
       },
-      guards: guides,
+      guards,
       doors,
     };
   },
@@ -187,47 +187,6 @@ export const ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS: Record<string, ActorTypeWorldK
       otherVillagers: npcs,
     };
   },
-
-  archive_keeper: (worldState: WorldState): unknown => {
-    // Archive keepers know about archives/objects and nearby NPCs
-    const objects = [...worldState.interactiveObjects]
-      .sort((a, b) => a.id.localeCompare(b.id))
-      .map((obj) => ({
-        id: obj.id,
-        displayName: obj.displayName,
-        objectType: obj.objectType,
-        position: { x: obj.position.x, y: obj.position.y },
-      }));
-
-    return {
-      player: {
-        id: worldState.player.id,
-        position: { x: worldState.player.position.x, y: worldState.player.position.y },
-      },
-      archives: objects,
-    };
-  },
-
-  engineer: (worldState: WorldState): unknown => {
-    // Engineers know about interactive objects (machinery, mechanisms)
-    const objects = [...worldState.interactiveObjects]
-      .sort((a, b) => a.id.localeCompare(b.id))
-      .map((obj) => ({
-        id: obj.id,
-        displayName: obj.displayName,
-        objectType: obj.objectType,
-        state: obj.state,
-        position: { x: obj.position.x, y: obj.position.y },
-      }));
-
-    return {
-      player: {
-        id: worldState.player.id,
-        position: { x: worldState.player.position.x, y: worldState.player.position.y },
-      },
-      machinery: objects,
-    };
-  },
 };
 
 /**
@@ -240,10 +199,18 @@ const resolveActorWorldKnowledgeBuilder = (
   return ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS[normalizedType];
 };
 
+export const buildActorTypeWorldKnowledge = (
+  actorType: string | null | undefined,
+  worldState: WorldState,
+  actorId: string,
+): unknown | null => {
+  const worldKnowledgeBuilder = resolveActorWorldKnowledgeBuilder(actorType);
+  return worldKnowledgeBuilder ? worldKnowledgeBuilder(worldState, actorId) : null;
+};
+
 export const buildNpcPromptContext = (npc: Npc, player: Player, worldState: WorldState): string => {
   const resolvedProfile = resolveNpcPromptProfile(npc.npcType);
-  const worldKnowledgeBuilder = resolveActorWorldKnowledgeBuilder(npc.npcType);
-  const worldKnowledge = worldKnowledgeBuilder ? worldKnowledgeBuilder(worldState, npc.id) : null;
+  const worldKnowledge = buildActorTypeWorldKnowledge(npc.npcType, worldState, npc.id);
 
   return JSON.stringify({
     actor: {


### PR DESCRIPTION
## Summary
- add an actor-type world-knowledge builder registry keyed by actor type
- route both guard and NPC prompt-context world knowledge through the shared registry path
- keep guard world payload contract stable and add NPC typeWorldKnowledge only when a known actor-type builder exists
- scope registry builders to `guard` plus exactly one non-guard type (`villager`) used by tests
- add deterministic unknown-type fallback behavior (`null` => omitted `typeWorldKnowledge`) with explicit test coverage

## Validation
- `npm run test -- src/interaction/guardPromptContext.test.ts src/interaction/npcPromptContext.test.ts`
- `npm run test`
- `npm run build` *(fails due to pre-existing missing exports unrelated to this ticket)*
- `npm run lint` *(fails due to pre-existing `@typescript-eslint/no-explicit-any` in `src/interaction/interactionDispatcher.test.ts`)*

## Closes #98
Closes #98