### PR TITLE
#104 add per-level objective text and UI objective display

### DIFF
--- a/docs/GAME_DESIGN_BASELINE.md
+++ b/docs/GAME_DESIGN_BASELINE.md
@@ -10,56 +10,59 @@ Current playable loop:
 - Runtime runs a fixed-step simulation at 100 ms ticks with a deterministic world update and render pass each frame.
 - Player input is keyboard-only and command-buffered.
 - Command set currently implemented:
-	- move (Arrow keys or WASD)
-	- interact (E)
+  - move (Arrow keys or WASD)
+  - interact (E)
 - Movement is deterministic and grid-based:
-	- Player facing updates from move direction even when movement is blocked.
-	- Movement is blocked by out-of-bounds positions and occupied tiles (guards, doors, NPCs, interactive objects).
+  - Player facing updates from move direction even when movement is blocked.
+  - Movement is blocked by out-of-bounds positions and occupied tiles (guards, doors, NPCs, interactive objects).
 - Interaction resolution is deterministic:
-	- Interact only checks orthogonally adjacent targets.
-	- Priority order when multiple targets are adjacent: guard, then door, then npc, then interactive object.
-	- Tie-break inside same kind: lexical by target id.
+  - Interact only checks orthogonally adjacent targets.
+  - Priority order when multiple targets are adjacent: guard, then door, then npc, then interactive object.
+  - Tie-break inside same kind: lexical by target id.
 - Pause and outcome gating:
-	- Opening a conversational interaction pauses simulation and clears pending input.
-	- While paused, commands are drained and discarded each tick.
-	- While the chat modal is open, keyboard commands are suppressed.
-	- If levelOutcome is set, movement commands are ignored and interaction dispatch is blocked.
+  - Opening a conversational interaction pauses simulation and clears pending input.
+  - While paused, commands are drained and discarded each tick.
+  - While the chat modal is open, keyboard commands are suppressed.
+  - If levelOutcome is set, movement commands are ignored and interaction dispatch is blocked.
 
 Implemented objective flow:
-- Levels resolve to win/lose through deterministic interaction outcomes (door outcome and optional first-use object outcome).
+- Level JSON now requires an objective string and level deserialization stores it as worldState.levelObjective.
+- Runtime controls display the active level objective and update it on default load, level switch, and reset.
+- Levels still resolve to win/lose through deterministic interaction outcomes (door outcome and optional first-use object outcome).
 - Outcome overlay is shown once when levelOutcome becomes non-null.
 
 ## Feature Inventory
 
 Implemented systems:
 - World model:
-	- Serializable WorldState with tick, grid, entities, conversation history, and levelOutcome.
-	- Deterministic command application and level deserialization.
-	- Spatial validation at level load (in-bounds and no overlaps).
+  - Serializable WorldState with tick, grid, levelObjective, entities, conversation history, and levelOutcome.
+  - Deterministic command application and level deserialization.
+  - Spatial validation at level load (in-bounds and no overlaps).
 - Input:
-	- Keyboard mapping to world commands.
-	- Modal-aware command suppression.
+  - Keyboard mapping to world commands.
+  - Modal-aware command suppression.
 - Interaction:
-	- Adjacent-target resolver with deterministic priority and tie-break.
-	- Door interaction:
-		- Returns door state text.
-		- Door outcome safe maps to win; danger maps to lose.
-	- Interactive object interaction (supply-crate):
-		- Sets object state to used.
-		- Returns idle/used response text.
-		- Can set levelOutcome from firstUseOutcome on first use.
-	- Guard and NPC conversation pipeline:
-		- First interact opens conversation context.
-		- Player message turns call LLM and append actor-scoped conversation history.
+  - Adjacent-target resolver with deterministic priority and tie-break.
+  - Door interaction:
+    - Returns door state text.
+    - Door outcome safe maps to win; danger maps to lose.
+  - Interactive object interaction (supply-crate):
+    - Sets object state to used.
+    - Returns idle/used response text.
+    - Can set levelOutcome from firstUseOutcome on first use.
+  - Guard and NPC conversation pipeline:
+    - First interact opens conversation context.
+    - Player message turns call LLM and append actor-scoped conversation history.
 - Runtime UI wiring:
-	- Level picker and reset.
-	- World JSON state panel.
-	- Chat modal.
-	- Pause overlay and level outcome overlay.
+  - Level picker and reset.
+  - Level objective panel in runtime controls.
+  - World JSON state panel.
+  - Chat modal.
+  - Pause overlay and level outcome overlay.
 
 Level roster (manifest):
-- riddle (Two Guards): demonstrates truth-teller/liar guard setup, two doors with safe/danger outcomes, and directional sprite sets.
-- starter (Starter): demonstrates mixed entity playfield with two guards, two doors, one villager NPC, and one supply crate interactive object.
+- riddle (Two Guards): demonstrates truth-teller/liar guard setup, two doors with safe/danger outcomes, directional sprite sets, and explicit objective text.
+- starter (Starter): demonstrates mixed entity playfield with two guards, two doors, one villager NPC, one supply crate interactive object, and explicit objective text.
 
 ## LLM Integration Boundaries
 
@@ -67,11 +70,11 @@ Current LLM boundary:
 - LLM is only used in conversational player-message turns for guard and npc interactions.
 - Initial conversation open (no player message) is deterministic and handled without LLM.
 - All authoritative gameplay rules remain deterministic and code-owned:
-	- Movement legality and spatial blocking
-	- Interaction target resolution priority
-	- Door and interactive-object outcome application
-	- Pause/resume behavior
-	- levelOutcome gating of further simulation interactions
+  - Movement legality and spatial blocking
+  - Interaction target resolution priority
+  - Door and interactive-object outcome application
+  - Pause/resume behavior
+  - levelOutcome gating of further simulation interactions
 - LLM output currently affects conversational text and stored conversation history only.
 - LLM failures are handled with deterministic fallback text.
 
@@ -79,38 +82,38 @@ Current LLM boundary:
 
 Design-level entity model in current implementation:
 - Player:
-	- Core fields: id, displayName, position, facingDirection, optional spriteAssetPath/spriteSet.
-	- Prompt exposure:
-		- Included in guard world payload as player id and position.
-		- Included in npc prompt context as player id and displayName.
+  - Core fields: id, displayName, position, facingDirection, optional spriteAssetPath/spriteSet.
+  - Prompt exposure:
+    - Included in guard world payload as player id and position.
+    - Included in npc prompt context as player id and displayName.
 - Guard:
-	- Core fields: id, displayName, position, guardState, honestyTrait, facingDirection, optional sprite fields, optional instanceKnowledge/instanceBehavior.
-	- Deterministic behavior fields:
-		- honestyTrait drives truth boolean in prompt context.
-		- facingDirection updates from approach on initial guard interaction open.
-	- Prompt model:
-		- Type-level profile resolved via actor prompt profile registry (guard persona contract).
-		- Type-level world knowledge builder coverage: guard builder includes player position, sorted guards with truth flags, and sorted doors with safe flags.
-		- Instance-level augmentation: optional instanceKnowledge and instanceBehavior are injected when present.
+  - Core fields: id, displayName, position, guardState, honestyTrait, facingDirection, optional sprite fields, optional instanceKnowledge/instanceBehavior.
+  - Deterministic behavior fields:
+    - honestyTrait drives truth boolean in prompt context.
+    - facingDirection updates from approach on initial guard interaction open.
+  - Prompt model:
+    - Type-level profile resolved via actor prompt profile registry (guard persona contract).
+    - Type-level world knowledge builder coverage: guard builder includes player position, sorted guards with truth flags, and sorted doors with safe flags.
+    - Instance-level augmentation: optional instanceKnowledge and instanceBehavior are injected when present.
 - NPC:
-	- Core fields: id, displayName, position, npcType, dialogueContextKey, optional sprite fields, optional instanceKnowledge/instanceBehavior.
-	- Prompt model:
-		- Type-level profile resolved from shared actor profile registry by npcType.
-		- Type-level world knowledge builder coverage:
-			- villager: includes other villagers, plus player position.
-			- archive_keeper: aliased to villager world knowledge builder.
-			- engineer and scholar currently have persona profiles but no dedicated world knowledge builder.
-		- Instance-level augmentation: optional instanceKnowledge and instanceBehavior are injected when present.
+  - Core fields: id, displayName, position, npcType, dialogueContextKey, optional sprite fields, optional instanceKnowledge/instanceBehavior.
+  - Prompt model:
+    - Type-level profile resolved from shared actor profile registry by npcType.
+    - Type-level world knowledge builder coverage:
+      - villager: includes other villagers, plus player position.
+      - archive_keeper: aliased to villager world knowledge builder.
+      - engineer and scholar currently have persona profiles but no dedicated world knowledge builder.
+    - Instance-level augmentation: optional instanceKnowledge and instanceBehavior are injected when present.
 - Door:
-	- Core fields: id, displayName, position, doorState, outcome, optional sprite fields.
-	- Deterministic outcome contract:
-		- outcome safe maps to win.
-		- outcome danger maps to lose.
+  - Core fields: id, displayName, position, doorState, outcome, optional sprite fields.
+  - Deterministic outcome contract:
+    - outcome safe maps to win.
+    - outcome danger maps to lose.
 - Interactive object:
-	- Core fields: id, displayName, position, objectType (currently supply-crate), interactionType, state, idle/used messages, optional firstUseOutcome, optional sprite fields.
-	- Deterministic outcome contract:
-		- On first use, may set levelOutcome from firstUseOutcome if no existing outcome.
-		- Subsequent uses keep used state and do not overwrite an existing levelOutcome.
+  - Core fields: id, displayName, position, objectType (currently supply-crate), interactionType, state, idle/used messages, optional firstUseOutcome, optional sprite fields.
+  - Deterministic outcome contract:
+    - On first use, may set levelOutcome from firstUseOutcome if no existing outcome.
+    - Subsequent uses keep used state and do not overwrite an existing levelOutcome.
 
 ## Known Constraints
 
@@ -129,9 +132,9 @@ Current constraints to design against:
 - Keep this file concise, factual, and derived from current code plus tests.
 - Preserve deterministic-vs-LLM boundary language explicitly on every update.
 - When adding a mechanic, document:
-	- command surface changes
-	- deterministic rule ownership
-	- interaction resolution changes (if any)
-	- levelOutcome behavior changes (if any)
-	- prompt-context schema deltas (type-level and instance-level)
+  - command surface changes
+  - deterministic rule ownership
+  - interaction resolution changes (if any)
+  - levelOutcome behavior changes (if any)
+  - prompt-context schema deltas (type-level and instance-level)
 - Do not describe planned behavior as implemented.

--- a/docs/RENDER_LAYER.md
+++ b/docs/RENDER_LAYER.md
@@ -8,11 +8,12 @@ The render layer translates `WorldState` into visual state and DOM-only runtime 
 - Keep viewport/camera centered around player with clamped world bounds
 - Map world entities to deterministic visuals by type and optional asset metadata
 - Consume world-owned player-facing direction when choosing player directional sprites
-- Manage DOM-only render utilities for runtime layout, chat UI, viewport pause presentation, and level-outcome presentation
+- Manage DOM-only render utilities for runtime layout, level controls UI, chat UI, viewport pause presentation, and level-outcome presentation
 
 Implementation entry points:
 - [src/render/scene.ts](../src/render/scene.ts)
 - [src/render/runtimeLayout.ts](../src/render/runtimeLayout.ts)
+- [src/render/levelUi.ts](../src/render/levelUi.ts)
 - [src/render/chatModal.ts](../src/render/chatModal.ts)
 - [src/render/viewportOverlay.ts](../src/render/viewportOverlay.ts)
 - [src/render/outcomeOverlay.ts](../src/render/outcomeOverlay.ts)
@@ -55,6 +56,7 @@ This keeps rendering deterministic even with partially configured sprite sets.
 
 The runtime mounts a small set of DOM-only helpers alongside the Pixi canvas:
 - `getRuntimeLayoutMarkup()` creates the host structure for viewport, side panels, modal host, and outcome host.
+- `createLevelUi()` manages level picker controls and the objective text panel in the runtime controls area.
 - `createChatModal()` manages the conversation dialog DOM and local focus behavior.
 - `createViewportOverlay()` manages the grey paused-world overlay inside `#viewport`.
 - `createOutcomeOverlay()` manages win/lose overlay messaging.
@@ -132,5 +134,6 @@ Source and verification:
 
 - `src/render/scene.test.ts`: color mapping, marker specs, sprite-mode behavior, player directional sprite selection from world-facing state, and deterministic directional fallback order
 - `src/render/runtimeLayout.test.ts`: viewport/layout behavior
+- `src/render/levelUi.test.ts`: level selector behavior and objective text rendering updates
 - `src/render/viewportOverlay.test.ts`: overlay visibility, `inert` toggling, focus blocking, and pointer blocking
 - `src/render/chatModal.test.ts`: close button and Escape exit behavior, modal visibility, and focus cleanup

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -91,6 +91,7 @@ Stores conversation history by actor id. The current conversational actors are g
 ### WorldState
 - `tick: number`
 - `grid: WorldGrid`
+- `levelObjective: string`
 - `player: Player`
 - `npcs: Npc[]`
 - `guards: Guard[]`
@@ -186,6 +187,7 @@ Flat JSON level definition used by files in `public/levels/*.json`.
 Required fields:
 - `version: 1`
 - `name: string`
+- `objective: string`
 - `width: number`
 - `height: number`
 - `player: { x: number; y: number; spriteAssetPath?: string; spriteSet?: SpriteSet }`

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -15,6 +15,7 @@ The world layer owns deterministic, JSON-serializable state and validation/deser
 `WorldState` in `src/world/types.ts` includes:
 - `tick`
 - `grid`
+- `levelObjective`
 - `player`
 - `npcs`
 - `guards`
@@ -42,7 +43,7 @@ Render consumes this token but does not author it.
 ## Level JSON Validation
 
 `validateLevelData()` in `src/world/level.ts` validates:
-- Required level metadata (`version`, `name`, dimensions)
+- Required level metadata (`version`, `name`, `objective`, dimensions)
 - `player`, `guards`, and `doors`
 - Optional `npcs` - array of level-defined NPCs with required `id`, `displayName`, `x`, `y`, and `npcType` fields
 - Optional `interactiveObjects`

--- a/public/levels/riddle.json
+++ b/public/levels/riddle.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "name": "Two Guards, Two Doors",
+  "objective": "Question the two guards and pick the door that leads to safety.",
   "width": 20,
   "height": 20,
   "player": {

--- a/public/levels/starter.json
+++ b/public/levels/starter.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "name": "Starter",
+  "objective": "Talk to both guards, then choose the safe door to escape.",
   "width": 20,
   "height": 20,
   "player": {

--- a/src/integration/starterLevel.test.ts
+++ b/src/integration/starterLevel.test.ts
@@ -152,6 +152,7 @@ describe('starter level integration pipeline', () => {
       const levelWithInstanceFields = {
         version: 1,
         name: 'Instance Fields Test',
+        objective: 'Verify instance field propagation.',
         width: 20,
         height: 20,
         player: { x: 10, y: 10 },

--- a/src/interaction/adjacencyResolver.test.ts
+++ b/src/interaction/adjacencyResolver.test.ts
@@ -5,6 +5,7 @@ import type { Door, Guard, InteractiveObject, Npc, WorldState } from '../world/t
 const baseState = (): WorldState => ({
   tick: 0,
   grid: { width: 12, height: 8, tileSize: 48 },
+  levelObjective: 'Reach the safe exit.',
   player: { id: 'player-1', displayName: 'Hero', position: { x: 3, y: 3 } },
   npcs: [],
   guards: [],

--- a/src/interaction/interactionDispatcher.test.ts
+++ b/src/interaction/interactionDispatcher.test.ts
@@ -21,6 +21,7 @@ const createMockLlmClient = (): LlmClient => ({
 const createTestWorldState = (overrides?: Partial<WorldState>): WorldState => ({
   tick: 0,
   grid: { width: 10, height: 10, tileSize: 32 },
+  levelObjective: overrides?.levelObjective ?? 'Find a way out.',
   player: {
     id: 'player',
     displayName: 'Player',
@@ -32,7 +33,7 @@ const createTestWorldState = (overrides?: Partial<WorldState>): WorldState => ({
   interactiveObjects: [],
   actorConversationHistoryByActorId: {},
   levelOutcome: null,
-  ...overrides,
+  ...(overrides ?? {}),
 });
 
 // Utility to create test entities
@@ -482,7 +483,10 @@ describe('InteractionDispatcher', () => {
   describe('error handling', () => {
     it('throws error for unknown handler kind', async () => {
       const dispatcher = createInteractionDispatcher({ llmClient });
-      const fakeTarget = { kind: 'unknown' as const, target: createTestDoor('fake-1') } as any;
+      const fakeTarget = {
+        kind: 'unknown' as const,
+        target: createTestDoor('fake-1'),
+      } as unknown as Parameters<typeof dispatcher.dispatch>[0];
       const worldState = createTestWorldState();
 
       expect(() => dispatcher.dispatch(fakeTarget, worldState)).toThrow(

--- a/src/interaction/objectInteraction.test.ts
+++ b/src/interaction/objectInteraction.test.ts
@@ -23,6 +23,7 @@ const makeSupplyCrate = (
 const createWorldState = (...interactiveObjects: InteractiveObject[]): WorldState => ({
   tick: 0,
   grid: { width: 12, height: 8, tileSize: 48 },
+  levelObjective: 'Inspect nearby objects for clues.',
   player,
   npcs: [],
   guards: [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -191,6 +191,7 @@ const startRuntime = async (): Promise<void> => {
         .then((newState) => {
           world.resetToState(newState);
           levelUi.setSelectedLevel(levelId);
+          levelUi.setLevelObjective(newState.levelObjective);
           outcomeOverlay.hide();
           levelOutcomeShown = false;
         })
@@ -204,6 +205,7 @@ const startRuntime = async (): Promise<void> => {
       fetchAndLoadLevel(levelUrl)
         .then((newState) => {
           world.resetToState(newState);
+          levelUi.setLevelObjective(newState.levelObjective);
           outcomeOverlay.hide();
           levelOutcomeShown = false;
         })
@@ -229,6 +231,7 @@ const startRuntime = async (): Promise<void> => {
         levelUi.setSelectedLevel(defaultLevel.id);
         return fetchAndLoadLevel(`${LEVELS_BASE_URL}/${defaultLevel.id}.json`).then((newState) => {
           world.resetToState(newState);
+          levelUi.setLevelObjective(newState.levelObjective);
         });
       }
 

--- a/src/render/levelUi.test.ts
+++ b/src/render/levelUi.test.ts
@@ -29,6 +29,9 @@ describe('createLevelUi', () => {
 
     expect(resetButton).not.toBeNull();
     expect(resetButton?.disabled).toBe(true);
+
+    const objectiveText = container.querySelector<HTMLElement>('.level-ui-objective-text');
+    expect(objectiveText?.textContent).toBe('Load a level to view its objective.');
   });
 
   it('keeps controls disabled when populated with an empty level list', () => {
@@ -98,5 +101,16 @@ describe('createLevelUi', () => {
     const select = container.querySelector<HTMLSelectElement>('#level-select');
     expect(select?.value).toBe('riddle');
     expect(onLevelSelect).not.toHaveBeenCalled();
+  });
+
+  it('renders and updates objective text through handle updates', () => {
+    const handle = createLevelUi(container, { onLevelSelect, onReset });
+
+    handle.setLevelObjective('Talk to both guards and pick the safe door.');
+    const objectiveText = container.querySelector<HTMLElement>('.level-ui-objective-text');
+    expect(objectiveText?.textContent).toBe('Talk to both guards and pick the safe door.');
+
+    handle.setLevelObjective('Reach the west door.');
+    expect(objectiveText?.textContent).toBe('Reach the west door.');
   });
 });

--- a/src/render/levelUi.ts
+++ b/src/render/levelUi.ts
@@ -10,6 +10,8 @@ export interface LevelUiHandle {
   populateLevels(levels: LevelEntry[]): void;
   /** Reflect the currently active level id in the dropdown (without triggering onLevelSelect). */
   setSelectedLevel(levelId: string): void;
+  /** Display the active level objective text in the runtime controls area. */
+  setLevelObjective(objective: string): void;
 }
 
 /**
@@ -38,6 +40,14 @@ export function createLevelUi(container: HTMLElement, callbacks: LevelUiCallback
   resetButton.textContent = 'Reset';
   resetButton.disabled = true;
 
+  const objectiveHeading = document.createElement('h3');
+  objectiveHeading.className = 'level-ui-objective-title';
+  objectiveHeading.textContent = 'Objective';
+
+  const objectiveText = document.createElement('p');
+  objectiveText.className = 'level-ui-objective-text';
+  objectiveText.textContent = 'Load a level to view its objective.';
+
   select.addEventListener('change', () => {
     const selectedId = select.value;
     if (selectedId) {
@@ -52,6 +62,8 @@ export function createLevelUi(container: HTMLElement, callbacks: LevelUiCallback
   wrapper.appendChild(label);
   wrapper.appendChild(select);
   wrapper.appendChild(resetButton);
+  wrapper.appendChild(objectiveHeading);
+  wrapper.appendChild(objectiveText);
   container.appendChild(wrapper);
 
   return {
@@ -84,6 +96,10 @@ export function createLevelUi(container: HTMLElement, callbacks: LevelUiCallback
 
     setSelectedLevel(levelId: string): void {
       select.value = levelId;
+    },
+
+    setLevelObjective(objective: string): void {
+      objectiveText.textContent = objective;
     },
   };
 }

--- a/src/render/scene.test.ts
+++ b/src/render/scene.test.ts
@@ -14,6 +14,7 @@ const createWorldState = (): WorldState => ({
     height: 20,
     tileSize: 48,
   },
+  levelObjective: 'Reach the safe door.',
   player: {
     id: 'player-1',
     displayName: 'Player',

--- a/src/runtimeController.test.ts
+++ b/src/runtimeController.test.ts
@@ -6,6 +6,7 @@ import type { World, WorldCommand, WorldState } from './world/types';
 const createTestWorldState = (overrides?: Partial<WorldState>): WorldState => ({
   tick: 0,
   grid: { width: 10, height: 10, tileSize: 32 },
+  levelObjective: overrides?.levelObjective ?? 'Reach the safe exit.',
   player: {
     id: 'player',
     displayName: 'Player',
@@ -17,7 +18,7 @@ const createTestWorldState = (overrides?: Partial<WorldState>): WorldState => ({
   interactiveObjects: [],
   actorConversationHistoryByActorId: {},
   levelOutcome: null,
-  ...overrides,
+  ...(overrides ?? {}),
 });
 
 const createTestWorld = (

--- a/src/style.css
+++ b/src/style.css
@@ -141,6 +141,25 @@ body {
   background: rgba(5, 10, 18, 0.75);
 }
 
+.level-ui {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.level-ui-objective-title {
+  margin: 0.5rem 0 0;
+  font-size: 0.95rem;
+}
+
+.level-ui-objective-text {
+  margin: 0;
+  padding: 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(187, 224, 239, 0.2);
+  background: rgba(5, 10, 18, 0.7);
+  min-height: 3.2rem;
+}
+
 /* Chat Modal Styles */
 .chat-modal-overlay {
   position: fixed;

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -7,6 +7,7 @@ import type { LevelData } from './types';
 const minimalLevel: LevelData = {
   version: 1,
   name: 'Test Level',
+  objective: 'Reach the exit.',
   width: 20,
   height: 20,
   player: { x: 2, y: 3 },
@@ -69,6 +70,7 @@ describe('deserializeLevel', () => {
     const state = deserializeLevel(minimalLevel);
 
     expect(state.tick).toBe(0);
+    expect(state.levelObjective).toBe('Reach the exit.');
     expect(state.npcs).toEqual([]);
     expect(state.interactiveObjects).toEqual([]);
   });
@@ -292,6 +294,15 @@ describe('validateLevelData', () => {
     expect(() => validateLevelData(bad)).toThrowError('name must be a non-empty string');
   });
 
+  it('throws when objective is missing or empty', () => {
+    const missingObjective = { ...minimalLevel } as Record<string, unknown>;
+    delete missingObjective['objective'];
+    expect(() => validateLevelData(missingObjective)).toThrowError('objective must be a non-empty string');
+
+    const emptyObjective = { ...minimalLevel, objective: '   ' };
+    expect(() => validateLevelData(emptyObjective)).toThrowError('objective must be a non-empty string');
+  });
+
   it('throws when width is zero or negative', () => {
     expect(() => validateLevelData({ ...minimalLevel, width: 0 })).toThrowError('width must be a positive number');
     expect(() => validateLevelData({ ...minimalLevel, width: -5 })).toThrowError('width must be a positive number');
@@ -357,6 +368,13 @@ describe('starter level', () => {
     const state = deserializeLevel(level);
 
     expect(state.player.position).toEqual({ x: 10, y: 10 });
+  });
+
+  it('includes objective text in runtime world state', () => {
+    const level = validateLevelData(starterRaw);
+    const state = deserializeLevel(level);
+
+    expect(state.levelObjective).toBe(level.objective);
   });
 
   it('has a 20×20 grid', () => {

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -50,6 +50,10 @@ export function validateLevelData(input: unknown): LevelData {
     throw new Error('Invalid level data: name must be a non-empty string');
   }
 
+  if (typeof raw['objective'] !== 'string' || raw['objective'].trim() === '') {
+    throw new Error('Invalid level data: objective must be a non-empty string');
+  }
+
   if (typeof raw['width'] !== 'number' || raw['width'] <= 0) {
     throw new Error('Invalid level data: width must be a positive number');
   }
@@ -279,6 +283,7 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       height: levelData.height,
       tileSize: DEFAULT_TILE_SIZE,
     },
+    levelObjective: levelData.objective,
     player: {
       id: 'player',
       displayName: 'Player',

--- a/src/world/levelLoader.test.ts
+++ b/src/world/levelLoader.test.ts
@@ -5,6 +5,7 @@ import type { LevelData } from './types';
 const minimalLevel: LevelData = {
   version: 1,
   name: 'Test Level',
+  objective: 'Reach the exit.',
   width: 20,
   height: 20,
   player: { x: 2, y: 3 },

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -7,6 +7,7 @@ export const createInitialWorldState = (): WorldState => ({
     height: 8,
     tileSize: 48,
   },
+  levelObjective: 'Reach the safe exit.',
   player: {
     id: 'player-1',
     displayName: 'Guard',

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -96,6 +96,7 @@ export interface WorldGrid {
 export interface LevelData {
   version: 1;
   name: string;
+  objective: string;
   width: number;
   height: number;
   player: { x: number; y: number; spriteAssetPath?: string; spriteSet?: SpriteSet };
@@ -155,6 +156,7 @@ export interface LevelData {
 export interface WorldState {
   tick: number;
   grid: WorldGrid;
+  levelObjective: string;
   player: Player;
   npcs: Npc[];
   guards: Guard[];
@@ -162,4 +164,20 @@ export interface WorldState {
   interactiveObjects: InteractiveObject[];
   actorConversationHistoryByActorId: ActorConversationHistoryByActorId;
   levelOutcome: 'win' | 'lose' | null;
+}
+
+export type WorldCommand =
+  | {
+      type: 'move';
+      dx: number;
+      dy: number;
+    }
+  | {
+      type: 'interact';
+    };
+
+export interface World {
+  getState(): WorldState;
+  applyCommands(commands: WorldCommand[]): void;
+  resetToState(state: WorldState): void;
 }


### PR DESCRIPTION
## Summary
- add required `objective` to level JSON schema (`LevelData`) and validation in `validateLevelData()`
- deserialize objective into deterministic serializable runtime state as `worldState.levelObjective`
- display objective text in runtime level controls UI and update it on initial load, level switch, and reset
- seed `starter` and `riddle` level JSON files with concrete objective text
- add/extend tests for schema/deserialization and objective rendering behavior
- update world/type documentation to include objective fields

## Validation
- `npm run test -- --run` ✅ pass (25 files, 259 tests)
- `npm run build` ✅ pass (`tsc && vite build`)
- `npm run lint` ✅ pass

## Closes #104
Closes #104