### PR TITLE
NPC Capabilities - Inventory, Movement, Environment Interaction

### DIFF
--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -75,6 +75,18 @@ Opt-in capability container for game entities. Omit a key if the entity lacks th
 - `patrol?: { path: GridPosition[] }` - Entity follows a patrol path
 - `lock?: { isLocked: boolean; requiredItemId?: string }` - Entity has a lock mechanism
 
+### TriggerEffect
+- `setFact: string` - Fact key to update on the NPC facts bag
+- `value: string | boolean | number` - Value to assign to that fact key
+
+Serializable trigger mutation used by NPC approach/talk hooks.
+
+### NpcTriggers
+- `onApproach?: TriggerEffect`
+- `onTalk?: TriggerEffect`
+
+Optional trigger hooks for deterministic NPC state updates.
+
 ### Player
 - `id: string`
 - `displayName: string`
@@ -125,6 +137,9 @@ Represents one deterministic selected-item use attempt resolved for a specific c
 - `position: GridPosition`
 - `npcType: string` - Categorizes the NPC's role (for prompt profile resolution)
 - `dialogueContextKey: string` - Deterministically derived from `npcType` via `npc_${npcType.toLowerCase()}`
+- `patrol?: { path: Array<{ x: number; y: number }> }` - Optional scripted patrol path, advanced by world tick in loop order
+- `triggers?: NpcTriggers` - Optional deterministic trigger hooks for approach/talk
+- `inventory?: InventoryItem[]` - Optional NPC-carried items used for deterministic dialogue item transfer
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`
 - `instanceKnowledge?: string` - Instance-specific knowledge this NPC has; included in prompt context output when set

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -326,4 +326,51 @@ describe('createNpcInteractionService', () => {
       },
     ]);
   });
+
+  it('moves takeItem outcome item from player inventory to npc inventory', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({ text: 'I will hold on to this.', outcome: { takeItem: 'key-token' } }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      inventory: [],
+    };
+    const player = {
+      ...worldState.player,
+      inventory: {
+        ...worldState.player.inventory,
+        items: [
+          {
+            itemId: 'key-token',
+            displayName: 'Key Token',
+            sourceObjectId: 'object-1',
+            pickedUpAtTick: 1,
+          },
+        ],
+      },
+    };
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player,
+      worldState: {
+        ...worldState,
+        player,
+        npcs: [npc],
+      },
+      playerMessage: 'Can you take this?',
+    });
+
+    expect(result.updatedWorldState.player.inventory.items).toEqual([]);
+    expect(result.updatedWorldState.npcs[0].inventory).toEqual([
+      {
+        itemId: 'key-token',
+        displayName: 'Key Token',
+        sourceObjectId: 'object-1',
+        pickedUpAtTick: 1,
+      },
+    ]);
+  });
 });

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -40,7 +40,11 @@ describe('createNpcInteractionService', () => {
     const parsedContext = JSON.parse(calledPrompt.context) as {
       actor: { id: string; npcType: string };
       npcProfile: { profileKey: string; personaContract: string };
-      npcInstance: { displayName: string; dialogueContextKey: string };
+      npcInstance: {
+        displayName: string;
+        dialogueContextKey: string;
+        patrolStatus: { isPatrolling: boolean };
+      };
       player: { id: string; displayName: string };
     };
     expect(parsedContext.actor).toEqual({ id: npc.id, npcType: npc.npcType });
@@ -49,6 +53,9 @@ describe('createNpcInteractionService', () => {
       displayName: npc.displayName,
       position: npc.position,
       dialogueContextKey: npc.dialogueContextKey,
+      patrolStatus: {
+        isPatrolling: false,
+      },
     });
     expect(parsedContext.player).toEqual({
       id: worldState.player.id,
@@ -248,5 +255,75 @@ describe('createNpcInteractionService', () => {
     expect(secondNpcPanelText).toBe('Player: Hello engineer\nNPC: Engineer response.');
     expect(secondNpcPanelText).not.toContain('Archivist response.');
     expect(firstNpcPanelText).not.toContain('Engineer response.');
+  });
+
+  it('applies onTalk trigger effect to npc facts after dialogue resolves', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({ text: 'I am now on alert.' }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      triggers: {
+        onTalk: {
+          setFact: 'alerted',
+          value: true,
+        },
+      },
+    };
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState: {
+        ...worldState,
+        npcs: [npc],
+      },
+      playerMessage: 'Status report?',
+    });
+
+    expect(result.updatedWorldState.npcs[0].facts).toEqual({
+      alerted: true,
+    });
+  });
+
+  it('moves giveItem outcome item from npc inventory to player inventory', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({ text: 'Take this key.', outcome: { giveItem: 'key-token' } }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      inventory: [
+        {
+          itemId: 'key-token',
+          displayName: 'Key Token',
+          sourceObjectId: 'npc-1',
+          pickedUpAtTick: 0,
+        },
+      ],
+    };
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState: {
+        ...worldState,
+        npcs: [npc],
+      },
+      playerMessage: 'Can you help me?',
+    });
+
+    expect(result.updatedWorldState.npcs[0].inventory).toEqual([]);
+    expect(result.updatedWorldState.player.inventory.items).toEqual([
+      {
+        itemId: 'key-token',
+        displayName: 'Key Token',
+        sourceObjectId: 'npc-1',
+        pickedUpAtTick: 0,
+      },
+    ]);
   });
 });

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -2,6 +2,108 @@ import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
 import type { ConversationMessage, Npc, Player, WorldState } from '../world/types';
 import { buildNpcPromptContext } from './npcPromptContext';
 
+interface NpcInteractionOutcome {
+  giveItem?: string;
+  takeItem?: string;
+}
+
+const applyTalkTrigger = (npc: Npc): Npc => {
+  const talkTrigger = npc.triggers?.onTalk;
+  if (!talkTrigger) {
+    return npc;
+  }
+
+  return {
+    ...npc,
+    facts: {
+      ...(npc.facts ?? {}),
+      [talkTrigger.setFact]: talkTrigger.value,
+    },
+  };
+};
+
+const reindexSelectedSlotAfterRemoval = (
+  selectedItem: Player['inventory']['selectedItem'],
+  removedSlotIndex: number,
+): Player['inventory']['selectedItem'] => {
+  if (!selectedItem) {
+    return selectedItem;
+  }
+
+  if (selectedItem.slotIndex === removedSlotIndex) {
+    return null;
+  }
+
+  if (selectedItem.slotIndex > removedSlotIndex) {
+    return {
+      ...selectedItem,
+      slotIndex: selectedItem.slotIndex - 1,
+    };
+  }
+
+  return selectedItem;
+};
+
+const applyInventoryOutcome = (
+  npc: Npc,
+  player: Player,
+  outcome: NpcInteractionOutcome | undefined,
+): { npc: Npc; player: Player } => {
+  if (!outcome) {
+    return { npc, player };
+  }
+
+  const npcItems = [...(npc.inventory ?? [])];
+  const playerItems = [...player.inventory.items];
+  let selectedItem = player.inventory.selectedItem ?? null;
+  let npcInventoryChanged = false;
+  let playerInventoryChanged = false;
+
+  if (typeof outcome.giveItem === 'string') {
+    const npcItemIndex = npcItems.findIndex((item) => item.itemId === outcome.giveItem);
+    if (npcItemIndex >= 0) {
+      const [transferredItem] = npcItems.splice(npcItemIndex, 1);
+      playerItems.push(transferredItem);
+      npcInventoryChanged = true;
+      playerInventoryChanged = true;
+    }
+  }
+
+  if (typeof outcome.takeItem === 'string') {
+    const playerItemIndex = playerItems.findIndex((item) => item.itemId === outcome.takeItem);
+    if (playerItemIndex >= 0) {
+      const [transferredItem] = playerItems.splice(playerItemIndex, 1);
+      selectedItem = reindexSelectedSlotAfterRemoval(selectedItem, playerItemIndex);
+      npcItems.push(transferredItem);
+      npcInventoryChanged = true;
+      playerInventoryChanged = true;
+    }
+  }
+
+  const nextNpc = npcInventoryChanged
+    ? {
+        ...npc,
+        inventory: npcItems,
+      }
+    : npc;
+
+  const nextPlayer = playerInventoryChanged
+    ? {
+        ...player,
+        inventory: {
+          ...player.inventory,
+          items: playerItems,
+          selectedItem,
+        },
+      }
+    : player;
+
+  return {
+    npc: nextNpc,
+    player: nextPlayer,
+  };
+};
+
 export interface NpcInteractionRequest {
   npc: Npc;
   player: Player;
@@ -29,15 +131,16 @@ export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractio
     };
     const historyWithPlayerMessage = [...previousHistory, playerMessageRecord];
 
-    const assistantText = await llmClient
+    const llmResponse = await llmClient
       .complete({
         actorId: request.npc.id,
         context: buildNpcPromptContext(request.npc, request.player, request.worldState),
         playerMessage: request.playerMessage,
         conversationHistory: historyWithPlayerMessage,
       })
-      .then((llmResponse) => llmResponse.text)
-      .catch(() => REQUEST_FAILURE_FALLBACK_TEXT);
+      .catch(() => ({ text: REQUEST_FAILURE_FALLBACK_TEXT }));
+
+    const assistantText = llmResponse.text;
 
     const assistantMessageRecord: ConversationMessage = {
       role: 'assistant',
@@ -49,9 +152,26 @@ export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractio
       [request.npc.id]: [...historyWithPlayerMessage, assistantMessageRecord],
     };
 
-    const updatedWorldState: WorldState = {
+    const stateWithUpdatedHistory: WorldState = {
       ...request.worldState,
       actorConversationHistoryByActorId: updatedHistoryByActorId,
+    };
+
+    const npcFromWorldState =
+      stateWithUpdatedHistory.npcs.find((candidate) => candidate.id === request.npc.id) ?? request.npc;
+    const npcAfterTalkTrigger = applyTalkTrigger(npcFromWorldState);
+    const inventoryResult = applyInventoryOutcome(
+      npcAfterTalkTrigger,
+      stateWithUpdatedHistory.player,
+      llmResponse.outcome,
+    );
+
+    const updatedWorldState: WorldState = {
+      ...stateWithUpdatedHistory,
+      player: inventoryResult.player,
+      npcs: stateWithUpdatedHistory.npcs.map((npc) =>
+        npc.id === request.npc.id ? inventoryResult.npc : npc,
+      ),
     };
 
     return {

--- a/src/interaction/npcPromptContext.test.ts
+++ b/src/interaction/npcPromptContext.test.ts
@@ -292,4 +292,54 @@ describe('NPC instance fields in prompt context', () => {
     expect(parsed.instanceKnowledge).toBe('Village square floods in spring.');
     expect(parsed.instanceBehavior).toBe('Speaks slowly and carefully.');
   });
+
+  it('includes patrolStatus metadata when NPC has a patrol path', () => {
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      position: { x: 8, y: 3 },
+      patrol: {
+        path: [
+          { x: 8, y: 3 },
+          { x: 9, y: 3 },
+        ],
+      },
+    };
+
+    const parsed = JSON.parse(buildNpcPromptContext(npc, worldState.player, worldState)) as {
+      npcInstance: {
+        patrolStatus: {
+          isPatrolling: boolean;
+          pathLength: number;
+          currentPathIndex: number;
+        };
+      };
+    };
+
+    expect(parsed.npcInstance.patrolStatus).toEqual({
+      isPatrolling: true,
+      pathLength: 2,
+      currentPathIndex: 0,
+    });
+  });
+
+  it('includes activeFacts when NPC facts exist', () => {
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      facts: {
+        alerted: true,
+        trust: 3,
+      },
+    };
+
+    const parsed = JSON.parse(buildNpcPromptContext(npc, worldState.player, worldState)) as {
+      activeFacts?: Record<string, string | boolean | number>;
+    };
+
+    expect(parsed.activeFacts).toEqual({
+      alerted: true,
+      trust: 3,
+    });
+  });
 });

--- a/src/interaction/npcPromptContext.ts
+++ b/src/interaction/npcPromptContext.ts
@@ -235,6 +235,23 @@ export const buildNpcPromptContext = (npc: Npc, player: Player, worldState: Worl
     }
   }
 
+  const patrolPath = npc.patrol?.path ?? [];
+  const patrolPathIndex = patrolPath.findIndex(
+    (step) => step.x === npc.position.x && step.y === npc.position.y,
+  );
+  const patrolStatus =
+    patrolPath.length > 0
+      ? {
+          isPatrolling: true,
+          pathLength: patrolPath.length,
+          currentPathIndex: patrolPathIndex,
+        }
+      : {
+          isPatrolling: false,
+        };
+
+  const activeFacts = npc.facts && Object.keys(npc.facts).length > 0 ? npc.facts : undefined;
+
   return JSON.stringify({
     actor: {
       id: npc.id,
@@ -248,8 +265,10 @@ export const buildNpcPromptContext = (npc: Npc, player: Player, worldState: Worl
         y: npc.position.y,
       },
       dialogueContextKey: npc.dialogueContextKey,
+      patrolStatus,
     },
     ...(worldKnowledge !== null && { typeWorldKnowledge: worldKnowledge }),
+    ...(activeFacts !== undefined && { activeFacts }),
     ...(npc.instanceKnowledge !== undefined && { instanceKnowledge: npc.instanceKnowledge }),
     ...(npc.instanceBehavior !== undefined && { instanceBehavior: npc.instanceBehavior }),
     ...(riddleClueConstraint !== undefined && { riddleClueConstraint }),

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -12,6 +12,10 @@ export interface LlmConversationMessage {
 
 export interface LlmResponse {
   text: string;
+  outcome?: {
+    giveItem?: string;
+    takeItem?: string;
+  };
 }
 
 export interface LlmClient {

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -1128,3 +1128,109 @@ describe('instanceKnowledge and instanceBehavior fields', () => {
   });
 });
 
+describe('NPC capability fields', () => {
+  it('maps optional npc patrol, triggers, and inventory fields during deserialization', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      npcs: [
+        {
+          id: 'npc-1',
+          displayName: 'Courier',
+          x: 5,
+          y: 5,
+          npcType: 'villager',
+          patrol: {
+            path: [
+              { x: 5, y: 5 },
+              { x: 6, y: 5 },
+            ],
+          },
+          triggers: {
+            onTalk: {
+              setFact: 'alerted',
+              value: true,
+            },
+          },
+          inventory: [
+            {
+              itemId: 'key-token',
+              displayName: 'Key Token',
+              sourceObjectId: 'npc-1',
+              pickedUpAtTick: 0,
+            },
+          ],
+        },
+      ],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    const state = deserializeLevel(validateLevelData(level));
+
+    expect(state.npcs[0].patrol).toEqual({
+      path: [
+        { x: 5, y: 5 },
+        { x: 6, y: 5 },
+      ],
+    });
+    expect(state.npcs[0].triggers).toEqual({
+      onTalk: {
+        setFact: 'alerted',
+        value: true,
+      },
+    });
+    expect(state.npcs[0].inventory).toEqual([
+      {
+        itemId: 'key-token',
+        displayName: 'Key Token',
+        sourceObjectId: 'npc-1',
+        pickedUpAtTick: 0,
+      },
+    ]);
+  });
+
+  it('rejects npc patrol paths with out-of-bounds coordinates', () => {
+    const bad = {
+      ...minimalLevel,
+      npcs: [
+        {
+          id: 'npc-1',
+          displayName: 'Courier',
+          x: 5,
+          y: 5,
+          npcType: 'villager',
+          patrol: {
+            path: [{ x: 99, y: 5 }],
+          },
+        },
+      ],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('patrol.path[0] is out of bounds');
+  });
+
+  it('rejects npc triggers with invalid shape', () => {
+    const bad = {
+      ...minimalLevel,
+      npcs: [
+        {
+          id: 'npc-1',
+          displayName: 'Courier',
+          x: 5,
+          y: 5,
+          npcType: 'villager',
+          triggers: {
+            onTalk: {
+              setFact: 42,
+              value: true,
+            },
+          },
+        },
+      ],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, doorState: 'open', outcome: 'safe' }],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('triggers.onTalk.setFact must be a non-empty string');
+  });
+});
+

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -1,4 +1,4 @@
-import type { LevelData, WorldState } from './types';
+import type { GridPosition, LevelData, WorldState } from './types';
 import { validateSpatialLayout } from './spatialRules';
 
 const DEFAULT_TILE_SIZE = 48;
@@ -81,6 +81,98 @@ const validateObjectCapabilities = (value: unknown, contextLabel: string): void 
   }
 };
 
+const validateGridPositionInBounds = (
+  value: unknown,
+  contextLabel: string,
+  gridWidth: number,
+  gridHeight: number,
+): void => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Invalid level data: ${contextLabel} must be an object with numeric x and y`);
+  }
+
+  const position = value as Record<string, unknown>;
+  if (typeof position['x'] !== 'number' || typeof position['y'] !== 'number') {
+    throw new Error(`Invalid level data: ${contextLabel} must include numeric x and y`);
+  }
+
+  if (
+    position['x'] < 0 ||
+    position['x'] >= gridWidth ||
+    position['y'] < 0 ||
+    position['y'] >= gridHeight
+  ) {
+    throw new Error(
+      `Invalid level data: ${contextLabel} is out of bounds at (${position['x']}, ${position['y']})`,
+    );
+  }
+};
+
+const validateTriggerEffect = (value: unknown, contextLabel: string): void => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Invalid level data: ${contextLabel} must be an object when provided`);
+  }
+
+  const effect = value as Record<string, unknown>;
+  if (typeof effect['setFact'] !== 'string' || effect['setFact'].trim() === '') {
+    throw new Error(`Invalid level data: ${contextLabel}.setFact must be a non-empty string`);
+  }
+
+  const effectValue = effect['value'];
+  if (
+    typeof effectValue !== 'string' &&
+    typeof effectValue !== 'boolean' &&
+    typeof effectValue !== 'number'
+  ) {
+    throw new Error(
+      `Invalid level data: ${contextLabel}.value must be a string, boolean, or number`,
+    );
+  }
+};
+
+const validateNpcTriggers = (value: unknown, contextLabel: string): void => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Invalid level data: ${contextLabel} must be an object when provided`);
+  }
+
+  const triggers = value as Record<string, unknown>;
+  for (const key of Object.keys(triggers)) {
+    if (key !== 'onApproach' && key !== 'onTalk') {
+      throw new Error(`Invalid level data: ${contextLabel} has unknown key '${key}'`);
+    }
+  }
+
+  if (triggers['onApproach'] !== undefined) {
+    validateTriggerEffect(triggers['onApproach'], `${contextLabel}.onApproach`);
+  }
+
+  if (triggers['onTalk'] !== undefined) {
+    validateTriggerEffect(triggers['onTalk'], `${contextLabel}.onTalk`);
+  }
+};
+
+const validateInventoryItems = (value: unknown, contextLabel: string): void => {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid level data: ${contextLabel} must be an array when provided`);
+  }
+
+  for (let index = 0; index < value.length; index++) {
+    const item = value[index] as Record<string, unknown>;
+    if (
+      typeof item !== 'object' ||
+      item === null ||
+      typeof item['itemId'] !== 'string' ||
+      typeof item['displayName'] !== 'string' ||
+      typeof item['sourceObjectId'] !== 'string' ||
+      typeof item['pickedUpAtTick'] !== 'number'
+    ) {
+      throw new Error(
+        `Invalid level data: ${contextLabel}[${index}] must include itemId, displayName, sourceObjectId, and pickedUpAtTick`,
+      );
+    }
+  }
+};
+
 /**
  * Validates that an unknown value conforms to the LevelData schema.
  * Throws a descriptive Error if any required field is missing or has an unexpected type/value.
@@ -115,6 +207,9 @@ export function validateLevelData(input: unknown): LevelData {
   if (typeof raw['height'] !== 'number' || raw['height'] <= 0) {
     throw new Error('Invalid level data: height must be a positive number');
   }
+
+  const levelWidth = raw['width'] as number;
+  const levelHeight = raw['height'] as number;
 
   const player = raw['player'];
   if (
@@ -270,6 +365,38 @@ export function validateLevelData(input: unknown): LevelData {
         validateSpriteSet(npc['spriteSet'], `npc at index ${i}`);
       }
 
+      if (npc['patrol'] !== undefined) {
+        if (
+          typeof npc['patrol'] !== 'object' ||
+          npc['patrol'] === null ||
+          Array.isArray(npc['patrol'])
+        ) {
+          throw new Error(`Invalid level data: npc at index ${i} patrol must be an object when provided`);
+        }
+
+        const patrol = npc['patrol'] as Record<string, unknown>;
+        if (!Array.isArray(patrol['path'])) {
+          throw new Error(`Invalid level data: npc at index ${i} patrol.path must be an array`);
+        }
+
+        for (let pathIndex = 0; pathIndex < patrol['path'].length; pathIndex++) {
+          validateGridPositionInBounds(
+            patrol['path'][pathIndex],
+            `npc at index ${i} patrol.path[${pathIndex}]`,
+            levelWidth,
+            levelHeight,
+          );
+        }
+      }
+
+      if (npc['triggers'] !== undefined) {
+        validateNpcTriggers(npc['triggers'], `npc at index ${i} triggers`);
+      }
+
+      if (npc['inventory'] !== undefined) {
+        validateInventoryItems(npc['inventory'], `npc at index ${i} inventory`);
+      }
+
       // instanceKnowledge and instanceBehavior are optional strings
       if (npc['instanceKnowledge'] !== undefined && typeof npc['instanceKnowledge'] !== 'string') {
         throw new Error(
@@ -418,6 +545,24 @@ export function deserializeLevel(levelData: LevelData): WorldState {
         dialogueContextKey: `npc_${n.npcType.toLowerCase()}`,
         ...(n.spriteAssetPath !== undefined ? { spriteAssetPath: n.spriteAssetPath } : {}),
         ...(n.spriteSet !== undefined ? { spriteSet: n.spriteSet } : {}),
+        ...(n.patrol !== undefined
+          ? {
+              patrol: {
+                path: n.patrol.path.map((position: GridPosition) => ({ x: position.x, y: position.y })),
+              },
+            }
+          : {}),
+        ...(n.triggers !== undefined ? { triggers: n.triggers } : {}),
+        ...(n.inventory !== undefined
+          ? {
+              inventory: n.inventory.map((item) => ({
+                itemId: item.itemId,
+                displayName: item.displayName,
+                sourceObjectId: item.sourceObjectId,
+                pickedUpAtTick: item.pickedUpAtTick,
+              })),
+            }
+          : {}),
         ...(n.instanceKnowledge !== undefined ? { instanceKnowledge: n.instanceKnowledge } : {}),
         ...(n.instanceBehavior !== undefined ? { instanceBehavior: n.instanceBehavior } : {}),
       } as any;

--- a/src/world/npcTick.test.ts
+++ b/src/world/npcTick.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { createInitialWorldState } from './state';
+import { tickNpcPatrols } from './npcTick';
+
+describe('tickNpcPatrols', () => {
+  it('advances an NPC with a patrol path by one step per tick', () => {
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      position: { x: 4, y: 4 },
+      patrol: {
+        path: [
+          { x: 4, y: 4 },
+          { x: 5, y: 4 },
+          { x: 6, y: 4 },
+        ],
+      },
+    };
+
+    const nextState = tickNpcPatrols({
+      ...worldState,
+      npcs: [npc],
+    });
+
+    expect(nextState.npcs[0].position).toEqual({ x: 5, y: 4 });
+  });
+
+  it('pauses NPC patrol when player occupies the next patrol position', () => {
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      position: { x: 4, y: 4 },
+      patrol: {
+        path: [
+          { x: 4, y: 4 },
+          { x: 5, y: 4 },
+        ],
+      },
+    };
+
+    const nextState = tickNpcPatrols({
+      ...worldState,
+      player: {
+        ...worldState.player,
+        position: { x: 5, y: 4 },
+      },
+      npcs: [npc],
+    });
+
+    expect(nextState.npcs[0].position).toEqual({ x: 4, y: 4 });
+  });
+
+  it('loops patrol paths when NPC reaches the final step', () => {
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      position: { x: 6, y: 4 },
+      patrol: {
+        path: [
+          { x: 4, y: 4 },
+          { x: 5, y: 4 },
+          { x: 6, y: 4 },
+        ],
+      },
+    };
+
+    const nextState = tickNpcPatrols({
+      ...worldState,
+      npcs: [npc],
+    });
+
+    expect(nextState.npcs[0].position).toEqual({ x: 4, y: 4 });
+  });
+});

--- a/src/world/npcTick.ts
+++ b/src/world/npcTick.ts
@@ -1,0 +1,38 @@
+import type { GridPosition, Npc, WorldState } from './types';
+
+const samePosition = (a: GridPosition, b: GridPosition): boolean => a.x === b.x && a.y === b.y;
+
+const getNextPatrolPosition = (npc: Npc): GridPosition | null => {
+  const path = npc.patrol?.path;
+  if (!path || path.length === 0) {
+    return null;
+  }
+
+  const currentIndex = path.findIndex((step) => samePosition(step, npc.position));
+  const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % path.length : 0;
+  return path[nextIndex];
+};
+
+export const tickNpcPatrols = (state: WorldState): WorldState => {
+  const nextNpcs = state.npcs.map((npc) => {
+    const nextPosition = getNextPatrolPosition(npc);
+    if (!nextPosition) {
+      return npc;
+    }
+
+    // NPC patrols pause when the player's tile is the next patrol step.
+    if (samePosition(nextPosition, state.player.position)) {
+      return npc;
+    }
+
+    return {
+      ...npc,
+      position: { x: nextPosition.x, y: nextPosition.y },
+    };
+  });
+
+  return {
+    ...state,
+    npcs: nextNpcs,
+  };
+};

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -122,9 +122,22 @@ export interface EntityCapabilities {
   lock?: { isLocked: boolean; requiredItemId?: string };
 }
 
+export interface TriggerEffect {
+  setFact: string;
+  value: string | boolean | number;
+}
+
+export interface NpcTriggers {
+  onApproach?: TriggerEffect;
+  onTalk?: TriggerEffect;
+}
+
 export interface Npc extends GameEntity {
   npcType: string;
   dialogueContextKey: string;
+  patrol?: { path: Array<{ x: number; y: number }> };
+  triggers?: NpcTriggers;
+  inventory?: InventoryItem[];
   /** Instance-specific knowledge this NPC has (overrides or extends type-level knowledge). */
   instanceKnowledge?: string;
   /** Instance-specific behavior traits for this NPC (overrides or extends type-level behavior). */
@@ -246,6 +259,9 @@ export interface LevelData {
     x: number;
     y: number;
     npcType: string;
+    patrol?: { path: GridPosition[] };
+    triggers?: NpcTriggers;
+    inventory?: InventoryItem[];
     spriteAssetPath?: string;
     spriteSet?: SpriteSet;
     /** Instance-specific knowledge this NPC has. */

--- a/src/world/world.ts
+++ b/src/world/world.ts
@@ -1,5 +1,6 @@
 import { createInitialWorldState } from './state';
 import { resolveIntent } from './intentResolver';
+import { tickNpcPatrols } from './npcTick';
 import type { Intent, World, WorldCommand, WorldState } from './types';
 
 const applyCommand = (worldState: WorldState, command: WorldCommand): WorldState => {
@@ -47,7 +48,8 @@ export const createWorld = (): World => {
   return {
     getState: () => worldState,
     applyCommands: (commands: WorldCommand[]) => {
-      const nextState = commands.reduce(applyCommand, worldState);
+      const stateAfterCommands = commands.reduce(applyCommand, worldState);
+      const nextState = tickNpcPatrols(stateAfterCommands);
       worldState = {
         ...nextState,
         tick: nextState.tick + 1,


### PR DESCRIPTION
## Summary
- add optional NPC capability fields (`patrol`, `triggers`, `inventory`) and supporting trigger model types
- add deterministic NPC patrol ticking each world tick, including player-occupancy pause behavior and looped paths
- extend NPC interaction pipeline to apply `onTalk` fact triggers and transfer items via dialogue outcomes (`giveItem`/`takeItem` support)
- expose patrol status and active NPC facts in NPC prompt context
- validate new NPC fields in level validation and map them in deserialization
- add tests for patrol ticking, onTalk trigger activation, giveItem transfer, prompt context exposure, and level validation
- update type documentation

Closes #135

## Validation
- `npm run test` (385 passed)
