### PR TITLE
#132 Generic Entity Core and Capability Registry

### DIFF
--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -58,6 +58,21 @@ Serializable optional directional sprite metadata:
 
 `default` is the deterministic base asset for missing directional keys.
 
+### GameEntity
+Base interface shared by all world entities. JSON-serializable.
+- `id: string`
+- `position: GridPosition`
+- `displayName: string`
+- `spriteSet?: SpriteSet`
+- `spriteAssetPath?: string`
+
+### EntityCapabilities
+Opt-in capability container for game entities. Omit a key if the entity lacks that capability.
+- `inventory?: { items: InventoryItem[] }` - Entity can carry items
+- `dialogue?: { threadId?: string }` - Entity participates in conversation threads
+- `patrol?: { path: GridPosition[] }` - Entity follows a patrol path
+- `lock?: { isLocked: boolean; requiredItemId?: string }` - Entity has a lock mechanism
+
 ### Player
 - `id: string`
 - `displayName: string`
@@ -114,7 +129,7 @@ Represents one deterministic selected-item use attempt resolved for a specific c
 - `instanceBehavior?: string` - Instance-specific behavior traits for this NPC; included in prompt context output when set
 
 ### Guard
-Extends `Interactable`:
+Extends `GameEntity`:
 - `guardState: 'idle' | 'patrolling' | 'alert'`
 - `honestyTrait?: 'truth-teller' | 'liar'`
 - `spriteAssetPath?: string`
@@ -124,7 +139,7 @@ Extends `Interactable`:
 - `itemUseRules?: Record<string, ItemUseRule>` - Deterministic item-use rules keyed by item ID. When player uses a matching item on this guard, the rule determines success/blocked outcome.
 
 ### Door
-Extends `Interactable`:
+Extends `GameEntity`:
 - `doorState: 'open' | 'closed' | 'locked'`
 - `outcome?: 'safe' | 'danger'`
 - `requiredItemId?: string` - Item id required to unlock this door via item-use. If set, door must be interacted with using this item before traversal is allowed.
@@ -134,7 +149,7 @@ Extends `Interactable`:
 - `spriteSet?: SpriteSet`
 
 ### InteractiveObject
-Extends `Interactable`:
+Extends `GameEntity`:
 - `objectType: 'supply-crate'`
 - `interactionType: 'inspect' | 'use' | 'talk'`
 - `state: 'idle' | 'used'`

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -95,14 +95,32 @@ export interface RiddleClueConstraint {
   constraint: string;
 }
 
-export interface Npc {
+/**
+ * Shared structural base for all game entities.
+ * All world entities share this common root. JSON-serializable.
+ */
+export interface GameEntity {
   id: string;
-  displayName: string;
   position: GridPosition;
+  displayName: string;
+  spriteSet?: SpriteSet;
+  spriteAssetPath?: string;
+}
+
+/**
+ * Opt-in capability container for game entities.
+ * Capabilities are typed sub-objects; omit a key if the entity lacks that capability.
+ */
+export interface EntityCapabilities {
+  inventory?: { items: InventoryItem[] };
+  dialogue?: { threadId?: string };
+  patrol?: { path: GridPosition[] };
+  lock?: { isLocked: boolean; requiredItemId?: string };
+}
+
+export interface Npc extends GameEntity {
   npcType: string;
   dialogueContextKey: string;
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
   /** Instance-specific knowledge this NPC has (overrides or extends type-level knowledge). */
   instanceKnowledge?: string;
   /** Instance-specific behavior traits for this NPC (overrides or extends type-level behavior). */
@@ -118,20 +136,11 @@ export interface ConversationMessage {
 
 export type ActorConversationHistoryByActorId = Record<string, ConversationMessage[]>;
 
-/** Shared base for all interactable world objects. JSON-serializable. */
-export interface Interactable {
-  id: string;
-  displayName: string;
-  position: GridPosition;
-}
-
 /** A guard entity that the player can interact with. */
-export interface Guard extends Interactable {
+export interface Guard extends GameEntity {
   guardState: 'idle' | 'patrolling' | 'alert';
   honestyTrait?: 'truth-teller' | 'liar';
   facingDirection?: SpriteDirection;
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
   /** Instance-specific knowledge this guard has (overrides or extends type-level knowledge). */
   instanceKnowledge?: string;
   /** Instance-specific behavior traits for this guard (overrides or extends type-level behavior). */
@@ -141,18 +150,16 @@ export interface Guard extends Interactable {
 }
 
 /** A door that the player can pass through or be blocked by. */
-export interface Door extends Interactable {
+export interface Door extends GameEntity {
   doorState: 'open' | 'closed' | 'locked';
   outcome?: 'safe' | 'danger';
   /** Item ID required to unlock this door (if set, door must be interacted with using this item) */
   requiredItemId?: string;
   /** Whether this door has been unlocked via item-use (persists unlock state; default: false) */
   isUnlocked?: boolean;
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
 }
 
-export interface InteractiveObject extends Interactable {
+export interface InteractiveObject extends GameEntity {
   objectType: 'supply-crate' | 'mechanism';
   interactionType: 'inspect' | 'use' | 'talk';
   state: 'idle' | 'used';
@@ -163,8 +170,6 @@ export interface InteractiveObject extends Interactable {
   idleMessage?: string;
   usedMessage?: string;
   firstUseOutcome?: 'win' | 'lose';
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
   /** Deterministic item-use rules: item ID → rule definition */
   itemUseRules?: Record<string, ItemUseRule>;
 }


### PR DESCRIPTION
## Summary

Introduces `GameEntity` as the shared structural base for all world entities and adds the `EntityCapabilities` opt-in capability container pattern in `src/world/types.ts`.

### Changes

- **Added `GameEntity`** — common base with `id`, `position`, `displayName`, `spriteSet?`, `spriteAssetPath?`
- **Added `EntityCapabilities`** — typed opt-in sub-objects: `inventory?`, `dialogue?`, `patrol?`, `lock?`
- **`Guard`, `Door`, `InteractiveObject`** now extend `GameEntity`; the internal `Interactable` base is removed
- **`Npc`** now extends `GameEntity` (previously it had all fields inline without a shared base)
- Removed all duplicated `id`, `position`, `displayName`, `spriteSet?`, `spriteAssetPath?` from each concrete type; they are inherited from `GameEntity`

### Out of scope (as specified)

- No changes to `deserializeLevel()` or level JSON format
- No changes to interaction handlers or dispatch routing

### Validation

- `npm run test`: 349 tests pass, 3 pre-existing failures in `keyboard-modal-suppression.test.ts` (`window is not defined`, unrelated to this change)
- `npx tsc --noEmit`: 0 new errors introduced (17 pre-existing errors in unrelated test files)
- `WorldState` remains fully JSON-serializable

Closes #132