### PR TITLE
#133 Unified Trait/Fact State for LLM-Readable NPC and Object Behavior

### DIFF
--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -65,6 +65,8 @@ Base interface shared by all world entities. JSON-serializable.
 - `displayName: string`
 - `spriteSet?: SpriteSet`
 - `spriteAssetPath?: string`
+- `traits?: Record<string, string>` - Open-ended behavioral traits bag, directly readable by LLM prompt builders. E.g. `{ truthMode: 'truth-teller' | 'liar' }` on guards.
+- `facts?: Record<string, string | number | boolean>` - Open-ended facts bag for arbitrary key/value data, directly readable by LLM prompt builders.
 
 ### EntityCapabilities
 Opt-in capability container for game entities. Omit a key if the entity lacks that capability.
@@ -131,7 +133,7 @@ Represents one deterministic selected-item use attempt resolved for a specific c
 ### Guard
 Extends `GameEntity`:
 - `guardState: 'idle' | 'patrolling' | 'alert'`
-- `honestyTrait?: 'truth-teller' | 'liar'`
+- `traits.truthMode?: 'truth-teller' | 'liar'` - Guard honesty mode, now stored in the shared `traits` bag. Defaults to `'truth-teller'` when absent.
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`
 - `instanceKnowledge?: string` - Instance-specific knowledge this guard has; included in prompt context output when set

--- a/public/levels/guard-bribe.json
+++ b/public/levels/guard-bribe.json
@@ -16,6 +16,9 @@
       "x": 10,
       "y": 7,
       "guardState": "idle",
+      "traits": {
+        "truthMode": "truth-teller"
+      },
       "spriteSet": {
         "default": "/assets/medieval_guard_shield_spear_front.svg",
         "front": "/assets/medieval_guard_shield_spear_front.svg",

--- a/public/levels/riddle.json
+++ b/public/levels/riddle.json
@@ -23,7 +23,7 @@
       "x": 8,
       "y": 10,
       "guardState": "idle",
-      "honestyTrait": "truth-teller",
+      "traits": { "truthMode": "truth-teller" },
       "spriteSet": {
         "default": "/assets/medieval_guard_shield_spear_front.svg",
         "front": "/assets/medieval_guard_shield_spear_front.svg",
@@ -38,7 +38,7 @@
       "x": 12,
       "y": 10,
       "guardState": "idle",
-      "honestyTrait": "liar",
+      "traits": { "truthMode": "liar" },
       "spriteSet": {
         "default": "/assets/medieval_guard_shield_spear_front.svg",
         "front": "/assets/medieval_guard_shield_spear_front.svg",

--- a/public/levels/starter.json
+++ b/public/levels/starter.json
@@ -17,6 +17,9 @@
       "x": 5,
       "y": 10,
       "guardState": "patrolling",
+      "traits": {
+        "truthMode": "truth-teller"
+      },
       "spriteSet": {
         "default": "/assets/medieval_guard_spear_front.svg",
         "front": "/assets/medieval_guard_spear_front.svg",
@@ -37,6 +40,9 @@
       "x": 10,
       "y": 5,
       "guardState": "patrolling",
+      "traits": {
+        "truthMode": "truth-teller"
+      },
       "spriteSet": {
         "default": "/assets/medieval_guard_spear_front.svg",
         "front": "/assets/medieval_guard_spear_front.svg",

--- a/src/input/keyboard-modal-suppression.test.ts
+++ b/src/input/keyboard-modal-suppression.test.ts
@@ -2,43 +2,72 @@ import { describe, expect, it, vi } from 'vitest';
 import { bindKeyboardCommands, mapKeyboardEventToWorldCommand } from './keyboard';
 import { createCommandBuffer } from './commands';
 
+const createKeyboardTarget = (): {
+  target: Window;
+  dispatchKey: (key: string) => void;
+} => {
+  const listeners = new Set<(event: KeyboardEvent) => void>();
+
+  const target = {
+    addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+      if (typeof listener === 'function') {
+        listeners.add(listener as (event: KeyboardEvent) => void);
+      }
+    },
+    removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+      if (typeof listener === 'function') {
+        listeners.delete(listener as (event: KeyboardEvent) => void);
+      }
+    },
+  } as unknown as Window;
+
+  const dispatchKey = (key: string): void => {
+    const event = {
+      key,
+      preventDefault: () => {
+        // no-op for tests
+      },
+    } as unknown as KeyboardEvent;
+    listeners.forEach((listener) => listener(event));
+  };
+
+  return { target, dispatchKey };
+};
+
 describe('keyboard binding', () => {
   it('enqueues movement commands when modal is not open', () => {
     const commandBuffer = createCommandBuffer();
     const isModalOpen = vi.fn(() => false);
+    const { target, dispatchKey } = createKeyboardTarget();
 
-    bindKeyboardCommands(window, commandBuffer, { isModalOpen });
+    bindKeyboardCommands(target, commandBuffer, { isModalOpen });
+    dispatchKey('ArrowUp');
 
-    const event = new KeyboardEvent('keydown', { key: 'ArrowUp' });
-    window.dispatchEvent(event);
-
-    const commands = commandBuffer.dequeueAll();
+    const commands = commandBuffer.drain();
     expect(commands).toContainEqual({ type: 'move', dx: 0, dy: -1 });
   });
 
   it('suppresses movement commands when modal is open', () => {
     const commandBuffer = createCommandBuffer();
     const isModalOpen = vi.fn(() => true);
+    const { target, dispatchKey } = createKeyboardTarget();
 
-    bindKeyboardCommands(window, commandBuffer, { isModalOpen });
+    bindKeyboardCommands(target, commandBuffer, { isModalOpen });
+    dispatchKey('ArrowUp');
 
-    const event = new KeyboardEvent('keydown', { key: 'ArrowUp' });
-    window.dispatchEvent(event);
-
-    const commands = commandBuffer.dequeueAll();
+    const commands = commandBuffer.drain();
     expect(commands).toEqual([]);
   });
 
   it('suppresses interact commands when modal is open', () => {
     const commandBuffer = createCommandBuffer();
     const isModalOpen = vi.fn(() => true);
+    const { target, dispatchKey } = createKeyboardTarget();
 
-    bindKeyboardCommands(window, commandBuffer, { isModalOpen });
+    bindKeyboardCommands(target, commandBuffer, { isModalOpen });
+    dispatchKey('e');
 
-    const event = new KeyboardEvent('keydown', { key: 'e' });
-    window.dispatchEvent(event);
-
-    const commands = commandBuffer.dequeueAll();
+    const commands = commandBuffer.drain();
     expect(commands).toEqual([]);
   });
 });

--- a/src/integration/riddleLevel.test.ts
+++ b/src/integration/riddleLevel.test.ts
@@ -57,16 +57,16 @@ describe('riddle level integration pipeline', () => {
     });
   });
 
-  it('has guards with correct honestyTrait values', () => {
+  it('has guards with correct traits.truthMode values', () => {
     const worldState = createRiddleState();
 
     const truthGuard = worldState.guards.find((guard) => guard.id === 'guard-truth');
     expect(truthGuard).toBeDefined();
-    expect(truthGuard?.honestyTrait).toBe('truth-teller');
+    expect(truthGuard?.traits?.truthMode).toBe('truth-teller');
 
     const liarGuard = worldState.guards.find((guard) => guard.id === 'guard-liar');
     expect(liarGuard).toBeDefined();
-    expect(liarGuard?.honestyTrait).toBe('liar');
+    expect(liarGuard?.traits?.truthMode).toBe('liar');
   });
 
   it('has doors with correct outcome values', () => {

--- a/src/interaction/guardPromptContext.test.ts
+++ b/src/interaction/guardPromptContext.test.ts
@@ -17,14 +17,14 @@ describe('buildGuardWorldContextPayload', () => {
         displayName: 'South Guard',
         position: { x: 4, y: 8 },
         guardState: 'patrolling',
-        honestyTrait: 'liar',
+        traits: { truthMode: 'liar' },
       },
       {
         id: 'guard-1',
         displayName: 'North Guard',
         position: { x: 1, y: 0 },
         guardState: 'idle',
-        honestyTrait: 'truth-teller',
+        traits: { truthMode: 'truth-teller' },
       },
     ];
     worldState.doors = [
@@ -165,14 +165,14 @@ describe('guard truth encoding', () => {
       displayName: 'Truth Guard',
       position: { x: 1, y: 1 },
       guardState: 'idle' as const,
-      honestyTrait: 'truth-teller' as const,
+      traits: { truthMode: 'truth-teller' as const },
     };
     const liar = {
       id: 'g-liar',
       displayName: 'Liar Guard',
       position: { x: 2, y: 2 },
       guardState: 'idle' as const,
-      honestyTrait: 'liar' as const,
+      traits: { truthMode: 'liar' as const },
     };
     worldState.guards = [liar, truthTeller];
 

--- a/src/interaction/guardPromptContext.ts
+++ b/src/interaction/guardPromptContext.ts
@@ -12,7 +12,7 @@ import {
 export const GUARD_PERSONA_CONTRACT =
   'You are a vigilant city guard. Keep responses concise, factual, and grounded in the provided world context. The actor and each guard include a truth boolean: if truth is true, answer truthfully; if truth is false, answer with the logical opposite while still sounding confident and never admitting deception. Infer which door the actor is guarding from relative positions. Do not invent positions or events not present in context.';
 
-const isGuardTruthful = (guard: Guard): boolean => guard.honestyTrait !== 'liar';
+const isGuardTruthful = (guard: Guard): boolean => guard.traits?.truthMode !== 'liar';
 
 export interface GuardWorldContextPayload {
   player: {

--- a/src/interaction/npcPromptContext.ts
+++ b/src/interaction/npcPromptContext.ts
@@ -145,7 +145,7 @@ export const ACTOR_TYPE_WORLD_KNOWLEDGE_BUILDERS: Record<string, ActorTypeWorldK
         id: guard.id,
         displayName: guard.displayName,
         position: { x: guard.position.x, y: guard.position.y },
-        truth: guard.honestyTrait !== 'liar',
+        truth: guard.traits?.truthMode !== 'liar',
       }));
 
     const doors = [...worldState.doors]

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -599,34 +599,34 @@ describe('starter level', () => {
   });
 });
 
-describe('honestyTrait field', () => {
-  it('accepts guards with honestyTrait: "truth-teller"', () => {
+describe('traits field', () => {
+  it('accepts guards with traits.truthMode: "truth-teller"', () => {
     const level: LevelData = {
       ...minimalLevel,
-      guards: [{ id: 'guard-1', displayName: 'Truthful', x: 5, y: 7, guardState: 'idle', honestyTrait: 'truth-teller' }],
+      guards: [{ id: 'guard-1', displayName: 'Truthful', x: 5, y: 7, guardState: 'idle', traits: { truthMode: 'truth-teller' } }],
       doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
     };
 
     const validated = validateLevelData(level);
     const state = deserializeLevel(validated);
 
-    expect(state.guards[0].honestyTrait).toBe('truth-teller');
+    expect(state.guards[0].traits?.truthMode).toBe('truth-teller');
   });
 
-  it('accepts guards with honestyTrait: "liar"', () => {
+  it('accepts guards with traits.truthMode: "liar"', () => {
     const level: LevelData = {
       ...minimalLevel,
-      guards: [{ id: 'guard-1', displayName: 'Lying', x: 5, y: 7, guardState: 'idle', honestyTrait: 'liar' }],
+      guards: [{ id: 'guard-1', displayName: 'Lying', x: 5, y: 7, guardState: 'idle', traits: { truthMode: 'liar' } }],
       doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
     };
 
     const validated = validateLevelData(level);
     const state = deserializeLevel(validated);
 
-    expect(state.guards[0].honestyTrait).toBe('liar');
+    expect(state.guards[0].traits?.truthMode).toBe('liar');
   });
 
-  it('accepts guards without honestyTrait field', () => {
+  it('accepts guards without traits field', () => {
     const level: LevelData = {
       ...minimalLevel,
       guards: [{ id: 'guard-1', displayName: 'Unknown', x: 5, y: 7, guardState: 'idle' }],
@@ -636,17 +636,27 @@ describe('honestyTrait field', () => {
     const validated = validateLevelData(level);
     const state = deserializeLevel(validated);
 
-    expect(state.guards[0].honestyTrait).toBeUndefined();
+    expect(state.guards[0].traits).toBeUndefined();
   });
 
-  it('rejects guards with invalid honestyTrait value', () => {
+  it('rejects guards with non-object traits value', () => {
     const bad = {
       ...minimalLevel,
-      guards: [{ id: 'guard-1', displayName: 'Bad', x: 5, y: 7, guardState: 'idle', honestyTrait: 'dishonest' as unknown }],
+      guards: [{ id: 'guard-1', displayName: 'Bad', x: 5, y: 7, guardState: 'idle', traits: 'dishonest' as unknown }],
       doors: [{ id: 'door-1', displayName: 'Door', x: 2, y: 3, doorState: 'open', outcome: 'safe' }],
     };
 
-    expect(() => validateLevelData(bad)).toThrowError('invalid honestyTrait');
+    expect(() => validateLevelData(bad)).toThrowError('invalid traits (must be a plain object when provided)');
+  });
+
+  it('rejects guards with non-string trait value', () => {
+    const bad = {
+      ...minimalLevel,
+      guards: [{ id: 'guard-1', displayName: 'Bad', x: 5, y: 7, guardState: 'idle', traits: { truthMode: 42 } as unknown }],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 2, y: 3, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('traits.truthMode must be a string');
   });
 
   it('rejects guards with non-string spriteAssetPath', () => {

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -135,11 +135,16 @@ export function validateLevelData(input: unknown): LevelData {
       );
     }
     // honestyTrait is optional
-    if (guard['honestyTrait'] !== undefined) {
-      if (guard['honestyTrait'] !== 'truth-teller' && guard['honestyTrait'] !== 'liar') {
-        throw new Error(
-          `Invalid level data: guard at index ${i} has invalid honestyTrait (must be 'truth-teller' or 'liar')`,
-        );
+    // traits is optional — validate it's a plain string-valued object when present
+    if (guard['traits'] !== undefined) {
+      if (typeof guard['traits'] !== 'object' || guard['traits'] === null || Array.isArray(guard['traits'])) {
+        throw new Error(`Invalid level data: guard at index ${i} has invalid traits (must be a plain object when provided)`);
+      }
+      const rawTraits = guard['traits'] as Record<string, unknown>;
+      for (const [key, value] of Object.entries(rawTraits)) {
+        if (typeof value !== 'string') {
+          throw new Error(`Invalid level data: guard at index ${i} traits.${key} must be a string`);
+        }
       }
     }
 
@@ -425,7 +430,7 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       displayName: g.displayName,
       position: { x: g.x, y: g.y },
       guardState: g.guardState,
-      honestyTrait: g.honestyTrait,
+      ...(g.traits !== undefined ? { traits: g.traits } : {}),
       ...(g.spriteAssetPath !== undefined ? { spriteAssetPath: g.spriteAssetPath } : {}),
       ...(g.spriteSet !== undefined ? { spriteSet: g.spriteSet } : {}),
       ...(g.instanceKnowledge !== undefined ? { instanceKnowledge: g.instanceKnowledge } : {}),

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -105,6 +105,10 @@ export interface GameEntity {
   displayName: string;
   spriteSet?: SpriteSet;
   spriteAssetPath?: string;
+  /** Open-ended behavioral traits bag, readable by LLM prompt builders. */
+  traits?: Record<string, string>;
+  /** Open-ended facts bag for arbitrary key/value data, readable by LLM prompt builders. */
+  facts?: Record<string, string | number | boolean>;
 }
 
 /**
@@ -139,7 +143,6 @@ export type ActorConversationHistoryByActorId = Record<string, ConversationMessa
 /** A guard entity that the player can interact with. */
 export interface Guard extends GameEntity {
   guardState: 'idle' | 'patrolling' | 'alert';
-  honestyTrait?: 'truth-teller' | 'liar';
   facingDirection?: SpriteDirection;
   /** Instance-specific knowledge this guard has (overrides or extends type-level knowledge). */
   instanceKnowledge?: string;
@@ -202,7 +205,8 @@ export interface LevelData {
     x: number;
     y: number;
     guardState: 'patrolling' | 'alert' | 'idle';
-    honestyTrait?: 'truth-teller' | 'liar';
+    /** Behavioral traits bag. Use traits.truthMode for guard honesty ('truth-teller' | 'liar'). */
+    traits?: Record<string, string>;
     spriteAssetPath?: string;
     spriteSet?: SpriteSet;
     /** Instance-specific knowledge this guard has. */


### PR DESCRIPTION
## Summary

Replaces the hardcoded `honestyTrait` field on `Guard` with the new open-ended `traits` and `facts` bags on `GameEntity`. Guard honesty is now expressed as `traits.truthMode: 'truth-teller' | 'liar'`.

## Changes

### `src/world/types.ts`
- Added `traits?: Record<string, string>` and `facts?: Record<string, string | number | boolean>` to `GameEntity`
- Removed `honestyTrait` from `Guard` interface
- Updated `LevelData` guard shape: removed `honestyTrait`, added `traits?: Record<string, string>`

### `src/interaction/guardPromptContext.ts` + `src/interaction/npcPromptContext.ts`
- `isGuardTruthful` now reads `guard.traits?.truthMode !== 'liar'` (defaults to truth-teller when absent)

### `src/world/level.ts`
- Replaced `honestyTrait` enum validation with `traits` plain-object validation (all values must be strings)
- Deserialization passes `traits` through conditionally

### `public/levels/riddle.json`
- Migrated both guard entries from `"honestyTrait": "..."` to `"traits": { "truthMode": "..." }`

### Tests updated
- `src/world/level.test.ts`: `honestyTrait field` describe replaced with `traits field` tests
- `src/integration/riddleLevel.test.ts`: assertions updated to `traits.truthMode`
- `src/interaction/guardPromptContext.test.ts`: Guard fixtures updated to use `traits.truthMode`

### `docs/TYPES_REFERENCE.md`
- Added `traits` and `facts` to `GameEntity`
- Removed `honestyTrait` from `Guard`, replaced with `traits.truthMode` note

## Validation

- `npm run test`: **350 tests pass** (3 pre-existing `keyboard-modal-suppression` failures unrelated to this ticket)
- `WorldState` remains fully JSON-serializable
- LLM prompt output is functionally identical — `truth` boolean in guard world context unchanged

## Closes #133