### PR TITLE
Domain Class Foundation and Folder Restructure

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,6 +7,7 @@ Guard Game enforces strict layer separation to support deterministic world updat
 ```
 /src
   /world               - Deterministic world model (state, command application, ticks)
+/world/entities      - Domain class foundation and DTO-to-runtime seam mappings
   /render              - PixiJS rendering port plus DOM overlays for viewport pause, chat, and outcomes
   /interaction         - Interaction dispatch + result routing across target kinds
   /input               - Input command buffering and keyboard mapping
@@ -129,7 +130,7 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 - **Responsibility:** Maintain deterministic game state and apply commands.
 - **Input:** `WorldCommand[]` from the input buffer.
 - **Output:** Updated `WorldState`.
-- **Guarantee:** Same commands always produce same state.
+- **Guarantee:** Same commands always produce same state. Runtime domain classes under `src/world/entities` are construction/mapping helpers only and do not change deterministic command semantics.
 
 ### Render Layer
 - **Responsibility:** Translate world state into visual representation.

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -4,6 +4,13 @@ This document tracks the core serializable types and selected transient runtime 
 
 Source of truth:
 - `src/world/types.ts`
+- `src/world/entities/base/Entity.ts`
+- `src/world/entities/base/Actor.ts`
+- `src/world/entities/npcs/Npc.ts`
+- `src/world/entities/objects/WorldObject.ts`
+- `src/world/entities/items/Item.ts`
+- `src/world/entities/environment/Environment.ts`
+- `src/world/entities/dtoRuntimeSeams.ts`
 - `src/interaction/npcPromptContext.ts`
 - `src/interaction/objectInteraction.ts`
 - `src/interaction/adjacencyResolver.ts`
@@ -39,6 +46,51 @@ type ActionModalEligibleTarget = Extract<AdjacentTarget, { kind: 'guard' | 'npc'
 Used by runtime to distinguish between:
 - **Eligible:** Targets that open action modal (guards, NPCs)
 - **Ineligible:** Targets handled deterministically (doors, objects)
+
+## World Domain Runtime-Class Seams
+
+These interfaces and classes provide a typed construction seam between serializable DTOs in `src/world/types.ts` and runtime class instances in `src/world/entities/`.
+
+### EntityInit
+- `id: string`
+- `position: GridPosition`
+- `displayName: string`
+- `spriteAssetPath?: string`
+- `spriteSet?: SpriteSet`
+- `traits?: Record<string, string>`
+- `facts?: Record<string, string | number | boolean>`
+
+### ActorInit
+Extends `EntityInit`:
+- `facingDirection?: SpriteDirection`
+
+### NpcInit
+Extends `ActorInit`:
+- `npcType: string`
+- `dialogueContextKey: string`
+- `patrol?: { path: Array<{ x: number; y: number }> }`
+- `triggers?: NpcTriggers`
+- `inventory?: InventoryItem[]`
+- `instanceKnowledge?: string`
+- `instanceBehavior?: string`
+- `riddleClue?: RiddleClue`
+
+### WorldObjectInit
+Extends `EntityInit`:
+- `objectType: string`
+
+### ItemInit
+Extends `EntityInit`:
+- `itemType: string`
+
+### EnvironmentInit
+Extends `EntityInit`:
+- `isBlocking: boolean`
+
+### DtoToRuntimeAdapter<TDto, TRuntime>
+- `fromDto(dto: TDto): TRuntime`
+
+Used by seam adapter contracts in `src/world/entities/dtoRuntimeSeams.ts`.
 
 ## World Types
 

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -70,6 +70,20 @@ Legacy `WorldCommand` objects (`move`, `selectInventorySlot`, `useSelectedItem`,
 
 All fields are serializable primitives, arrays, or plain objects.
 
+## Domain Class Foundation
+
+The world layer now includes a domain-class foundation in `src/world/entities/`:
+- base classes: `Entity`, `Actor`
+- specialized classes: `Npc`, `Item`, `Environment`, `WorldObject`
+- seam adapters: `dtoRuntimeSeams.ts` (`mapEntityDtoToRuntime`, `mapNpcDtoToRuntime`)
+
+These classes establish a typed DTO-to-runtime boundary for future incremental migration away from direct object-literal construction.
+
+Determinism/serialization contract remains unchanged:
+- `WorldState` is still plain JSON-serializable data
+- command application and interaction outcomes remain code-owned and deterministic
+- class instances are currently seam scaffolding and test-covered (`src/world/entities/dtoRuntimeSeams.test.ts`) rather than a runtime behavior pivot
+
 `actorConversationHistoryByActorId` stores chat history keyed by actor id. It remains JSON-serializable and actor-neutral even though the current conversational actors are guards and NPCs.
 
 ### Player Facing Direction State

--- a/src/world/entities/base/Actor.ts
+++ b/src/world/entities/base/Actor.ts
@@ -1,0 +1,15 @@
+import type { SpriteDirection } from '../../types';
+import { Entity, type EntityInit } from './Entity';
+
+export interface ActorInit extends EntityInit {
+  facingDirection?: SpriteDirection;
+}
+
+export class Actor extends Entity {
+  public facingDirection?: SpriteDirection;
+
+  public constructor(init: ActorInit) {
+    super(init);
+    this.facingDirection = init.facingDirection;
+  }
+}

--- a/src/world/entities/base/Entity.ts
+++ b/src/world/entities/base/Entity.ts
@@ -1,0 +1,31 @@
+import type { GridPosition, SpriteSet } from '../../types';
+
+export interface EntityInit {
+  id: string;
+  position: GridPosition;
+  displayName: string;
+  spriteAssetPath?: string;
+  spriteSet?: SpriteSet;
+  traits?: Record<string, string>;
+  facts?: Record<string, string | number | boolean>;
+}
+
+export class Entity {
+  public readonly id: string;
+  public position: GridPosition;
+  public displayName: string;
+  public spriteAssetPath?: string;
+  public spriteSet?: SpriteSet;
+  public traits?: Record<string, string>;
+  public facts?: Record<string, string | number | boolean>;
+
+  public constructor(init: EntityInit) {
+    this.id = init.id;
+    this.position = { ...init.position };
+    this.displayName = init.displayName;
+    this.spriteAssetPath = init.spriteAssetPath;
+    this.spriteSet = init.spriteSet;
+    this.traits = init.traits;
+    this.facts = init.facts;
+  }
+}

--- a/src/world/entities/dtoRuntimeSeams.test.ts
+++ b/src/world/entities/dtoRuntimeSeams.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { Environment } from './environment/Environment';
+import { Item } from './items/Item';
+import { mapNpcDtoToRuntime } from './dtoRuntimeSeams';
+import { Npc } from './npcs/Npc';
+
+describe('domain class foundation seams', () => {
+  it('instantiates foundational classes and maps NPC dto to runtime class without runtime integration', () => {
+    const item = new Item({
+      id: 'item-1',
+      position: { x: 1, y: 2 },
+      displayName: 'Bronze Key',
+      itemType: 'key',
+    });
+    const environment = new Environment({
+      id: 'env-1',
+      position: { x: 3, y: 4 },
+      displayName: 'Stone Wall',
+      isBlocking: true,
+    });
+
+    const npc = mapNpcDtoToRuntime({
+      id: 'npc-1',
+      displayName: 'Archivist',
+      position: { x: 5, y: 6 },
+      npcType: 'archive_keeper',
+      dialogueContextKey: 'archive_keeper_intro',
+      patrol: { path: [{ x: 5, y: 6 }, { x: 6, y: 6 }] },
+    });
+
+    expect(item.itemType).toBe('key');
+    expect(environment.isBlocking).toBe(true);
+    expect(npc).toBeInstanceOf(Npc);
+    expect(npc.npcType).toBe('archive_keeper');
+    expect(JSON.parse(JSON.stringify(npc))).toMatchObject({
+      id: 'npc-1',
+      displayName: 'Archivist',
+      position: { x: 5, y: 6 },
+      npcType: 'archive_keeper',
+      dialogueContextKey: 'archive_keeper_intro',
+    });
+  });
+});

--- a/src/world/entities/dtoRuntimeSeams.ts
+++ b/src/world/entities/dtoRuntimeSeams.ts
@@ -1,0 +1,40 @@
+import type { GameEntity, Npc as NpcDto } from '../types';
+import { Entity } from './base/Entity';
+import { Npc } from './npcs/Npc';
+
+export type EntityDtoContract = GameEntity;
+export type NpcDtoContract = NpcDto;
+
+export interface DtoToRuntimeAdapter<TDto, TRuntime> {
+  fromDto(dto: TDto): TRuntime;
+}
+
+export const mapEntityDtoToRuntime = (dto: EntityDtoContract): Entity =>
+  new Entity({
+    id: dto.id,
+    position: dto.position,
+    displayName: dto.displayName,
+    spriteAssetPath: dto.spriteAssetPath,
+    spriteSet: dto.spriteSet,
+    traits: dto.traits,
+    facts: dto.facts,
+  });
+
+export const mapNpcDtoToRuntime = (dto: NpcDtoContract): Npc =>
+  new Npc({
+    id: dto.id,
+    position: dto.position,
+    displayName: dto.displayName,
+    spriteAssetPath: dto.spriteAssetPath,
+    spriteSet: dto.spriteSet,
+    traits: dto.traits,
+    facts: dto.facts,
+    npcType: dto.npcType,
+    dialogueContextKey: dto.dialogueContextKey,
+    patrol: dto.patrol,
+    triggers: dto.triggers,
+    inventory: dto.inventory,
+    instanceKnowledge: dto.instanceKnowledge,
+    instanceBehavior: dto.instanceBehavior,
+    riddleClue: dto.riddleClue,
+  });

--- a/src/world/entities/environment/Environment.ts
+++ b/src/world/entities/environment/Environment.ts
@@ -1,0 +1,14 @@
+import { Entity, type EntityInit } from '../base/Entity';
+
+export interface EnvironmentInit extends EntityInit {
+  isBlocking: boolean;
+}
+
+export class Environment extends Entity {
+  public isBlocking: boolean;
+
+  public constructor(init: EnvironmentInit) {
+    super(init);
+    this.isBlocking = init.isBlocking;
+  }
+}

--- a/src/world/entities/items/Item.ts
+++ b/src/world/entities/items/Item.ts
@@ -1,0 +1,14 @@
+import { Entity, type EntityInit } from '../base/Entity';
+
+export interface ItemInit extends EntityInit {
+  itemType: string;
+}
+
+export class Item extends Entity {
+  public itemType: string;
+
+  public constructor(init: ItemInit) {
+    super(init);
+    this.itemType = init.itemType;
+  }
+}

--- a/src/world/entities/npcs/Npc.ts
+++ b/src/world/entities/npcs/Npc.ts
@@ -1,0 +1,36 @@
+import type { InventoryItem, NpcTriggers, RiddleClue } from '../../types';
+import { Actor, type ActorInit } from '../base/Actor';
+
+export interface NpcInit extends ActorInit {
+  npcType: string;
+  dialogueContextKey: string;
+  patrol?: { path: Array<{ x: number; y: number }> };
+  triggers?: NpcTriggers;
+  inventory?: InventoryItem[];
+  instanceKnowledge?: string;
+  instanceBehavior?: string;
+  riddleClue?: RiddleClue;
+}
+
+export class Npc extends Actor {
+  public npcType: string;
+  public dialogueContextKey: string;
+  public patrol?: { path: Array<{ x: number; y: number }> };
+  public triggers?: NpcTriggers;
+  public inventory?: InventoryItem[];
+  public instanceKnowledge?: string;
+  public instanceBehavior?: string;
+  public riddleClue?: RiddleClue;
+
+  public constructor(init: NpcInit) {
+    super(init);
+    this.npcType = init.npcType;
+    this.dialogueContextKey = init.dialogueContextKey;
+    this.patrol = init.patrol ? { path: init.patrol.path.map((position) => ({ ...position })) } : undefined;
+    this.triggers = init.triggers;
+    this.inventory = init.inventory?.map((item) => ({ ...item }));
+    this.instanceKnowledge = init.instanceKnowledge;
+    this.instanceBehavior = init.instanceBehavior;
+    this.riddleClue = init.riddleClue ? { ...init.riddleClue } : undefined;
+  }
+}

--- a/src/world/entities/objects/WorldObject.ts
+++ b/src/world/entities/objects/WorldObject.ts
@@ -1,0 +1,14 @@
+import { Entity, type EntityInit } from '../base/Entity';
+
+export interface WorldObjectInit extends EntityInit {
+  objectType: string;
+}
+
+export abstract class WorldObject extends Entity {
+  public objectType: string;
+
+  protected constructor(init: WorldObjectInit) {
+    super(init);
+    this.objectType = init.objectType;
+  }
+}


### PR DESCRIPTION
## Summary
- add world entity folder structure for base, npcs, objects, items, and environment
- introduce foundational domain classes (Entity, Actor, Npc, WorldObject, Item, Environment)
- add DTO-to-runtime seam scaffolding via adapter contracts and no-op mapping functions
- add focused seam test proving class instantiation and mapping without runtime integration

## Validation
- npm run test
- npm run build
- npm run lint

Closes #145