### PR TITLE
Enforce ticket closure after merge and level NPC/object asset coverage

### DIFF
--- a/.github/agents/content-manager.agent.md
+++ b/.github/agents/content-manager.agent.md
@@ -15,6 +15,7 @@ Your role is to provide production-ready game assets and keep visual direction c
 - Create assets as SVG whenever a ticket requires any art or visual content.
 - Own game art direction and enforce a simple medieval visual theme suitable for a 2D grid-based game.
 - Ensure all on-grid assets are provided as `64x64` SVG files unless the user explicitly requests another size.
+- For any level work, create or validate assets for every NPC and interactive object used in that level.
 - Deliver assets after requirements are refined or broken down, and before the developer starts implementation.
 
 ## Art Direction Rules
@@ -36,16 +37,18 @@ Your role is to provide production-ready game assets and keep visual direction c
 ## Workflow
 
 1. Read the refined ticket scope and list all required assets.
-2. Define a small asset set that satisfies the scope and art direction.
-3. Create SVG assets with 64x64 sizing for grid entities.
-4. Validate asset consistency and sizing.
-5. Hand off an asset manifest summary (file names + purpose) for developer implementation.
+2. If the ticket includes level JSON or level build instructions, inventory all NPC and interactive object entries used by the level.
+3. Create missing assets (or update outdated ones) so every NPC/object used in the level has a production-ready asset.
+4. Validate that each referenced NPC/object has a corresponding asset file and consistent naming.
+5. Validate asset consistency and sizing.
+6. Hand off an asset manifest summary (file names + purpose + mapped NPC/object ids/types) for developer implementation.
 
 ## Constraints
 
 - Do not implement gameplay code unless explicitly asked.
 - Do not produce raster assets first when SVG is feasible.
 - Do not bypass medieval style and readability constraints without user approval.
+- Do not hand off level content tickets with uncovered NPC/object assets; treat missing coverage as a blocking asset gap.
 - If requested assets are ambiguous, clarify requirements before generating many variants.
 
 ## Output Format

--- a/.github/agents/coordinator.agent.md
+++ b/.github/agents/coordinator.agent.md
@@ -25,6 +25,7 @@ Your job is to orchestrate a complete ticket workflow across specialized agents 
 - Invoke `content manager` after ticket refinement and before implementation whenever assets are needed.
 - Require asset delivery as SVG by default.
 - Require `64x64` SVG assets for anything placed on the game grid unless the user explicitly approves another size.
+- For level tickets, require explicit NPC/object asset coverage: every NPC and interactive object used in the level must have a mapped asset in the handoff summary.
 - Confirm the asset handoff summary is available before invoking `developer`.
 
 3. Implementation stage:
@@ -50,6 +51,7 @@ Your job is to orchestrate a complete ticket workflow across specialized agents 
 7. Completion stage:
 - When PR is merge-ready and docs are updated, invoke `developer` to finish the PR flow.
 - Confirm merge result and local-main fast-forward status.
+- Confirm the corresponding ticket was closed as `Done`/`Completed` immediately after merge.
 - If the merged ticket is a sub ticket, ensure a parent-ticket status comment is added summarizing the change.
 - When the last sub ticket is merged, run parent-ticket completion review and transition parent to `Done` only if review passes.
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -13,6 +13,7 @@ Your job is to implement GitHub issues for the Guard Game project in small, work
 - Read the target GitHub issue and acceptance criteria before writing code.
 - Implement code changes directly in this repository.
 - Use GitHub through MCP GitHub tools only; do not use the GitHub CLI (`gh`) for issue, branch, pull request, or label operations.
+- After merging an implementation PR, close the corresponding ticket immediately and verify it is in `Done`/`Completed` state.
 - Hand off AI behavior customization requests to the `ai behavior adjuster` agent instead of implementing them here.
 - Work in a highly structured way and explicitly use the workflow skills for each phase:
   - `plan`
@@ -92,7 +93,8 @@ If the user asks you to finish a PR, follow this exact sequence:
 2. If PR passes:
   - consider and apply non-blocking comment adjustments when they improve quality
   - merge the PR
-  - close the ticket as `Done`/`Completed` (the merged PR must be the ticket's only implementation PR)
+  - close the corresponding ticket as `Done`/`Completed` immediately after merge (the merged PR must be the ticket's only implementation PR)
+  - verify the ticket state after closing; if close/transition fails, retry and report the blocker
   - if this was a sub ticket, add a parent-ticket comment summarizing what changed and linking the merged PR
   - if this was the last open sub ticket under a parent ticket, run parent completion review and close parent only when review passes
   - fast-forward local `main`


### PR DESCRIPTION
## Summary
This AI behavior update tightens workflow enforcement in agent instructions.

### Changes
- Updated `developer` agent instructions to require immediate ticket closure after PR merge and explicit post-close status verification.
- Updated `content manager` agent instructions to require complete NPC/object asset coverage for level work (create/validate assets for every level-used NPC and interactive object).
- Updated `coordinator` agent instructions to enforce both:
  - level NPC/object asset coverage in content handoff
  - ticket closure confirmation after merge completion

## Files Updated
- `.github/agents/developer.agent.md`
- `.github/agents/content-manager.agent.md`
- `.github/agents/coordinator.agent.md`

## Validation
- Reviewed diffs for all three instruction files.
- Confirmed workflow steps now explicitly enforce requested behavior.

## Notes
- This PR intentionally contains AI/workflow customization only.
- No gameplay/runtime code changes included.