### PR TITLE
Level Authoring v2 and Migration Tooling

### DIFF
--- a/docs/LEVEL_FORMAT.md
+++ b/docs/LEVEL_FORMAT.md
@@ -1,0 +1,278 @@
+# Level Format v2
+
+This document defines the authoring contract for Guard Game level files.
+
+## Versioning
+
+- Every level file must include `"version": 2`.
+- Any level with a missing version or a version other than `2` is rejected by runtime validation.
+
+## Top-Level Fields
+
+Required top-level authoring fields:
+
+- `id: string`
+  - Stable level identifier used by manifest entries and tooling.
+- `name: string`
+  - Human-readable level title.
+- `version: number`
+  - Must be `2`.
+- `grid: { width: number, height: number, tileSize?: number }`
+  - Grid dimensions for deterministic movement and bounds checks.
+- `startPosition: { x: number, y: number }`
+  - Initial player tile coordinate.
+
+Runtime JSON compatibility fields currently consumed by the game loader:
+
+- `width: number`
+- `height: number`
+- `player: { x: number, y: number, spriteAssetPath?: string, spriteSet?: SpriteSet }`
+
+When authoring new levels, keep `grid.width === width`, `grid.height === height`, and `startPosition` equal to `player` coordinates.
+
+## Entity Sections
+
+### guards
+
+```json
+{
+  "id": "guard-1",
+  "displayName": "Gate Guard",
+  "x": 10,
+  "y": 7,
+  "guardState": "idle",
+  "traits": {
+    "truthMode": "truth-teller"
+  },
+  "spriteAssetPath": "/assets/medieval_guard_shield_spear_front.svg",
+  "spriteSet": {
+    "default": "/assets/medieval_guard_shield_spear_front.svg"
+  },
+  "itemUseRules": {
+    "gold-coin": {
+      "allowed": true,
+      "responseText": "A bribe? Move along."
+    }
+  }
+}
+```
+
+- `guardState`: `idle | patrolling | alert`
+- `traits.truthMode`: `truth-teller | liar` (required by coverage checks)
+
+### npcs
+
+```json
+{
+  "id": "npc-1",
+  "displayName": "Archivist",
+  "x": 8,
+  "y": 9,
+  "npcType": "archive_keeper"
+}
+```
+
+- `npcType` must be a non-empty string.
+- Optional NPC fields: `patrol`, `triggers`, `inventory`, `instanceKnowledge`, `instanceBehavior`, `riddleClue`.
+
+### doors
+
+```json
+{
+  "id": "door-safe",
+  "displayName": "Left Door",
+  "x": 7,
+  "y": 8,
+  "doorState": "locked",
+  "requiredItemId": "armory-key",
+  "outcome": "safe"
+}
+```
+
+- `doorState`: `open | closed | locked`
+- `outcome`: `safe | danger` (used for level result)
+
+### interactiveObjects
+
+```json
+{
+  "id": "tool-chest",
+  "displayName": "Tool Chest",
+  "x": 5,
+  "y": 9,
+  "objectType": "supply-crate",
+  "interactionType": "inspect",
+  "state": "idle",
+  "capabilities": {
+    "containsItems": true
+  }
+}
+```
+
+- `interactionType`: `inspect | use | talk`
+- `state`: `idle | used`
+- `capabilities` is required by coverage checks.
+
+### player
+
+Runtime field:
+
+```json
+{
+  "player": {
+    "x": 10,
+    "y": 12
+  }
+}
+```
+
+Authoring alias:
+
+```json
+{
+  "startPosition": {
+    "x": 10,
+    "y": 12
+  }
+}
+```
+
+## Capability Blocks
+
+Interactive object `capabilities` flags:
+
+- `containsItems: boolean`
+  - Object can provide a `pickupItem` during interaction.
+- `isActivatable: boolean`
+  - Object can trigger an activation flow and state changes.
+- `isLockable: boolean`
+  - Object participates in lock/unlock style behavior.
+
+These flags are independent and can be combined.
+
+## Trait and Fact Fields
+
+Entity trait/fact bags are string-keyed maps.
+
+- `traits: Record<string, string>`
+  - Example: `traits.truthMode = "truth-teller"`.
+- `facts: Record<string, string | number | boolean>`
+  - Used for deterministic state facts referenced by prompts or interactions.
+
+Guard truth mode allowed values:
+
+- `truth-teller`
+- `liar`
+
+Riddle clue truth behavior allowed values:
+
+- `truthful`
+- `inverse`
+
+## Item Definitions and Use Rules
+
+Pickup items on objects:
+
+```json
+"pickupItem": {
+  "itemId": "armory-key",
+  "displayName": "Armory Key"
+}
+```
+
+Item use rules on guards/objects:
+
+```json
+"itemUseRules": {
+  "armory-key": {
+    "allowed": true,
+    "responseText": "The lock clicks open."
+  }
+}
+```
+
+- `allowed: boolean` determines whether use succeeds.
+- `responseText: string` is shown to the player.
+
+## Annotated Minimal Example
+
+```json
+{
+  "id": "minimal-v2",
+  "name": "Minimal v2",
+  "version": 2,
+  "grid": {
+    "width": 20,
+    "height": 20,
+    "tileSize": 48
+  },
+  "startPosition": {
+    "x": 10,
+    "y": 10
+  },
+  "width": 20,
+  "height": 20,
+  "premise": "A compact authoring sample.",
+  "goal": "Reach the safe door.",
+  "player": {
+    "x": 10,
+    "y": 10
+  },
+  "guards": [
+    {
+      "id": "guard-1",
+      "displayName": "Guide Guard",
+      "x": 9,
+      "y": 10,
+      "guardState": "idle",
+      "traits": {
+        "truthMode": "truth-teller"
+      }
+    }
+  ],
+  "doors": [
+    {
+      "id": "door-safe",
+      "displayName": "Safe Door",
+      "x": 10,
+      "y": 8,
+      "doorState": "closed",
+      "outcome": "safe"
+    }
+  ],
+  "npcs": [
+    {
+      "id": "npc-1",
+      "displayName": "Archivist",
+      "x": 11,
+      "y": 10,
+      "npcType": "archive_keeper"
+    }
+  ],
+  "interactiveObjects": [
+    {
+      "id": "supply-crate",
+      "displayName": "Supply Crate",
+      "x": 10,
+      "y": 11,
+      "objectType": "supply-crate",
+      "interactionType": "inspect",
+      "state": "idle",
+      "capabilities": {
+        "containsItems": true,
+        "isActivatable": false,
+        "isLockable": false
+      },
+      "pickupItem": {
+        "itemId": "starter-key",
+        "displayName": "Starter Key"
+      }
+    }
+  ]
+}
+```
+
+Notes:
+
+- Include both authoring aliases (`grid`, `startPosition`) and runtime-consumed fields (`width`, `height`, `player`) until loader convergence is complete.
+- Keep all world-facing values JSON-serializable.

--- a/public/levels/broken-mechanism.json
+++ b/public/levels/broken-mechanism.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "name": "The Broken Mechanism",
   "premise": "An ancient door mechanism is jammed. The corridor beyond holds your escape, but only the right tool can fix the mechanism.",
   "goal": "Find the iron wrench and repair the mechanism to open the path forward.",

--- a/public/levels/guard-bribe.json
+++ b/public/levels/guard-bribe.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "name": "The Persuasive Bribe",
   "premise": "A guard blocks the only passage through the old gate. Rumour has it they can be persuaded with enough coin.",
   "goal": "Offer the gold coin to the guard and slip through the gate.",

--- a/public/levels/key-armory.json
+++ b/public/levels/key-armory.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "name": "The Locked Armory",
   "premise": "A locked armory holds the supplies you need. You spotted a key in an old crate nearby.",
   "goal": "Find the key, unlock the armory door, and step through to safety.",

--- a/public/levels/riddle.json
+++ b/public/levels/riddle.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "name": "Two Guards, Two Doors",
   "premise": "Two guards stand by two doors, but one guard lies while the other tells the truth.",
   "goal": "Question the guards and choose the door that leads to safety.",

--- a/public/levels/starter.json
+++ b/public/levels/starter.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "name": "Starter",
   "premise": "You are a town guard testing patrol routes around a guarded courtyard.",
   "goal": "Inspect nearby clues and choose the safe exit door.",

--- a/public/levels/three-sages-fork.json
+++ b/public/levels/three-sages-fork.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "name": "Three Sages at the Fork",
   "premise": "Three sages offer conflicting clues about which forked path is safe.",
   "goal": "Interpret the sages' statements and pick the safe door.",

--- a/scripts/migrate-level-v1-to-v2.ts
+++ b/scripts/migrate-level-v1-to-v2.ts
@@ -1,0 +1,63 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+type JsonObject = Record<string, unknown>;
+
+const inputPath = process.argv[2];
+const outputPath = process.argv[3];
+
+if (!inputPath) {
+  throw new Error('Usage: ts-node scripts/migrate-level-v1-to-v2.ts <input.json> [output.json]');
+}
+
+const rawText = readFileSync(inputPath, 'utf8');
+const parsed = JSON.parse(rawText) as JsonObject;
+
+const interactiveObjects = Array.isArray(parsed.interactiveObjects) ? parsed.interactiveObjects : [];
+const guards = Array.isArray(parsed.guards) ? parsed.guards : [];
+
+parsed.version = 2;
+
+parsed.interactiveObjects = interactiveObjects.map((entry) => {
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    return entry;
+  }
+
+  const objectEntry = { ...(entry as JsonObject) };
+  if (
+    objectEntry.capabilities === undefined ||
+    typeof objectEntry.capabilities !== 'object' ||
+    objectEntry.capabilities === null ||
+    Array.isArray(objectEntry.capabilities)
+  ) {
+    objectEntry.capabilities = {};
+  }
+
+  return objectEntry;
+});
+
+parsed.guards = guards.map((entry) => {
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    return entry;
+  }
+
+  const guardEntry = { ...(entry as JsonObject) };
+  const traits =
+    typeof guardEntry.traits === 'object' && guardEntry.traits !== null && !Array.isArray(guardEntry.traits)
+      ? ({ ...(guardEntry.traits as JsonObject) } as JsonObject)
+      : {};
+
+  if (typeof traits.truthMode !== 'string') {
+    traits.truthMode = 'truth-teller';
+  }
+
+  guardEntry.traits = traits;
+  return guardEntry;
+});
+
+const migrated = `${JSON.stringify(parsed, null, 2)}\n`;
+
+if (outputPath) {
+  writeFileSync(outputPath, migrated, 'utf8');
+} else {
+  process.stdout.write(migrated);
+}

--- a/src/integration/levelAssetCoverage.test.ts
+++ b/src/integration/levelAssetCoverage.test.ts
@@ -20,11 +20,25 @@ type LevelEntity = {
   };
 };
 
+type LevelGuard = LevelEntity & {
+  traits?: {
+    truthMode?: string;
+  };
+};
+
+type LevelNpc = LevelEntity & {
+  npcType?: string;
+};
+
+type LevelInteractiveObject = LevelEntity & {
+  capabilities?: Record<string, boolean>;
+};
+
 type LevelFile = {
-  guards?: LevelEntity[];
+  guards?: LevelGuard[];
   doors?: LevelEntity[];
-  npcs?: LevelEntity[];
-  interactiveObjects?: LevelEntity[];
+  npcs?: LevelNpc[];
+  interactiveObjects?: LevelInteractiveObject[];
 };
 
 const repoRoot = resolve(__dirname, '../../');
@@ -70,6 +84,10 @@ describe('level NPC/object asset coverage', () => {
       const level: LevelFile = JSON.parse(readFileSync(levelPath, 'utf8'));
 
       for (const guard of level.guards ?? []) {
+        expect(guard.traits, `${entry.id}: guard ${guard.id} missing traits object`).toBeDefined();
+        expect(guard.traits?.truthMode, `${entry.id}: guard ${guard.id} missing traits.truthMode`).toBeDefined();
+        expect(typeof guard.traits?.truthMode, `${entry.id}: guard ${guard.id} traits.truthMode must be a string`).toBe('string');
+
         const paths = collectEntityAssetPaths(guard);
         if (paths.length === 0) {
           missingCoverage.push(`level=${entry.id} guard=${guard.id}`);
@@ -98,6 +116,9 @@ describe('level NPC/object asset coverage', () => {
       }
 
       for (const npc of level.npcs ?? []) {
+        expect(npc.npcType, `${entry.id}: npc ${npc.id} missing npcType`).toBeDefined();
+        expect(typeof npc.npcType, `${entry.id}: npc ${npc.id} npcType must be a string`).toBe('string');
+
         const paths = collectEntityAssetPaths(npc);
         if (paths.length === 0) {
           missingCoverage.push(`level=${entry.id} npc=${npc.id}`);
@@ -112,6 +133,8 @@ describe('level NPC/object asset coverage', () => {
       }
 
       for (const object of level.interactiveObjects ?? []) {
+        expect(object.capabilities, `${entry.id}: object ${object.id} missing capabilities`).toBeDefined();
+
         const paths = collectEntityAssetPaths(object);
         if (paths.length === 0) {
           missingCoverage.push(`level=${entry.id} object=${object.id}`);

--- a/src/integration/starterLevel.test.ts
+++ b/src/integration/starterLevel.test.ts
@@ -173,7 +173,7 @@ describe('starter level integration pipeline', () => {
   describe('instanceKnowledge and instanceBehavior full pipeline', () => {
     it('propagates instanceKnowledge and instanceBehavior from level JSON through deserializeLevel into prompt context', () => {
       const levelWithInstanceFields = {
-        version: 1,
+        version: 2,
         name: 'Instance Fields Test',
         premise: 'A deterministic fixture for instance fields.',
         goal: 'Confirm instance fields propagate to prompt context.',

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -5,7 +5,7 @@ import * as spatialRules from './spatialRules';
 import type { LevelData } from './types';
 
 const minimalLevel: LevelData = {
-  version: 1,
+  version: 2,
   name: 'Test Level',
   premise: 'A deterministic test premise.',
   goal: 'Reach the safe test door.',
@@ -277,7 +277,7 @@ describe('deserializeLevel', () => {
   });
 
   it('preserves the schema version field in the input (does not discard it)', () => {
-    const level: LevelData = { ...minimalLevel, version: 1 };
+    const level: LevelData = { ...minimalLevel, version: 2 };
     // The function consumes version; ensure it still accepts it without error
     const state = deserializeLevel(level);
 
@@ -339,9 +339,15 @@ describe('validateLevelData', () => {
     expect(result).toEqual(minimalLevel);
   });
 
-  it('throws when version is not 1', () => {
-    const bad = { ...minimalLevel, version: 2 };
-    expect(() => validateLevelData(bad)).toThrowError('version must be 1');
+  it('throws when version is missing', () => {
+    const bad = { ...minimalLevel } as Record<string, unknown>;
+    delete bad.version;
+    expect(() => validateLevelData(bad)).toThrowError('Level format version is missing. Expected version 2.');
+  });
+
+  it('throws when version is not 2', () => {
+    const bad = { ...minimalLevel, version: 1 };
+    expect(() => validateLevelData(bad)).toThrowError('Level format version 1 is not supported. Expected version 2.');
   });
 
   it('throws when name is an empty string', () => {

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -184,8 +184,12 @@ export function validateLevelData(input: unknown): LevelData {
 
   const raw = input as Record<string, unknown>;
 
-  if (raw['version'] !== 1) {
-    throw new Error('Invalid level data: version must be 1');
+  if (raw['version'] === undefined) {
+    throw new Error('Level format version is missing. Expected version 2.');
+  }
+
+  if (raw['version'] !== 2) {
+    throw new Error(`Level format version ${raw['version']} is not supported. Expected version 2.`);
   }
 
   if (typeof raw['name'] !== 'string' || raw['name'].trim() === '') {

--- a/src/world/levelLoader.test.ts
+++ b/src/world/levelLoader.test.ts
@@ -3,7 +3,7 @@ import { fetchAndLoadLevel, fetchLevelManifest } from './levelLoader';
 import type { LevelData } from './types';
 
 const minimalLevel: LevelData = {
-  version: 1,
+  version: 2,
   name: 'Test Level',
   premise: 'A deterministic test premise.',
   goal: 'Verify level loading behavior.',

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -216,7 +216,7 @@ export interface LevelMetadata {
 
 /** Flat JSON representation of a level file (public/levels/*.json). Version-stamped for future migrations. */
 export interface LevelData {
-  version: 1;
+  version: number;
   name: string;
   premise: string;
   goal: string;


### PR DESCRIPTION
## Summary
- enforce level format version 2 in world validation
- migrate all current authored level JSON files to `version: 2`
- add v1->v2 migration script for level authoring updates
- extend level integration coverage for capabilities, guard truthMode, and npcType
- document the v2 level format for content authors

Closes #137