### PR TITLE
#105 add deterministic inventory and pickup interactions

### DIFF
--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -142,6 +142,12 @@ Related tests live in `src/interaction/interactionDispatcher.test.ts` under disp
 
 This allows multiple objects to share one behavior implementation while retaining per-instance outcomes/messages from level JSON.
 
+Pickup behavior is deterministic and code-owned:
+- if an interactive object has `pickupItem` and is interacted with in `idle` state, the item is added to `player.inventory.items`
+- pickup entries include `sourceObjectId` and `pickedUpAtTick` to keep state auditable and replay-friendly
+- repeated interactions on the same object instance cannot duplicate pickup entries
+- no LLM call participates in pickup rule enforcement
+
 ## LLM Boundary
 
 Only conversational player-message flows route to the LLM layer (guard/NPC chat services). Chat-open flows and deterministic door/object interactions do not call the LLM client.

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -32,9 +32,19 @@ Serializable optional directional sprite metadata:
 - `id: string`
 - `displayName: string`
 - `position: GridPosition`
+- `inventory: PlayerInventory`
 - `facingDirection?: SpriteDirection` - world-owned orientation token derived from latest directional movement intent
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`
+
+### InventoryItem
+- `itemId: string`
+- `displayName: string`
+- `sourceObjectId: string`
+- `pickedUpAtTick: number`
+
+### PlayerInventory
+- `items: InventoryItem[]`
 
 ### Npc
 - `id: string`
@@ -68,6 +78,7 @@ Extends `Interactable`:
 - `objectType: 'supply-crate'`
 - `interactionType: 'inspect' | 'use' | 'talk'`
 - `state: 'idle' | 'used'`
+- `pickupItem?: { itemId: string; displayName: string }`
 - `idleMessage?: string`
 - `usedMessage?: string`
 - `firstUseOutcome?: 'win' | 'lose'`
@@ -237,6 +248,10 @@ Example interactive object entry:
   "objectType": "supply-crate",
   "interactionType": "inspect",
   "state": "idle",
+  "pickupItem": {
+    "itemId": "starter-storage-key",
+    "displayName": "Storage Key"
+  },
   "idleMessage": "You crack open the crate and find emergency supplies.",
   "usedMessage": "The supply crate is already open and empty.",
   "spriteAssetPath": "/assets/medieval_supply_crate_inspect.svg"

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -40,6 +40,16 @@ Deterministic rules:
 
 Render consumes this token but does not author it.
 
+### Player Inventory State
+
+`player.inventory` is world-owned deterministic state with shape:
+- `items: Array<{ itemId, displayName, sourceObjectId, pickedUpAtTick }>`
+
+Deterministic rules:
+- New runtime state initializes `player.inventory.items` to `[]`.
+- Level deserialization also initializes `player.inventory.items` to `[]`.
+- Inventory entries are only appended by deterministic interaction logic in the interaction layer.
+
 ## Level JSON Validation
 
 `validateLevelData()` in `src/world/level.ts` validates:
@@ -73,6 +83,7 @@ For `interactiveObjects`, validation enforces:
 - `objectType` currently restricted to `supply-crate`
 - `interactionType` in `inspect | use | talk`
 - `state` in `idle | used`
+- optional `pickupItem` with non-empty string `itemId` and `displayName`
 - optional `firstUseOutcome` in `win | lose`
 
 ## Deserialization
@@ -119,6 +130,7 @@ Deserialization remains deterministic: the same `npcType` always produces the sa
 ### Interactive Object Deserialization
 
 Interactive object instance fields deserialize directly:
+- `pickupItem`
 - `idleMessage`
 - `usedMessage`
 - `firstUseOutcome`

--- a/public/levels/starter.json
+++ b/public/levels/starter.json
@@ -64,6 +64,10 @@
       "objectType": "supply-crate",
       "interactionType": "inspect",
       "state": "idle",
+      "pickupItem": {
+        "itemId": "starter-storage-key",
+        "displayName": "Storage Key"
+      },
       "idleMessage": "You crack open the crate and find emergency supplies.",
       "usedMessage": "The supply crate is already open and empty.",
       "spriteAssetPath": "/assets/medieval_supply_crate_inspect.svg"

--- a/src/integration/starterLevel.test.ts
+++ b/src/integration/starterLevel.test.ts
@@ -116,6 +116,14 @@ describe('starter level integration pipeline', () => {
     expect(firstResult.responseText).toBe('You crack open the crate and find emergency supplies.');
     expect(firstResult.updatedWorldState.interactiveObjects[0].state).toBe('used');
     expect(firstResult.updatedWorldState.levelOutcome).toBeNull();
+    expect(firstResult.updatedWorldState.player.inventory.items).toEqual([
+      {
+        itemId: 'starter-storage-key',
+        displayName: 'Storage Key',
+        sourceObjectId: 'crate-supplies',
+        pickedUpAtTick: 0,
+      },
+    ]);
 
     const secondResult = handleInteractiveObjectInteraction({
       interactiveObject: firstResult.updatedWorldState.interactiveObjects[0],
@@ -125,6 +133,7 @@ describe('starter level integration pipeline', () => {
 
     expect(secondResult.responseText).toBe('The supply crate is already open and empty.');
     expect(secondResult.updatedWorldState.interactiveObjects[0].state).toBe('used');
+    expect(secondResult.updatedWorldState.player.inventory.items).toHaveLength(1);
 
     expect(worldState).toEqual(beforeInteraction);
   });

--- a/src/interaction/adjacencyResolver.test.ts
+++ b/src/interaction/adjacencyResolver.test.ts
@@ -6,7 +6,14 @@ const baseState = (): WorldState => ({
   tick: 0,
   grid: { width: 12, height: 8, tileSize: 48 },
   levelObjective: 'Reach the safe exit.',
-  player: { id: 'player-1', displayName: 'Hero', position: { x: 3, y: 3 } },
+  player: {
+    id: 'player-1',
+    displayName: 'Hero',
+    position: { x: 3, y: 3 },
+    inventory: {
+      items: [],
+    },
+  },
   npcs: [],
   guards: [],
   doors: [],

--- a/src/interaction/doorInteraction.test.ts
+++ b/src/interaction/doorInteraction.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { handleDoorInteraction } from './doorInteraction';
 import type { Door, Player } from '../world/types';
 
-const player: Player = { id: 'player-1', displayName: 'Hero', position: { x: 1, y: 1 } };
+const player: Player = {
+  id: 'player-1',
+  displayName: 'Hero',
+  position: { x: 1, y: 1 },
+  inventory: {
+    items: [],
+  },
+};
 
 const makeDoor = (doorState: Door['doorState'], outcome?: Door['outcome']): Door => ({
   id: 'door-1',

--- a/src/interaction/guardInteraction.test.ts
+++ b/src/interaction/guardInteraction.test.ts
@@ -5,7 +5,14 @@ import { GUARD_PERSONA_CONTRACT } from './guardPromptContext';
 import { createGuardInteractionService, handleGuardInteraction } from './guardInteraction';
 import type { Guard, Player } from '../world/types';
 
-const player: Player = { id: 'player-1', displayName: 'Hero', position: { x: 1, y: 1 } };
+const player: Player = {
+  id: 'player-1',
+  displayName: 'Hero',
+  position: { x: 1, y: 1 },
+  inventory: {
+    items: [],
+  },
+};
 
 const makeGuard = (guardState: Guard['guardState']): Guard => ({
   id: 'guard-1',

--- a/src/interaction/interactionDispatcher.test.ts
+++ b/src/interaction/interactionDispatcher.test.ts
@@ -18,23 +18,38 @@ const createMockLlmClient = (): LlmClient => ({
 });
 
 // Utility to create minimal test world state
-const createTestWorldState = (overrides?: Partial<WorldState>): WorldState => ({
-  tick: 0,
-  grid: { width: 10, height: 10, tileSize: 32 },
-  levelObjective: overrides?.levelObjective ?? 'Find a way out.',
-  player: {
-    id: 'player',
-    displayName: 'Player',
-    position: { x: 0, y: 0 },
-  },
-  guards: [],
-  doors: [],
-  npcs: [],
-  interactiveObjects: [],
-  actorConversationHistoryByActorId: {},
-  levelOutcome: null,
-  ...(overrides ?? {}),
-});
+const createTestWorldState = (
+  overrides?: Omit<Partial<WorldState>, 'player'> & { player?: Partial<WorldState['player']> },
+): WorldState => {
+  const baseState: WorldState = {
+    tick: 0,
+    grid: { width: 10, height: 10, tileSize: 32 },
+    levelObjective: 'Find a way out.',
+    player: {
+      id: 'player',
+      displayName: 'Player',
+      position: { x: 0, y: 0 },
+      inventory: {
+        items: [],
+      },
+    },
+    guards: [],
+    doors: [],
+    npcs: [],
+    interactiveObjects: [],
+    actorConversationHistoryByActorId: {},
+    levelOutcome: null,
+  };
+
+  return {
+    ...baseState,
+    ...(overrides ?? {}),
+    player: {
+      ...baseState.player,
+      ...(overrides?.player ?? {}),
+    },
+  };
+};
 
 // Utility to create test entities
 const createTestGuard = (id: string): Guard => ({

--- a/src/interaction/objectInteraction.test.ts
+++ b/src/interaction/objectInteraction.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { handleInteractiveObjectInteraction } from './objectInteraction';
 import type { InteractiveObject, Player, WorldState } from '../world/types';
 
-const player: Player = { id: 'player-1', displayName: 'Hero', position: { x: 3, y: 3 } };
+const player: Player = {
+  id: 'player-1',
+  displayName: 'Hero',
+  position: { x: 3, y: 3 },
+  inventory: {
+    items: [],
+  },
+};
 
 const makeSupplyCrate = (
   id: string,
@@ -37,6 +44,10 @@ describe('handleInteractiveObjectInteraction', () => {
   it('uses shared object-type behavior and instance fields for first supply-crate interaction', () => {
     const crate = makeSupplyCrate('crate-a', 'idle', {
       idleMessage: 'You lift the lid and uncover a brass key.',
+      pickupItem: {
+        itemId: 'brass-key',
+        displayName: 'Brass Key',
+      },
       firstUseOutcome: 'win',
     });
     const worldState = createWorldState(crate);
@@ -51,6 +62,14 @@ describe('handleInteractiveObjectInteraction', () => {
     expect(result.responseText).toBe('You lift the lid and uncover a brass key.');
     expect(result.updatedWorldState.levelOutcome).toBe('win');
     expect(result.updatedWorldState.interactiveObjects[0].state).toBe('used');
+    expect(result.updatedWorldState.player.inventory.items).toEqual([
+      {
+        itemId: 'brass-key',
+        displayName: 'Brass Key',
+        sourceObjectId: 'crate-a',
+        pickedUpAtTick: 0,
+      },
+    ]);
   });
 
   it('returns used-state message on repeat interaction and does not re-trigger first-use outcome', () => {
@@ -69,6 +88,7 @@ describe('handleInteractiveObjectInteraction', () => {
     expect(result.responseText).toBe('Only splinters remain inside the crate.');
     expect(result.updatedWorldState.levelOutcome).toBeNull();
     expect(result.updatedWorldState.interactiveObjects[0].state).toBe('used');
+    expect(result.updatedWorldState.player.inventory.items).toEqual([]);
   });
 
   it('keeps per-instance outcomes distinct while reusing the same supply-crate handler', () => {
@@ -93,7 +113,39 @@ describe('handleInteractiveObjectInteraction', () => {
 
     expect(winningResult.responseText).toBe('You find the evacuation signal flare.');
     expect(winningResult.updatedWorldState.levelOutcome).toBe('win');
+    expect(winningResult.updatedWorldState.player.inventory.items).toEqual([]);
     expect(neutralResult.responseText).toBe('You find rope and a water skin.');
     expect(neutralResult.updatedWorldState.levelOutcome).toBeNull();
+    expect(neutralResult.updatedWorldState.player.inventory.items).toEqual([]);
+  });
+
+  it('does not duplicate pickup from the same object instance across repeated interactions', () => {
+    const crate = makeSupplyCrate('crate-repeat', 'idle', {
+      pickupItem: {
+        itemId: 'field-rations',
+        displayName: 'Field Rations',
+      },
+    });
+
+    const firstResult = handleInteractiveObjectInteraction({
+      interactiveObject: crate,
+      player,
+      worldState: createWorldState(crate),
+    });
+
+    const secondResult = handleInteractiveObjectInteraction({
+      interactiveObject: firstResult.updatedWorldState.interactiveObjects[0],
+      player,
+      worldState: firstResult.updatedWorldState,
+    });
+
+    expect(firstResult.updatedWorldState.player.inventory.items).toHaveLength(1);
+    expect(secondResult.updatedWorldState.player.inventory.items).toHaveLength(1);
+    expect(secondResult.updatedWorldState.player.inventory.items[0]).toEqual({
+      itemId: 'field-rations',
+      displayName: 'Field Rations',
+      sourceObjectId: 'crate-repeat',
+      pickedUpAtTick: 0,
+    });
   });
 });

--- a/src/interaction/objectInteraction.ts
+++ b/src/interaction/objectInteraction.ts
@@ -28,6 +28,12 @@ const handleSupplyCrateInteraction: InteractiveObjectTypeHandler = (
 	request,
 ): InteractiveObjectInteractionResult => {
 	const wasUsed = request.interactiveObject.state === 'used';
+	const pickupItem = request.interactiveObject.pickupItem;
+	const inventoryItems = request.worldState.player.inventory.items;
+	const inventoryAlreadyContainsObjectPickup = inventoryItems.some(
+		(item) => item.sourceObjectId === request.interactiveObject.id,
+	);
+	const canPickup = !wasUsed && pickupItem !== undefined && !inventoryAlreadyContainsObjectPickup;
 	const responseText = wasUsed
 		? request.interactiveObject.usedMessage ?? `${request.interactiveObject.displayName} is already open.`
 		: request.interactiveObject.idleMessage ??
@@ -42,8 +48,26 @@ const handleSupplyCrateInteraction: InteractiveObjectTypeHandler = (
 		request.worldState.levelOutcome ??
 		(!wasUsed ? (request.interactiveObject.firstUseOutcome ?? null) : null);
 
+	const nextInventoryItems = canPickup
+		? [
+				...inventoryItems,
+				{
+					itemId: pickupItem.itemId,
+					displayName: pickupItem.displayName,
+					sourceObjectId: request.interactiveObject.id,
+					pickedUpAtTick: request.worldState.tick,
+				},
+			]
+		: inventoryItems;
+
 	const updatedWorldState: WorldState = {
 		...request.worldState,
+		player: {
+			...request.worldState.player,
+			inventory: {
+				items: nextInventoryItems,
+			},
+		},
 		interactiveObjects: replaceInteractiveObjectInWorld(request.worldState, updatedObject),
 		levelOutcome: nextLevelOutcome,
 	};

--- a/src/render/scene.test.ts
+++ b/src/render/scene.test.ts
@@ -19,6 +19,9 @@ const createWorldState = (): WorldState => ({
     id: 'player-1',
     displayName: 'Player',
     position: { x: 10, y: 10 },
+    inventory: {
+      items: [],
+    },
   },
   npcs: [
     {

--- a/src/runtimeController.test.ts
+++ b/src/runtimeController.test.ts
@@ -3,23 +3,38 @@ import { createCommandBuffer } from './input/commands';
 import { createRuntimeController } from './runtimeController';
 import type { World, WorldCommand, WorldState } from './world/types';
 
-const createTestWorldState = (overrides?: Partial<WorldState>): WorldState => ({
-  tick: 0,
-  grid: { width: 10, height: 10, tileSize: 32 },
-  levelObjective: overrides?.levelObjective ?? 'Reach the safe exit.',
-  player: {
-    id: 'player',
-    displayName: 'Player',
-    position: { x: 1, y: 1 },
-  },
-  guards: [],
-  doors: [],
-  npcs: [],
-  interactiveObjects: [],
-  actorConversationHistoryByActorId: {},
-  levelOutcome: null,
-  ...(overrides ?? {}),
-});
+const createTestWorldState = (
+  overrides?: Omit<Partial<WorldState>, 'player'> & { player?: Partial<WorldState['player']> },
+): WorldState => {
+  const baseState: WorldState = {
+    tick: 0,
+    grid: { width: 10, height: 10, tileSize: 32 },
+    levelObjective: 'Reach the safe exit.',
+    player: {
+      id: 'player',
+      displayName: 'Player',
+      position: { x: 1, y: 1 },
+      inventory: {
+        items: [],
+      },
+    },
+    guards: [],
+    doors: [],
+    npcs: [],
+    interactiveObjects: [],
+    actorConversationHistoryByActorId: {},
+    levelOutcome: null,
+  };
+
+  return {
+    ...baseState,
+    ...(overrides ?? {}),
+    player: {
+      ...baseState.player,
+      ...(overrides?.player ?? {}),
+    },
+  };
+};
 
 const createTestWorld = (
   initialState: WorldState = createTestWorldState(),

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -23,6 +23,9 @@ describe('deserializeLevel', () => {
       id: 'player',
       displayName: 'Player',
       position: { x: 2, y: 3 },
+      inventory: {
+        items: [],
+      },
       facingDirection: 'front',
     });
   });
@@ -73,6 +76,14 @@ describe('deserializeLevel', () => {
     expect(state.levelObjective).toBe('Reach the exit.');
     expect(state.npcs).toEqual([]);
     expect(state.interactiveObjects).toEqual([]);
+    expect(state.player.inventory.items).toEqual([]);
+  });
+
+  it('keeps player inventory JSON-serializable after deserialization', () => {
+    const state = deserializeLevel(minimalLevel);
+
+    const roundTrip = JSON.parse(JSON.stringify(state)) as typeof state;
+    expect(roundTrip.player.inventory.items).toEqual([]);
   });
 
   it('handles empty guard and door arrays', () => {
@@ -342,6 +353,30 @@ describe('validateLevelData', () => {
     expect(() => validateLevelData(bad)).toThrowError('doors must be an array');
   });
 
+  it('throws when interactiveObject pickupItem is invalid', () => {
+    const bad = {
+      ...minimalLevel,
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+      interactiveObjects: [
+        {
+          id: 'crate-1',
+          displayName: 'Crate',
+          x: 4,
+          y: 4,
+          objectType: 'supply-crate',
+          interactionType: 'inspect',
+          state: 'idle',
+          pickupItem: {
+            itemId: '',
+            displayName: 'Key',
+          },
+        },
+      ],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid pickupItem');
+  });
+
   it('throws when input is not an object', () => {
     expect(() => validateLevelData(null)).toThrowError('expected an object');
     expect(() => validateLevelData('string')).toThrowError('expected an object');
@@ -403,6 +438,16 @@ describe('starter level', () => {
 
     expect(state.guards.map((g) => g.id)).toEqual(['guard-1', 'guard-2']);
     expect(state.doors.map((d) => d.id)).toEqual(['door-1', 'door-2']);
+  });
+
+  it('maps starter pickup item metadata into interactive object state', () => {
+    const level = validateLevelData(starterRaw);
+    const state = deserializeLevel(level);
+
+    expect(state.interactiveObjects[0].pickupItem).toEqual({
+      itemId: 'starter-storage-key',
+      displayName: 'Storage Key',
+    });
   });
 });
 

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -253,6 +253,22 @@ export function validateLevelData(input: unknown): LevelData {
         );
       }
 
+      if (interactiveObject['pickupItem'] !== undefined) {
+        const pickupItem = interactiveObject['pickupItem'] as Record<string, unknown>;
+        if (
+          typeof pickupItem !== 'object' ||
+          pickupItem === null ||
+          typeof pickupItem['itemId'] !== 'string' ||
+          pickupItem['itemId'].trim() === '' ||
+          typeof pickupItem['displayName'] !== 'string' ||
+          pickupItem['displayName'].trim() === ''
+        ) {
+          throw new Error(
+            `Invalid level data: interactiveObject at index ${i} has invalid pickupItem (must include non-empty string itemId and displayName)`,
+          );
+        }
+      }
+
       if (
         interactiveObject['spriteAssetPath'] !== undefined &&
         typeof interactiveObject['spriteAssetPath'] !== 'string'
@@ -288,6 +304,9 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       id: 'player',
       displayName: 'Player',
       position: { x: levelData.player.x, y: levelData.player.y },
+      inventory: {
+        items: [],
+      },
       facingDirection: 'front',
       ...(levelData.player.spriteAssetPath !== undefined
         ? { spriteAssetPath: levelData.player.spriteAssetPath }
@@ -332,6 +351,7 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       objectType: o.objectType,
       interactionType: o.interactionType,
       state: o.state,
+      pickupItem: o.pickupItem,
       idleMessage: o.idleMessage,
       usedMessage: o.usedMessage,
       firstUseOutcome: o.firstUseOutcome,

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -12,6 +12,9 @@ export const createInitialWorldState = (): WorldState => ({
     id: 'player-1',
     displayName: 'Guard',
     position: { x: 1, y: 1 },
+    inventory: {
+      items: [],
+    },
     facingDirection: 'front',
   },
   npcs: [

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -17,10 +17,22 @@ export interface SpriteSet {
   right?: string;
 }
 
+export interface InventoryItem {
+  itemId: string;
+  displayName: string;
+  sourceObjectId: string;
+  pickedUpAtTick: number;
+}
+
+export interface PlayerInventory {
+  items: InventoryItem[];
+}
+
 export interface Player {
   id: string;
   displayName: string;
   position: GridPosition;
+  inventory: PlayerInventory;
   facingDirection?: SpriteDirection;
   spriteAssetPath?: string;
   spriteSet?: SpriteSet;
@@ -79,6 +91,10 @@ export interface InteractiveObject extends Interactable {
   objectType: 'supply-crate';
   interactionType: 'inspect' | 'use' | 'talk';
   state: 'idle' | 'used';
+  pickupItem?: {
+    itemId: string;
+    displayName: string;
+  };
   idleMessage?: string;
   usedMessage?: string;
   firstUseOutcome?: 'win' | 'lose';
@@ -145,6 +161,10 @@ export interface LevelData {
     objectType: 'supply-crate';
     interactionType: 'inspect' | 'use' | 'talk';
     state: 'idle' | 'used';
+    pickupItem?: {
+      itemId: string;
+      displayName: string;
+    };
     idleMessage?: string;
     usedMessage?: string;
     firstUseOutcome?: 'win' | 'lose';


### PR DESCRIPTION
## Summary
- adds a serializable deterministic player inventory model to world state (`player.inventory.items`)
- extends interactive objects and level schema with optional `pickupItem` metadata
- implements deterministic pickup on interaction for pickup-capable objects
- prevents duplicate pickups from the same object instance by tracking `sourceObjectId`
- adds starter-level pickup item metadata to `public/levels/starter.json`
- updates tests and docs for new field contracts and behavior boundaries

## Validation
- `npm run lint` ✅ pass
- `npm run build` ✅ pass
- `npm test -- --run` ✅ pass (25 files, 263 tests)

## Closes #105
Closes #105