### PR TITLE
#97 add instance-level knowledge and behavior fields to actors

### DIFF
--- a/docs/LLM_LAYER.md
+++ b/docs/LLM_LAYER.md
@@ -37,6 +37,21 @@ For NPC conversational turns:
 - shared profile information (`npcProfile`) resolved from `npcType`
 - per-instance NPC data (`npcInstance`) from world state
 - actor-type world context (`typeWorldKnowledge`) when a builder resolves for the `npcType`
+- instance-specific knowledge (`instanceKnowledge`) when present on the `Npc` object
+- instance-specific behavior traits (`instanceBehavior`) when present on the `Npc` object
+
+## Guard Prompt Context Flow
+
+For guard conversational turns:
+1. `createGuardInteractionService()` in `src/interaction/guardInteraction.ts` builds context with `buildGuardPromptContext(guard, worldState)`.
+2. The service passes actor id, context, player message, and history into `llmClient.complete(...)`.
+
+`buildGuardPromptContext()` includes:
+- the requesting guard's identity and truth encoding (`guard`)
+- guard persona contract (`guardPersonaContract`)
+- world knowledge payload (`world`) with all guards, doors, and player position
+- instance-specific knowledge (`instanceKnowledge`) when present on the `Guard` object
+- instance-specific behavior traits (`instanceBehavior`) when present on the `Guard` object
 
 ## Deterministic Fallbacks
 

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -44,6 +44,8 @@ Serializable optional directional sprite metadata:
 - `dialogueContextKey: string` - Deterministically derived from `npcType` via `npc_${npcType.toLowerCase()}`
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`
+- `instanceKnowledge?: string` - Instance-specific knowledge this NPC has; included in prompt context output when set
+- `instanceBehavior?: string` - Instance-specific behavior traits for this NPC; included in prompt context output when set
 
 ### Guard
 Extends `Interactable`:
@@ -51,6 +53,8 @@ Extends `Interactable`:
 - `honestyTrait?: 'truth-teller' | 'liar'`
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`
+- `instanceKnowledge?: string` - Instance-specific knowledge this guard has; included in prompt context output when set
+- `instanceBehavior?: string` - Instance-specific behavior traits for this guard; included in prompt context output when set
 
 ### Door
 Extends `Interactable`:
@@ -140,9 +144,18 @@ Deterministic fallback profile used when a normalized `npcType` has no registry 
 - `npcProfile: ResolvedNpcPromptProfile`
 - `npcInstance: { displayName, position: { x, y }, dialogueContextKey }`
 - `typeWorldKnowledge?: unknown` — actor-type-specific world facts; omitted when `buildActorTypeWorldKnowledge` returns `null`
+- `instanceKnowledge?: string` — instance-specific knowledge from the NPC; included only when set on the `Npc` object
+- `instanceBehavior?: string` — instance-specific behavior traits from the NPC; included only when set on the `Npc` object
 - `player: { id, displayName }`
 
 This separates shared type-level prompt policy (`npcProfile`) from per-instance world facts (`npcInstance`) and type-scoped world context (`typeWorldKnowledge`).
+
+`buildGuardPromptContext(guard, worldState)` returns a serialized JSON object with:
+- `guard: { id, displayName, position: { x, y }, truth }`
+- `guardPersonaContract: string`
+- `world: GuardWorldContextPayload`
+- `instanceKnowledge?: string` — instance-specific knowledge from the guard; included only when set on the `Guard` object
+- `instanceBehavior?: string` — instance-specific behavior traits from the guard; included only when set on the `Guard` object
 
 ### ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS
 
@@ -176,11 +189,11 @@ Required fields:
 - `width: number`
 - `height: number`
 - `player: { x: number; y: number; spriteAssetPath?: string; spriteSet?: SpriteSet }`
-- `guards: Array<{ id, displayName, x, y, guardState, honestyTrait?, spriteAssetPath?, spriteSet? }>`
+- `guards: Array<{ id, displayName, x, y, guardState, honestyTrait?, spriteAssetPath?, spriteSet?, instanceKnowledge?, instanceBehavior? }>`
 - `doors: Array<{ id, displayName, x, y, doorState, outcome, spriteAssetPath?, spriteSet? }>`
 
 Optional fields:
-- `npcs: Array<{ id, displayName, x, y, npcType, spriteAssetPath?, spriteSet? }>`
+- `npcs: Array<{ id, displayName, x, y, npcType, spriteAssetPath?, spriteSet?, instanceKnowledge?, instanceBehavior? }>`
 - `interactiveObjects: Array<...>` with the same object fields as `InteractiveObject`, but `x/y` instead of `position`
 
 Shipped level sprite metadata examples:

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -51,6 +51,9 @@ Sprite metadata contracts:
 - `spriteAssetPath?: string` remains optional for player, guards, doors, npcs, and interactive objects.
 - `spriteSet?: SpriteSet` is now optional for player, guards, doors, npcs, and interactive objects.
 
+Guard instance fields:
+- optional `instanceKnowledge?: string` and `instanceBehavior?: string` — validated as strings when provided; passed through to runtime `Guard` objects
+
 When `spriteSet` is present, validation enforces:
 - it must be an object
 - only known keys are read (`default`, `front`, `away`, `left`, `right`)
@@ -62,6 +65,7 @@ Path format correctness and asset loadability are intentionally handled by rende
 For `npcs`, validation enforces:
 - required identity/position fields (`id`, `displayName`, `x`, `y`)
 - required `npcType: string` - categorizes the NPC's role (for example, `'archive_keeper'`, `'scholar'`)
+- optional `instanceKnowledge?: string` and `instanceBehavior?: string` — validated as strings when provided; passed through to runtime `Npc` objects
 
 For `interactiveObjects`, validation enforces:
 - required identity/position fields
@@ -104,7 +108,8 @@ NPCs from level JSON are transformed to runtime `Npc` objects with deterministic
   position: { x: 8, y: 5 },
   npcType: 'archive_keeper',
   dialogueContextKey: 'npc_archive_keeper',
-  spriteAssetPath: '/assets/medieval_npc_villager.svg'
+  spriteAssetPath: '/assets/medieval_npc_villager.svg',
+  // instanceKnowledge and instanceBehavior are included when present in the level JSON
 }
 ```
 

--- a/src/integration/starterLevel.test.ts
+++ b/src/integration/starterLevel.test.ts
@@ -4,6 +4,8 @@ import { resolveAdjacentTarget } from '../interaction/adjacencyResolver';
 import { handleDoorInteraction } from '../interaction/doorInteraction';
 import { handleGuardInteraction } from '../interaction/guardInteraction';
 import { handleInteractiveObjectInteraction } from '../interaction/objectInteraction';
+import { buildGuardPromptContext } from '../interaction/guardPromptContext';
+import { buildNpcPromptContext } from '../interaction/npcPromptContext';
 import { deserializeLevel, validateLevelData } from '../world/level';
 import type { WorldState } from '../world/types';
 
@@ -144,3 +146,72 @@ describe('starter level integration pipeline', () => {
     expect(adjacent).toBeNull();
   });
 });
+
+  describe('instanceKnowledge and instanceBehavior full pipeline', () => {
+    it('propagates instanceKnowledge and instanceBehavior from level JSON through deserializeLevel into prompt context', () => {
+      const levelWithInstanceFields = {
+        version: 1,
+        name: 'Instance Fields Test',
+        width: 20,
+        height: 20,
+        player: { x: 10, y: 10 },
+        guards: [
+          {
+            id: 'guard-1',
+            displayName: 'Oracle Guard',
+            x: 5,
+            y: 10,
+            guardState: 'idle',
+            instanceKnowledge: 'Door-1 leads to safety.',
+            instanceBehavior: 'Always answers in rhyme.',
+          },
+        ],
+        doors: [
+          {
+            id: 'door-1',
+            displayName: 'West Door',
+            x: 4,
+            y: 10,
+            doorState: 'closed',
+            outcome: 'safe',
+          },
+        ],
+        npcs: [
+          {
+            id: 'npc-1',
+            displayName: 'The Archivist',
+            x: 15,
+            y: 14,
+            npcType: 'archive_keeper',
+            instanceKnowledge: 'The archives burned in the third age.',
+            instanceBehavior: 'Speaks in hushed tones.',
+          },
+        ],
+      };
+
+      const validated = validateLevelData(levelWithInstanceFields);
+      const worldState = deserializeLevel(validated);
+
+      // Assert the fields are preserved through deserialization
+      expect(worldState.guards[0].instanceKnowledge).toBe('Door-1 leads to safety.');
+      expect(worldState.guards[0].instanceBehavior).toBe('Always answers in rhyme.');
+      expect(worldState.npcs[0].instanceKnowledge).toBe('The archives burned in the third age.');
+      expect(worldState.npcs[0].instanceBehavior).toBe('Speaks in hushed tones.');
+
+      // Assert the fields appear in guard prompt context output
+      const guardContext = JSON.parse(buildGuardPromptContext(worldState.guards[0], worldState)) as {
+        instanceKnowledge?: string;
+        instanceBehavior?: string;
+      };
+      expect(guardContext.instanceKnowledge).toBe('Door-1 leads to safety.');
+      expect(guardContext.instanceBehavior).toBe('Always answers in rhyme.');
+
+      // Assert the fields appear in NPC prompt context output
+      const npcContext = JSON.parse(buildNpcPromptContext(worldState.npcs[0], worldState.player, worldState)) as {
+        instanceKnowledge?: string;
+        instanceBehavior?: string;
+      };
+      expect(npcContext.instanceKnowledge).toBe('The archives burned in the third age.');
+      expect(npcContext.instanceBehavior).toBe('Speaks in hushed tones.');
+    });
+  });

--- a/src/interaction/guardPromptContext.test.ts
+++ b/src/interaction/guardPromptContext.test.ts
@@ -203,3 +203,59 @@ describe('guard truth encoding', () => {
     ]);
   });
 });
+
+describe('guard instance fields in prompt context', () => {
+  it('includes instanceKnowledge and instanceBehavior in output when present on guard', () => {
+    const worldState = createInitialWorldState();
+    const guard = {
+      id: 'guard-1',
+      displayName: 'Oracle Guard',
+      position: { x: 3, y: 3 },
+      guardState: 'idle' as const,
+      instanceKnowledge: 'Door-1 leads to safety.',
+      instanceBehavior: 'Always answers in rhyme.',
+    };
+    worldState.guards = [guard];
+
+    const parsed = JSON.parse(buildGuardPromptContext(guard, worldState)) as {
+      instanceKnowledge?: string;
+      instanceBehavior?: string;
+    };
+
+    expect(parsed.instanceKnowledge).toBe('Door-1 leads to safety.');
+    expect(parsed.instanceBehavior).toBe('Always answers in rhyme.');
+  });
+
+  it('omits instanceKnowledge and instanceBehavior keys when not set on guard', () => {
+    const worldState = createInitialWorldState();
+    const guard = {
+      id: 'guard-1',
+      displayName: 'Plain Guard',
+      position: { x: 3, y: 3 },
+      guardState: 'idle' as const,
+    };
+    worldState.guards = [guard];
+
+    const parsed = JSON.parse(buildGuardPromptContext(guard, worldState)) as Record<string, unknown>;
+
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'instanceKnowledge')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'instanceBehavior')).toBe(false);
+  });
+
+  it('includes only instanceKnowledge when instanceBehavior is absent', () => {
+    const worldState = createInitialWorldState();
+    const guard = {
+      id: 'guard-1',
+      displayName: 'Guard',
+      position: { x: 3, y: 3 },
+      guardState: 'idle' as const,
+      instanceKnowledge: 'Only knowledge provided.',
+    };
+    worldState.guards = [guard];
+
+    const parsed = JSON.parse(buildGuardPromptContext(guard, worldState)) as Record<string, unknown>;
+
+    expect(parsed['instanceKnowledge']).toBe('Only knowledge provided.');
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'instanceBehavior')).toBe(false);
+  });
+});

--- a/src/interaction/guardPromptContext.ts
+++ b/src/interaction/guardPromptContext.ts
@@ -78,5 +78,7 @@ export const buildGuardPromptContext = (guard: Guard, worldState: WorldState): s
     },
     guardPersonaContract: guardProfile.personaContract,
     world: worldKnowledge,
+    ...(guard.instanceKnowledge !== undefined && { instanceKnowledge: guard.instanceKnowledge }),
+    ...(guard.instanceBehavior !== undefined && { instanceBehavior: guard.instanceBehavior }),
   });
 };

--- a/src/interaction/npcPromptContext.test.ts
+++ b/src/interaction/npcPromptContext.test.ts
@@ -225,3 +225,71 @@ describe('buildNpcPromptContext', () => {
     expect(worldKnowledge.otherVillagers[0].id).toBe('npc-villager-2');
   });
 });
+
+describe('NPC instance fields in prompt context', () => {
+  it('includes instanceKnowledge and instanceBehavior in output when present on NPC', () => {
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      id: 'npc-1',
+      instanceKnowledge: 'The archives burned in the third age.',
+      instanceBehavior: 'Refuses to discuss recent events.',
+    };
+    worldState.npcs = [npc];
+
+    const parsed = JSON.parse(buildNpcPromptContext(npc, worldState.player, worldState)) as {
+      instanceKnowledge?: string;
+      instanceBehavior?: string;
+    };
+
+    expect(parsed.instanceKnowledge).toBe('The archives burned in the third age.');
+    expect(parsed.instanceBehavior).toBe('Refuses to discuss recent events.');
+  });
+
+  it('omits instanceKnowledge and instanceBehavior keys when not set on NPC', () => {
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+
+    const parsed = JSON.parse(buildNpcPromptContext(npc, worldState.player, worldState)) as Record<string, unknown>;
+
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'instanceKnowledge')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'instanceBehavior')).toBe(false);
+  });
+
+  it('includes only instanceBehavior when instanceKnowledge is absent', () => {
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      id: 'npc-1',
+      instanceBehavior: 'Only behavior provided.',
+    };
+    worldState.npcs = [npc];
+
+    const parsed = JSON.parse(buildNpcPromptContext(npc, worldState.player, worldState)) as Record<string, unknown>;
+
+    expect(parsed['instanceBehavior']).toBe('Only behavior provided.');
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'instanceKnowledge')).toBe(false);
+  });
+
+  it('instance fields appear alongside typeWorldKnowledge when actor type is known', () => {
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      id: 'npc-1',
+      npcType: 'villager',
+      instanceKnowledge: 'Village square floods in spring.',
+      instanceBehavior: 'Speaks slowly and carefully.',
+    };
+    worldState.npcs = [npc];
+
+    const parsed = JSON.parse(buildNpcPromptContext(npc, worldState.player, worldState)) as {
+      typeWorldKnowledge?: unknown;
+      instanceKnowledge?: string;
+      instanceBehavior?: string;
+    };
+
+    expect(parsed.typeWorldKnowledge).toBeDefined();
+    expect(parsed.instanceKnowledge).toBe('Village square floods in spring.');
+    expect(parsed.instanceBehavior).toBe('Speaks slowly and carefully.');
+  });
+});

--- a/src/interaction/npcPromptContext.ts
+++ b/src/interaction/npcPromptContext.ts
@@ -236,6 +236,8 @@ export const buildNpcPromptContext = (npc: Npc, player: Player, worldState: Worl
       dialogueContextKey: npc.dialogueContextKey,
     },
     ...(worldKnowledge !== null && { typeWorldKnowledge: worldKnowledge }),
+    ...(npc.instanceKnowledge !== undefined && { instanceKnowledge: npc.instanceKnowledge }),
+    ...(npc.instanceBehavior !== undefined && { instanceBehavior: npc.instanceBehavior }),
     player: {
       id: player.id,
       displayName: player.displayName,

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -755,3 +755,155 @@ describe('npcs field', () => {
   });
 });
 
+describe('instanceKnowledge and instanceBehavior fields', () => {
+  it('passes through guard instanceKnowledge and instanceBehavior during deserialization', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      guards: [
+        {
+          id: 'guard-1',
+          displayName: 'Oracle Guard',
+          x: 5,
+          y: 7,
+          guardState: 'idle',
+          instanceKnowledge: 'This guard knows door-1 is safe.',
+          instanceBehavior: 'Speaks in riddles.',
+        },
+      ],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const validated = validateLevelData(level);
+    const state = deserializeLevel(validated);
+
+    expect(state.guards[0].instanceKnowledge).toBe('This guard knows door-1 is safe.');
+    expect(state.guards[0].instanceBehavior).toBe('Speaks in riddles.');
+  });
+
+  it('passes through NPC instanceKnowledge and instanceBehavior during deserialization', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      npcs: [
+        {
+          id: 'npc-1',
+          displayName: 'Wise Archivist',
+          x: 8,
+          y: 3,
+          npcType: 'archive_keeper',
+          instanceKnowledge: 'Knows the archive holds records of the last five kings.',
+          instanceBehavior: 'Speaks formally at all times.',
+        },
+      ],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const validated = validateLevelData(level);
+    const state = deserializeLevel(validated);
+
+    expect(state.npcs[0].instanceKnowledge).toBe('Knows the archive holds records of the last five kings.');
+    expect(state.npcs[0].instanceBehavior).toBe('Speaks formally at all times.');
+  });
+
+  it('omits instanceKnowledge and instanceBehavior keys when not provided in guard', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      guards: [{ id: 'guard-1', displayName: 'Guard', x: 5, y: 7, guardState: 'idle' }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const state = deserializeLevel(validateLevelData(level));
+
+    expect(Object.prototype.hasOwnProperty.call(state.guards[0], 'instanceKnowledge')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(state.guards[0], 'instanceBehavior')).toBe(false);
+  });
+
+  it('omits instanceKnowledge and instanceBehavior keys when not provided in NPC', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      npcs: [{ id: 'npc-1', displayName: 'Npc', x: 5, y: 5, npcType: 'archive_keeper' }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const state = deserializeLevel(validateLevelData(level));
+
+    expect(Object.prototype.hasOwnProperty.call(state.npcs[0], 'instanceKnowledge')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(state.npcs[0], 'instanceBehavior')).toBe(false);
+  });
+
+  it('rejects guard with non-string instanceKnowledge', () => {
+    const bad = {
+      ...minimalLevel,
+      guards: [{ id: 'guard-1', displayName: 'Guard', x: 5, y: 7, guardState: 'idle', instanceKnowledge: 42 }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid instanceKnowledge');
+  });
+
+  it('rejects guard with non-string instanceBehavior', () => {
+    const bad = {
+      ...minimalLevel,
+      guards: [{ id: 'guard-1', displayName: 'Guard', x: 5, y: 7, guardState: 'idle', instanceBehavior: true }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid instanceBehavior');
+  });
+
+  it('rejects NPC with non-string instanceKnowledge', () => {
+    const bad = {
+      ...minimalLevel,
+      npcs: [{ id: 'npc-1', displayName: 'Npc', x: 5, y: 5, npcType: 'archivist', instanceKnowledge: [] }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid instanceKnowledge');
+  });
+
+  it('rejects NPC with non-string instanceBehavior', () => {
+    const bad = {
+      ...minimalLevel,
+      npcs: [{ id: 'npc-1', displayName: 'Npc', x: 5, y: 5, npcType: 'archivist', instanceBehavior: 0 }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid instanceBehavior');
+  });
+
+  it('deserializes a level with both guard and NPC instance fields correctly end-to-end', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      guards: [
+        {
+          id: 'guard-1',
+          displayName: 'Riddle Guard',
+          x: 5,
+          y: 7,
+          guardState: 'idle',
+          instanceKnowledge: 'Door-1 leads to safety.',
+          instanceBehavior: 'Always answers in rhyme.',
+        },
+      ],
+      npcs: [
+        {
+          id: 'npc-1',
+          displayName: 'Keeper',
+          x: 8,
+          y: 3,
+          npcType: 'archive_keeper',
+          instanceKnowledge: 'The archives burned in the third age.',
+          instanceBehavior: 'Refuses to discuss recent events.',
+        },
+      ],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const state = deserializeLevel(validateLevelData(level));
+
+    expect(state.guards[0].instanceKnowledge).toBe('Door-1 leads to safety.');
+    expect(state.guards[0].instanceBehavior).toBe('Always answers in rhyme.');
+    expect(state.npcs[0].instanceKnowledge).toBe('The archives burned in the third age.');
+    expect(state.npcs[0].instanceBehavior).toBe('Refuses to discuss recent events.');
+  });
+});
+


### PR DESCRIPTION
## Summary

Adds `instanceKnowledge` and `instanceBehavior` as separately named fields in the prompt context JSON output for both guards and NPCs, and adds test coverage for level deserialization and prompt context inclusion of these fields.

The type definitions (`Guard`, `Npc`, `LevelData`) and level deserialization pass-through were already present on `main`. This PR completes the feature by wiring instance fields into the LLM-facing prompt context and adding the required test cases.

## Changes

| File | Change |
|---|---|
| `src/interaction/guardPromptContext.ts` | Conditionally adds `instanceKnowledge` and `instanceBehavior` to `buildGuardPromptContext` output |
| `src/interaction/npcPromptContext.ts` | Conditionally adds `instanceKnowledge` and `instanceBehavior` to `buildNpcPromptContext` output |
| `src/world/level.test.ts` | New `describe` block: 8 tests for instance field deserialization (pass-through, absence, validation errors, end-to-end) |
| `src/interaction/guardPromptContext.test.ts` | 3 new tests: instance fields present, absent, and partially present in guard prompt output |
| `src/interaction/npcPromptContext.test.ts` | 4 new tests: instance fields present, absent, partially present, and alongside `typeWorldKnowledge` |

## Validation

```
npm run test -- --run
```
- Test Files: 25 passed (25)
- Tests: 255 passed (255)

```
npm run build
```
- Pre-existing TypeScript errors on `main` (`WorldCommand`/`World` missing from `types.ts`) — unrelated to this PR; build errors present before branching.

## Closes #97