### PR TITLE
#117 implement deterministic selected-inventory and item-use command pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ The current baseline runtime in `src/main.ts` follows this loop:
 
 1. Keyboard input maps to `WorldCommand` values and is enqueued into `CommandBuffer`.
 2. A fixed simulation tick of 100ms drains buffered commands.
-3. `world.applyCommands(commands)` updates deterministic state and advances `tick`.
-4. If an `interact` command was issued, nearby NPC interaction is resolved through the interaction service and LLM client boundary.
-5. Every animation frame renders the latest world state through the Pixi render port and prints JSON state in the debug panel.
+3. `world.applyCommands(commands)` updates deterministic state and advances `tick`, including inventory slot selection state.
+4. If any `useSelectedItem` commands were issued, runtime orchestration resolves a deterministic item-use attempt event for each command and stores the latest event in serialized world state.
+5. If an `interact` command was issued, one adjacent target is resolved through the interaction dispatcher; conversational turns may cross the LLM boundary, while door/object paths stay deterministic.
+6. Every animation frame renders the latest world state through the Pixi render port and prints JSON state in the debug panel.
 
 ## Architecture Documentation
 
@@ -193,7 +194,9 @@ Before opening a PR, ensure:
   - player marker moves one tile per input tick
   - movement is clamped within grid bounds
   - `player.position` changes in the JSON panel
-4. Press `E` when not adjacent to an NPC and confirm the interaction panel says no NPC is nearby.
+4. Press `1` while no inventory item is present and confirm `player.inventory.selectedItem` stays `null` in the JSON panel.
+5. Press `F` and confirm `lastItemUseAttemptEvent.result` becomes `no-selection` in the JSON panel.
+6. Press `E` when not adjacent to an interactable target and confirm no interaction opens.
 
 ## Resources
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,11 +49,12 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 
 ### Frame Loop
 1. **Input Phase:** Keyboard input is captured and mapped to `WorldCommand` values, enqueued into `CommandBuffer`.
-2. **Tick Phase** (fixed 100ms): `runtimeController.stepSimulation()` is called. It drains the command buffer, gates commands based on current pause state and level outcome, then applies the resolved command set to world state via `world.applyCommands(commands)`. If the runtime is paused (a guard or NPC conversation is open), buffered commands are discarded and no world update or interaction dispatch occurs for that tick.
-3. **Interaction Dispatch:** If an `interact` command was issued and the runtime is not paused, `runInteractionIfRequested()` resolves one adjacent target and calls `interactionDispatcher.dispatch(...)`.
-4. **Result Routing:** Returned `InteractionHandlerResult` (sync or async) is routed through `resultDispatcher.dispatch(...)` into main-loop side effects. Conversational open results synchronously call `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`. Door and interactive-object results stay local to world-state reset and level-outcome callbacks.
-5. **Render Phase:** Every animation frame renders the latest world state through the PixiJS render port. Character sprite assets are loaded and resolved to sprite/marker mode inside the render layer only. Separate DOM render utilities manage the chat modal, paused-viewport overlay, and level-outcome overlay.
-6. **Debug Phase:** Current JSON world state is serialized and printed to the debug panel.
+2. **Tick Phase** (fixed 100ms): `runtimeController.stepSimulation()` is called. It drains the command buffer, gates commands based on current pause state and level outcome, then applies the resolved command set to world state via `world.applyCommands(commands)`. This same step also captures every `useSelectedItem` command index from the drained tick list and, after command application, routes those use attempts through the deterministic item-use resolver boundary. If the runtime is paused (a guard or NPC conversation is open), buffered commands are discarded and no world update, item-use resolution, or interaction dispatch occurs for that tick.
+3. **Deterministic Use-Attempt Routing:** When `useSelectedItem` commands are present, `RuntimeController` calls the injected item-use resolver with the post-command `WorldState` and each original command index. `main.ts` commits the latest emitted `ItemUseAttemptResultEvent` back into serialized world state through `world.resetToState(...)`.
+4. **Interaction Dispatch:** If an `interact` command was issued and the runtime is not paused, `runInteractionIfRequested()` resolves one adjacent target and calls `interactionDispatcher.dispatch(...)`.
+5. **Result Routing:** Returned `InteractionHandlerResult` (sync or async) is routed through `resultDispatcher.dispatch(...)` into main-loop side effects. Conversational open results synchronously call `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`. Door and interactive-object results stay local to world-state reset and level-outcome callbacks.
+6. **Render Phase:** Every animation frame renders the latest world state through the PixiJS render port. Character sprite assets are loaded and resolved to sprite/marker mode inside the render layer only. Separate DOM render utilities manage the chat modal, paused-viewport overlay, and level-outcome overlay.
+7. **Debug Phase:** Current JSON world state is serialized and printed to the debug panel.
 
 ```
 [Keyboard Input]
@@ -90,16 +91,23 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 - **Guarantee:** No game logic; only read and draw. Sprite load status maps and Pixi sprite instances are transient render concerns and are never written into `WorldState`.
 
 ### Interaction Layer
-- **Responsibility:**
-  - Route adjacent targets by kind using handler registries
-  - Preserve behavior parity between sync chat-open flow and async player-message flow
-  - Convert handler results into side-effect callbacks through result handlers
-- **Input:** Resolved adjacent target + current `WorldState` (+ optional player message for conversational turns).
-- **Output:** `InteractionHandlerResult` (or `Promise<InteractionHandlerResult>`).
-- **Guarantee:**
-  - Initial conversational open (`guard`/`npc` without player message) remains synchronous
-  - Conversational player-message turns remain asynchronous
-  - Door/object deterministic interactions remain synchronous and local
+Responsibilities:
+- Route adjacent targets by kind using handler registries
+- Preserve behavior parity between sync chat-open flow and async player-message flow
+- Provide deterministic item-use resolver boundaries for runtime-orchestrated selected-item use commands
+- Convert handler results into side-effect callbacks through result handlers
+
+Input:
+Resolved adjacent target + current `WorldState` (+ optional player message for conversational turns).
+
+Output:
+`InteractionHandlerResult` (or `Promise<InteractionHandlerResult>`).
+
+Guarantees:
+- Initial conversational open (`guard`/`npc` without player message) remains synchronous
+- Conversational player-message turns remain asynchronous
+- Selected-item use resolution remains synchronous, deterministic, and LLM-free
+- Door/object deterministic interactions remain synchronous and local
 
 ### Input Layer
 - **Responsibility:** Map keyboard input to game commands.

--- a/docs/TESTING_PATTERNS.md
+++ b/docs/TESTING_PATTERNS.md
@@ -23,6 +23,8 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
 - **Movement intent regression checks (`src/world/world.test.ts`):**
   - directional movement intents deterministically map to `player.facingDirection` (`left`, `right`, `away`, `front`)
   - facing direction still updates from directional intent when movement is blocked
+  - `selectInventorySlot` stores `{ slotIndex, itemId }` for valid indexes using the current deterministic inventory order
+  - invalid inventory indexes clear `player.inventory.selectedItem` to `null`
 
 ### Render Layer Tests
 - **What to test:** Sprite positioning, sprite lifecycle, viewport math, deterministic asset fallback, and DOM render utility behavior
@@ -83,6 +85,22 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
   - `drain()` returns a snapshot - mutating the returned array does not affect the buffer
   - a second `drain()` after the first returns an empty array until new commands are enqueued
   - `clear()` discards all pending commands without preventing future `enqueue()` operations
+- **Keyboard mapping checks** (`src/input/keyboard.test.ts`):
+  - `f` maps to `useSelectedItem`
+  - numeric keys `1`..`9` map to `selectInventorySlot` with zero-based `slotIndex`
+  - unrelated keys still resolve to `null`
+
+### Runtime Orchestration Tests
+- **What to test:** Tick-time command gating, pause semantics, command-indexed callbacks, and state-commit orchestration that intentionally lives outside the pure world layer
+- **Type:** Unit tests
+- **Pattern:** Enqueue commands into `CommandBuffer`, step `RuntimeController`, then assert callback order and payloads against the resulting world snapshot
+- **Item-use pipeline checks** (`src/runtimeController.test.ts`):
+  - each `useSelectedItem` command emits exactly one deterministic `ItemUseAttemptResultEvent`
+  - emitted events preserve the original command index from the drained tick list
+  - no selected item resolves to `no-selection`
+  - selected item with no target rules resolves to `no-target`
+  - multiple use commands in one tick emit stable ordered callbacks
+  - paused runtime and level-outcome gating prevent item-use callbacks from leaking through unintended ticks
 
 ### LLM Layer Tests
 - **What to test:** Context serialization, response parsing, API fallbacks
@@ -95,6 +113,7 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
 When features cross layer boundaries, write integration tests:
 - **Player movement + rendering:** World updates position and facing direction, render layer reflects the selected sprite orientation
 - **Input + world:** Keyboard input flows through buffer and updates world state
+- **Input + runtime item-use:** Keyboard input or buffered commands trigger stable selected-item use callbacks without mutating render or LLM layers directly
 - **Interaction + result routing:** Interact command resolves target, dispatcher returns result, result dispatcher applies side effect
 - **NPC interaction + LLM:** Player message triggers LLM call and updates conversation thread
 - **Conversation pause lifecycle:** Conversational open pauses the runtime, shows pause UI, and close/Escape resume the runtime through the shared `onClose` path

--- a/src/input/keyboard.test.ts
+++ b/src/input/keyboard.test.ts
@@ -16,6 +16,15 @@ describe('mapKeyboardEventToWorldCommand', () => {
 
   it('preserves interact mapping and ignores unrelated keys', () => {
     expect(mapKeyboardEventToWorldCommand('e')).toEqual({ type: 'interact' });
+    expect(mapKeyboardEventToWorldCommand('f')).toEqual({ type: 'useSelectedItem' });
+    expect(mapKeyboardEventToWorldCommand('1')).toEqual({
+      type: 'selectInventorySlot',
+      slotIndex: 0,
+    });
+    expect(mapKeyboardEventToWorldCommand('9')).toEqual({
+      type: 'selectInventorySlot',
+      slotIndex: 8,
+    });
     expect(mapKeyboardEventToWorldCommand('q')).toBeNull();
   });
 });

--- a/src/input/keyboard.ts
+++ b/src/input/keyboard.ts
@@ -11,9 +11,17 @@ const keyToCommandMap: Record<string, WorldCommand> = {
   s: { type: 'move', dx: 0, dy: 1 },
   d: { type: 'move', dx: 1, dy: 0 },
   e: { type: 'interact' },
+  f: { type: 'useSelectedItem' },
 };
 
 export const mapKeyboardEventToWorldCommand = (key: string): WorldCommand | null => {
+  if (/^[1-9]$/.test(key)) {
+    return {
+      type: 'selectInventorySlot',
+      slotIndex: Number(key) - 1,
+    };
+  }
+
   return keyToCommandMap[key] ?? null;
 };
 

--- a/src/interaction/adjacencyResolver.test.ts
+++ b/src/interaction/adjacencyResolver.test.ts
@@ -5,6 +5,11 @@ import type { Door, Guard, InteractiveObject, Npc, WorldState } from '../world/t
 const baseState = (): WorldState => ({
   tick: 0,
   grid: { width: 12, height: 8, tileSize: 48 },
+  levelMetadata: {
+    name: 'Test Level',
+    premise: 'Fixture for adjacency resolution tests.',
+    goal: 'Resolve adjacent targets.',
+  },
   levelObjective: 'Reach the safe exit.',
   player: {
     id: 'player-1',

--- a/src/interaction/interactionDispatcher.test.ts
+++ b/src/interaction/interactionDispatcher.test.ts
@@ -24,6 +24,11 @@ const createTestWorldState = (
   const baseState: WorldState = {
     tick: 0,
     grid: { width: 10, height: 10, tileSize: 32 },
+    levelMetadata: {
+      name: 'Test Level',
+      premise: 'Fixture for interaction dispatcher tests.',
+      goal: 'Dispatch interaction handlers deterministically.',
+    },
     levelObjective: 'Find a way out.',
     player: {
       id: 'player',

--- a/src/interaction/itemUse.ts
+++ b/src/interaction/itemUse.ts
@@ -1,0 +1,30 @@
+import type { ItemUseAttemptResultEvent, WorldState } from '../world/types';
+
+export interface ItemUseResolutionInput {
+  worldState: WorldState;
+  commandIndex: number;
+}
+
+export interface ItemUseResolver {
+  resolveItemUseAttempt(input: ItemUseResolutionInput): ItemUseAttemptResultEvent;
+}
+
+/**
+ * Default deterministic resolver for item-use attempts.
+ * Later tickets can extend this with door/guard/object-specific rule checks.
+ */
+export const createDefaultItemUseResolver = (): ItemUseResolver => {
+  return {
+    resolveItemUseAttempt({ worldState, commandIndex }: ItemUseResolutionInput): ItemUseAttemptResultEvent {
+      const selectedItem = worldState.player.inventory.selectedItem ?? null;
+
+      return {
+        tick: worldState.tick,
+        commandIndex,
+        selectedItem,
+        result: selectedItem ? 'no-target' : 'no-selection',
+        target: null,
+      };
+    },
+  };
+};

--- a/src/interaction/objectInteraction.test.ts
+++ b/src/interaction/objectInteraction.test.ts
@@ -29,7 +29,12 @@ const makeSupplyCrate = (
 
 const createWorldState = (...interactiveObjects: InteractiveObject[]): WorldState => ({
   tick: 0,
-  grid: { width: 12, height: 8, tileSize: 48 },
+  grid: { width: 10, height: 10, tileSize: 32 },
+  levelMetadata: {
+    name: 'Test Level',
+    premise: 'Fixture for object interaction tests.',
+    goal: 'Interact with nearby objects.',
+  },
   levelObjective: 'Inspect nearby objects for clues.',
   player,
   npcs: [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   isPromiseLike,
 } from './interaction/interactionDispatcher';
 import { getActorConversationHistory } from './interaction/actorConversationThread';
+import { createDefaultItemUseResolver } from './interaction/itemUse';
 import { createGeminiLlmClient } from './llm/client';
 import { createPixiRenderPort } from './render/scene';
 import { createLevelUi } from './render/levelUi';
@@ -51,6 +52,7 @@ const world = createWorld();
 const commandBuffer = createCommandBuffer();
 const llmClient = createGeminiLlmClient();
 const interactionDispatcher = createInteractionDispatcher({ llmClient });
+const itemUseResolver = createDefaultItemUseResolver();
 const outcomeOverlay = createOutcomeOverlay(outcomeOverlayHostElement);
 const viewportPauseOverlay = createViewportOverlay(viewportElement);
 const levelBriefingPanel = createLevelBriefingPanel(levelBriefingElement);
@@ -180,6 +182,14 @@ const runtimeController = createRuntimeController({
   world,
   commandBuffer,
   runInteractions: runInteractionIfRequested,
+  itemUseResolver,
+  onItemUseAttemptResolved: (event) => {
+    const currentState = world.getState();
+    world.resetToState({
+      ...currentState,
+      lastItemUseAttemptEvent: event,
+    });
+  },
 });
 
 const fixedTickDurationMs = 100;
@@ -201,7 +211,7 @@ const startRuntime = async (): Promise<void> => {
         .then((newState) => {
           world.resetToState(newState);
           levelUi.setSelectedLevel(levelId);
-          levelUi.setLevelObjective(newState.levelObjective);
+          levelUi.setLevelObjective(newState.levelObjective ?? newState.levelMetadata.goal);
           outcomeOverlay.hide();
           levelOutcomeShown = false;
         })
@@ -215,7 +225,7 @@ const startRuntime = async (): Promise<void> => {
       fetchAndLoadLevel(levelUrl)
         .then((newState) => {
           world.resetToState(newState);
-          levelUi.setLevelObjective(newState.levelObjective);
+          levelUi.setLevelObjective(newState.levelObjective ?? newState.levelMetadata.goal);
           outcomeOverlay.hide();
           levelOutcomeShown = false;
         })
@@ -241,7 +251,7 @@ const startRuntime = async (): Promise<void> => {
         levelUi.setSelectedLevel(defaultLevel.id);
         return fetchAndLoadLevel(`${LEVELS_BASE_URL}/${defaultLevel.id}.json`).then((newState) => {
           world.resetToState(newState);
-          levelUi.setLevelObjective(newState.levelObjective);
+          levelUi.setLevelObjective(newState.levelObjective ?? newState.levelMetadata.goal);
         });
       }
 

--- a/src/render/scene.test.ts
+++ b/src/render/scene.test.ts
@@ -14,6 +14,11 @@ const createWorldState = (): WorldState => ({
     height: 20,
     tileSize: 48,
   },
+  levelMetadata: {
+    name: 'Test Level',
+    premise: 'Fixture for scene rendering tests.',
+    goal: 'Render world entities.',
+  },
   levelObjective: 'Reach the safe door.',
   player: {
     id: 'player-1',

--- a/src/runtimeController.test.ts
+++ b/src/runtimeController.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createCommandBuffer } from './input/commands';
 import { createRuntimeController } from './runtimeController';
+import { createDefaultItemUseResolver } from './interaction/itemUse';
 import type { World, WorldCommand, WorldState } from './world/types';
 
 const createTestWorldState = (
@@ -16,6 +17,7 @@ const createTestWorldState = (
       position: { x: 1, y: 1 },
       inventory: {
         items: [],
+        selectedItem: null,
       },
     },
     guards: [],
@@ -143,5 +145,113 @@ describe('createRuntimeController', () => {
 
     expect(applyCommandsSpy).toHaveBeenCalledWith([]);
     expect(runInteractions).toHaveBeenCalledWith(world.getState(), []);
+  });
+
+  it('emits deterministic no-selection item-use result when no inventory item is selected', () => {
+    const commandBuffer = createCommandBuffer();
+    const { world } = createTestWorld();
+    const runInteractions = vi.fn();
+    const onItemUseAttemptResolved = vi.fn();
+    const controller = createRuntimeController({
+      world,
+      commandBuffer,
+      runInteractions,
+      itemUseResolver: createDefaultItemUseResolver(),
+      onItemUseAttemptResolved,
+    });
+
+    commandBuffer.enqueue({ type: 'useSelectedItem' });
+    controller.stepSimulation();
+
+    expect(onItemUseAttemptResolved).toHaveBeenCalledTimes(1);
+    expect(onItemUseAttemptResolved).toHaveBeenCalledWith({
+      tick: 1,
+      commandIndex: 0,
+      selectedItem: null,
+      result: 'no-selection',
+      target: null,
+    });
+  });
+
+  it('emits deterministic no-target item-use result when an inventory item is selected', () => {
+    const commandBuffer = createCommandBuffer();
+    const { world } = createTestWorld(
+      createTestWorldState({
+        player: {
+          inventory: {
+            items: [
+              {
+                itemId: 'key-bronze',
+                displayName: 'Bronze Key',
+                sourceObjectId: 'crate-1',
+                pickedUpAtTick: 0,
+              },
+            ],
+            selectedItem: {
+              slotIndex: 0,
+              itemId: 'key-bronze',
+            },
+          },
+        },
+      }),
+    );
+    const runInteractions = vi.fn();
+    const onItemUseAttemptResolved = vi.fn();
+    const controller = createRuntimeController({
+      world,
+      commandBuffer,
+      runInteractions,
+      itemUseResolver: createDefaultItemUseResolver(),
+      onItemUseAttemptResolved,
+    });
+
+    commandBuffer.enqueue({ type: 'useSelectedItem' });
+    controller.stepSimulation();
+
+    expect(onItemUseAttemptResolved).toHaveBeenCalledTimes(1);
+    expect(onItemUseAttemptResolved).toHaveBeenCalledWith({
+      tick: 1,
+      commandIndex: 0,
+      selectedItem: {
+        slotIndex: 0,
+        itemId: 'key-bronze',
+      },
+      result: 'no-target',
+      target: null,
+    });
+  });
+
+  it('emits item-use results deterministically for multiple use commands in one tick', () => {
+    const commandBuffer = createCommandBuffer();
+    const { world } = createTestWorld();
+    const runInteractions = vi.fn();
+    const onItemUseAttemptResolved = vi.fn();
+    const controller = createRuntimeController({
+      world,
+      commandBuffer,
+      runInteractions,
+      itemUseResolver: createDefaultItemUseResolver(),
+      onItemUseAttemptResolved,
+    });
+
+    commandBuffer.enqueue({ type: 'move', dx: 1, dy: 0 });
+    commandBuffer.enqueue({ type: 'useSelectedItem' });
+    commandBuffer.enqueue({ type: 'useSelectedItem' });
+    controller.stepSimulation();
+
+    expect(onItemUseAttemptResolved).toHaveBeenNthCalledWith(1, {
+      tick: 1,
+      commandIndex: 1,
+      selectedItem: null,
+      result: 'no-selection',
+      target: null,
+    });
+    expect(onItemUseAttemptResolved).toHaveBeenNthCalledWith(2, {
+      tick: 1,
+      commandIndex: 2,
+      selectedItem: null,
+      result: 'no-selection',
+      target: null,
+    });
   });
 });

--- a/src/runtimeController.test.ts
+++ b/src/runtimeController.test.ts
@@ -10,6 +10,11 @@ const createTestWorldState = (
   const baseState: WorldState = {
     tick: 0,
     grid: { width: 10, height: 10, tileSize: 32 },
+    levelMetadata: {
+      name: 'Test Level',
+      premise: 'Fixture for runtime controller tests.',
+      goal: 'Run deterministic simulation ticks.',
+    },
     levelObjective: 'Reach the safe exit.',
     player: {
       id: 'player',

--- a/src/runtimeController.ts
+++ b/src/runtimeController.ts
@@ -1,4 +1,6 @@
 import type { CommandBuffer } from './input/commands';
+import type { ItemUseResolver } from './interaction/itemUse';
+import type { ItemUseAttemptResultEvent } from './world/types';
 import type { World, WorldCommand, WorldState } from './world/types';
 
 export interface RuntimeConversationSession {
@@ -9,6 +11,8 @@ export interface RuntimeControllerDependencies {
   world: Pick<World, 'getState' | 'applyCommands'>;
   commandBuffer: Pick<CommandBuffer, 'drain' | 'clear'>;
   runInteractions: (worldState: WorldState, commands: WorldCommand[]) => void;
+  itemUseResolver?: ItemUseResolver;
+  onItemUseAttemptResolved?: (event: ItemUseAttemptResultEvent) => void;
 }
 
 export interface RuntimeController {
@@ -39,8 +43,25 @@ export const createRuntimeController = (
         commandsToApply = [];
       }
 
+      const useSelectedItemCommandIndexes = commandsToApply
+        .map((command, index) => (command.type === 'useSelectedItem' ? index : null))
+        .filter((index): index is number => index !== null);
+
       dependencies.world.applyCommands(commandsToApply);
       const worldState = dependencies.world.getState();
+
+      if (dependencies.itemUseResolver && dependencies.onItemUseAttemptResolved) {
+        useSelectedItemCommandIndexes.forEach((commandIndex) => {
+          const event = dependencies.itemUseResolver?.resolveItemUseAttempt({
+            worldState,
+            commandIndex,
+          });
+          if (event) {
+            dependencies.onItemUseAttemptResolved?.(event);
+          }
+        });
+      }
+
       dependencies.runInteractions(worldState, commandsToApply);
     },
 

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -26,6 +26,7 @@ describe('deserializeLevel', () => {
       position: { x: 2, y: 3 },
       inventory: {
         items: [],
+        selectedItem: null,
       },
       facingDirection: 'front',
     });
@@ -433,7 +434,7 @@ describe('starter level', () => {
     const level = validateLevelData(starterRaw);
     const state = deserializeLevel(level);
 
-    expect(state.levelObjective).toBe(level.objective);
+    expect(state.levelObjective).toBe(level.objective ?? level.goal);
   });
 
   it('has a 20×20 grid', () => {

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -324,12 +324,14 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       premise: levelData.premise,
       goal: levelData.goal,
     },
+    levelObjective: levelData.objective ?? levelData.goal,
     player: {
       id: 'player',
       displayName: 'Player',
       position: { x: levelData.player.x, y: levelData.player.y },
       inventory: {
         items: [],
+        selectedItem: null,
       },
       facingDirection: 'front',
       ...(levelData.player.spriteAssetPath !== undefined
@@ -413,6 +415,7 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       spriteSet: o.spriteSet,
     })),
     actorConversationHistoryByActorId: {},
+    lastItemUseAttemptEvent: null,
     levelOutcome: null,
   };
   validateSpatialLayout(worldState);

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -18,6 +18,7 @@ export const createInitialWorldState = (): WorldState => ({
     position: { x: 1, y: 1 },
     inventory: {
       items: [],
+      selectedItem: null,
     },
     facingDirection: 'front',
   },

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -12,6 +12,7 @@ export const createInitialWorldState = (): WorldState => ({
     premise: 'A baseline deterministic world used before a level is loaded.',
     goal: 'Move around and interact with nearby entities.',
   },
+  levelObjective: 'Move around and interact with nearby entities.',
   player: {
     id: 'player-1',
     displayName: 'Guard',
@@ -47,6 +48,7 @@ export const createInitialWorldState = (): WorldState => ({
     },
   ],
   actorConversationHistoryByActorId: {},
+  lastItemUseAttemptEvent: null,
   levelOutcome: null,
 });
 

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -26,6 +26,25 @@ export interface InventoryItem {
 
 export interface PlayerInventory {
   items: InventoryItem[];
+  selectedItem: SelectedInventoryItem | null;
+}
+
+export interface SelectedInventoryItem {
+  slotIndex: number;
+  itemId: string;
+}
+
+export type ItemUseAttemptResult = 'no-selection' | 'no-target' | 'blocked' | 'success';
+
+export interface ItemUseAttemptResultEvent {
+  tick: number;
+  commandIndex: number;
+  selectedItem: SelectedInventoryItem | null;
+  result: ItemUseAttemptResult;
+  target: {
+    kind: 'door' | 'guard' | 'npc' | 'interactiveObject';
+    targetId: string;
+  } | null;
 }
 
 export interface Player {
@@ -230,6 +249,13 @@ export type WorldCommand =
     }
   | {
       type: 'interact';
+    }
+  | {
+      type: 'selectInventorySlot';
+      slotIndex: number;
+    }
+  | {
+      type: 'useSelectedItem';
     };
 
 export interface World {

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -26,7 +26,7 @@ export interface InventoryItem {
 
 export interface PlayerInventory {
   items: InventoryItem[];
-  selectedItem: SelectedInventoryItem | null;
+  selectedItem?: SelectedInventoryItem | null;
 }
 
 export interface SelectedInventoryItem {
@@ -162,6 +162,7 @@ export interface LevelData {
   name: string;
   premise: string;
   goal: string;
+  objective?: string;
   width: number;
   height: number;
   player: { x: number; y: number; spriteAssetPath?: string; spriteSet?: SpriteSet };
@@ -232,12 +233,14 @@ export interface WorldState {
   tick: number;
   grid: WorldGrid;
   levelMetadata: LevelMetadata;
+  levelObjective?: string;
   player: Player;
   npcs: Npc[];
   guards: Guard[];
   doors: Door[];
   interactiveObjects: InteractiveObject[];
   actorConversationHistoryByActorId: ActorConversationHistoryByActorId;
+  lastItemUseAttemptEvent?: ItemUseAttemptResultEvent | null;
   levelOutcome: 'win' | 'lose' | null;
 }
 

--- a/src/world/world.test.ts
+++ b/src/world/world.test.ts
@@ -141,4 +141,72 @@ describe('createWorld', () => {
     expect(canMoveSpy).toHaveBeenCalledTimes(1);
     expect(canMoveSpy).toHaveBeenCalledWith(expect.any(Object), { x: 2, y: 1 });
   });
+
+  it('selects a valid inventory slot deterministically', () => {
+    const world = createWorld();
+    const baseState = world.getState();
+
+    world.resetToState({
+      ...baseState,
+      player: {
+        ...baseState.player,
+        inventory: {
+          ...baseState.player.inventory,
+          items: [
+            {
+              itemId: 'key-bronze',
+              displayName: 'Bronze Key',
+              sourceObjectId: 'crate-1',
+              pickedUpAtTick: 0,
+            },
+            {
+              itemId: 'gem-blue',
+              displayName: 'Blue Gem',
+              sourceObjectId: 'crate-2',
+              pickedUpAtTick: 0,
+            },
+          ],
+          selectedItem: null,
+        },
+      },
+    });
+
+    world.applyCommands([{ type: 'selectInventorySlot', slotIndex: 1 }]);
+
+    expect(world.getState().player.inventory.selectedItem).toEqual({
+      slotIndex: 1,
+      itemId: 'gem-blue',
+    });
+  });
+
+  it('clears selected inventory item when selecting an invalid slot index', () => {
+    const world = createWorld();
+    const baseState = world.getState();
+
+    world.resetToState({
+      ...baseState,
+      player: {
+        ...baseState.player,
+        inventory: {
+          ...baseState.player.inventory,
+          items: [
+            {
+              itemId: 'key-bronze',
+              displayName: 'Bronze Key',
+              sourceObjectId: 'crate-1',
+              pickedUpAtTick: 0,
+            },
+          ],
+          selectedItem: {
+            slotIndex: 0,
+            itemId: 'key-bronze',
+          },
+        },
+      },
+    });
+
+    world.applyCommands([{ type: 'selectInventorySlot', slotIndex: 9 }]);
+
+    expect(world.getState().player.inventory.selectedItem).toBeNull();
+  });
 });

--- a/src/world/world.ts
+++ b/src/world/world.ts
@@ -47,6 +47,27 @@ const applyCommand = (worldState: WorldState, command: WorldCommand): WorldState
     };
   }
 
+  if (command.type === 'selectInventorySlot') {
+    const selectedCandidate = worldState.player.inventory.items[command.slotIndex];
+    const selectedItem = selectedCandidate
+      ? {
+          slotIndex: command.slotIndex,
+          itemId: selectedCandidate.itemId,
+        }
+      : null;
+
+    return {
+      ...worldState,
+      player: {
+        ...worldState.player,
+        inventory: {
+          ...worldState.player.inventory,
+          selectedItem,
+        },
+      },
+    };
+  }
+
   return worldState;
 };
 


### PR DESCRIPTION
## Summary
- add deterministic selected inventory slot state and update rules in world state
- add deterministic input commands for inventory slot selection (1-9) and selected item use (F)
- add runtime item-use attempt resolver boundary and deterministic result event emission
- initialize and deserialize world state with selected inventory and last item-use attempt event defaults
- keep interaction/world/input/render boundaries intact while wiring runtime callbacks

## Validation
- npm test

## Closes #117