### PR TITLE
Environment Base Type and Blocking Rules

### DIFF
--- a/docs/GAME_DESIGN_BASELINE.md
+++ b/docs/GAME_DESIGN_BASELINE.md
@@ -16,7 +16,7 @@ Current playable loop:
   - use selected inventory item (F)
 - Movement is deterministic and grid-based:
   - Player facing updates from move direction even when movement is blocked.
-  - Movement is blocked by out-of-bounds positions and occupied tiles (guards, doors, NPCs, interactive objects).
+  - Movement is blocked by out-of-bounds positions and occupied tiles (blocking environments, guards, locked doors, NPCs, interactive objects).
 - Interaction resolution is deterministic:
   - Interact only checks orthogonally adjacent targets.
   - Priority order when multiple targets are adjacent: guard, then door, then npc, then interactive object.
@@ -38,9 +38,9 @@ Implemented objective flow:
 
 Implemented systems:
 - World model:
-  - Serializable WorldState with tick, grid, level metadata/objective, entities, conversation history, last item-use attempt event, and levelOutcome.
+  - Serializable WorldState with tick, grid, level metadata/objective, entities (including optional environments), conversation history, last item-use attempt event, and levelOutcome.
   - Deterministic command application and level deserialization.
-  - Spatial validation at level load (in-bounds and no overlaps).
+  - Spatial validation at level load (in-bounds and no overlaps, including environments).
   - Deterministic selected inventory slot state in player inventory (`selectedItem`).
 - Input:
   - Keyboard mapping to world commands with Arrow/WASD parity for movement and inventory-slot selection (`1`..`9`) and selected-item use.
@@ -48,6 +48,7 @@ Implemented systems:
   - Modal-aware command suppression via runtime `isModalOpen()` callback (gates movement/interact, preserves slot selection).
 - Interaction:
   - Adjacent-target resolver with deterministic priority and tie-break.
+  - Environment entities are excluded from interaction target resolution.
   - Door interaction:
     - Returns door state text.
     - Door outcome safe maps to win; danger maps to lose.

--- a/docs/LEVEL_FORMAT.md
+++ b/docs/LEVEL_FORMAT.md
@@ -113,6 +113,24 @@ When authoring new levels, keep `grid.width === width`, `grid.height === height`
 - `state`: `idle | used`
 - `capabilities` is required by coverage checks.
 
+### environments
+
+```json
+{
+  "id": "wall-1",
+  "displayName": "Stone Wall",
+  "x": 6,
+  "y": 7,
+  "isBlocking": true
+}
+```
+
+- `environments` is an optional top-level array.
+- Each environment entry requires `id`, `displayName`, `x`, `y`, and `isBlocking`.
+- `isBlocking: true` blocks movement into that tile.
+- Environments participate in overlap validation with all other world entities.
+- Environments are spatial-only and are not valid interaction targets.
+
 ### player
 
 Runtime field:

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -239,6 +239,19 @@ Extends `GameEntity`:
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`
 
+### Environment
+- `id: string`
+- `displayName: string`
+- `position: GridPosition`
+- `isBlocking: boolean`
+
+Environment entities are world-level spatial entities only. They can block movement when `isBlocking` is true and are not interaction targets.
+
+### LevelData (environments excerpt)
+- `environments?: Array<{ id: string; displayName: string; x: number; y: number; isBlocking: boolean }>`
+
+Optional level schema section for environment entries. During deserialization, level coordinates (`x`, `y`) are mapped to runtime `position`.
+
 ### WorldGrid
 - `width: number`
 - `height: number`
@@ -263,6 +276,7 @@ Stores conversation history by actor id. The current conversational actors are g
 - `guards: Guard[]`
 - `doors: Door[]`
 - `interactiveObjects: InteractiveObject[]`
+- `environments?: Environment[]`
 - `actorConversationHistoryByActorId: ActorConversationHistoryByActorId`
 - `lastItemUseAttemptEvent?: ItemUseAttemptResultEvent | null` - latest resolved selected-item use attempt
 - `levelOutcome: 'win' | 'lose' | null`

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -64,6 +64,7 @@ Legacy `WorldCommand` objects (`move`, `selectInventorySlot`, `useSelectedItem`,
 - `guards`
 - `doors`
 - `interactiveObjects`
+- `environments`
 - `actorConversationHistoryByActorId`
 - `lastItemUseAttemptEvent`
 - `levelOutcome`
@@ -142,6 +143,7 @@ Deterministic rules:
 - `player`, `guards`, and `doors`
 - Optional `npcs` - array of level-defined NPCs with required `id`, `displayName`, `x`, `y`, and `npcType` fields
 - Optional `interactiveObjects`
+- Optional `environments` - array with required `id`, `displayName`, `x`, `y`, and `isBlocking` fields
 
 Sprite metadata contracts:
 - `spriteAssetPath?: string` remains optional for player, guards, doors, npcs, and interactive objects.
@@ -170,6 +172,10 @@ For `interactiveObjects`, validation enforces:
 - `state` in `idle | used`
 - optional `pickupItem` with non-empty string `itemId` and `displayName`
 - optional `firstUseOutcome` in `win | lose`
+
+For `environments`, validation enforces:
+- required identity/position fields
+- required `isBlocking: boolean`
 
 ## Deserialization
 
@@ -225,6 +231,12 @@ Interactive object instance fields deserialize directly:
 - `spriteAssetPath`
 - `spriteSet`
 
+Environment fields deserialize directly:
+- `id`
+- `displayName`
+- `position` (mapped from level `x`/`y`)
+- `isBlocking`
+
 This enables shared behavior per object type while preserving instance-specific text, outcomes, and asset metadata.
 
 ## Shipped Level Demonstrations
@@ -246,9 +258,9 @@ Movement commands also update immutable player-facing state in `src/world/world.
 
 ## Testing Strategy
 
-- `src/world/level.test.ts`: schema validation + deserialization coverage for `spriteAssetPath` and `spriteSet`, including player default `facingDirection` on load
+- `src/world/level.test.ts`: schema validation + deserialization coverage for `spriteAssetPath`, `spriteSet`, and optional `environments`, including player default `facingDirection` on load
 - `src/world/world.test.ts`: deterministic movement mapping from command intent to `player.facingDirection`, including blocked movement intent
 - `src/integration/riddleLevel.test.ts`: riddle-level sprite-set wiring assertions for player/guards/doors and player default `facingDirection`
-- `src/world/spatialRules.test.ts`: occupancy invariants
+- `src/world/spatialRules.test.ts`: occupancy invariants, environment blocking checks, and environment overlap validation
 
 Determinism rule remains unchanged: identical starting state + identical command/interaction sequence => identical resulting state.

--- a/src/interaction/adjacencyResolver.test.ts
+++ b/src/interaction/adjacencyResolver.test.ts
@@ -23,6 +23,7 @@ const baseState = (): WorldState => ({
   guards: [],
   doors: [],
   interactiveObjects: [],
+  environments: [],
   actorConversationHistoryByActorId: {},
   levelOutcome: null,
 });
@@ -84,6 +85,20 @@ describe('resolveAdjacentTarget', () => {
       const state = baseState();
       state.guards = [makeGuard(5, 3)]; // distance 2 right
       state.doors = [makeDoor(3, 5)]; // distance 2 down
+      expect(resolveAdjacentTarget(state)).toBeNull();
+    });
+
+    it('ignores adjacent environments as interaction targets', () => {
+      const state = baseState();
+      state.environments = [
+        {
+          id: 'wall-1',
+          displayName: 'Stone Wall',
+          position: { x: 4, y: 3 },
+          isBlocking: true,
+        },
+      ];
+
       expect(resolveAdjacentTarget(state)).toBeNull();
     });
   });

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -95,6 +95,30 @@ describe('deserializeLevel', () => {
     expect(state.player.inventory.items).toEqual([]);
   });
 
+  it('deserializes environments when provided', () => {
+    const state = deserializeLevel({
+      ...minimalLevel,
+      environments: [
+        {
+          id: 'wall-1',
+          displayName: 'Stone Wall',
+          x: 6,
+          y: 7,
+          isBlocking: true,
+        },
+      ],
+    });
+
+    expect(state.environments).toEqual([
+      {
+        id: 'wall-1',
+        displayName: 'Stone Wall',
+        position: { x: 6, y: 7 },
+        isBlocking: true,
+      },
+    ]);
+  });
+
   it('keeps player inventory JSON-serializable after deserialization', () => {
     const state = deserializeLevel(minimalLevel);
 
@@ -337,6 +361,41 @@ describe('validateLevelData', () => {
   it('returns the input unchanged when all required fields are valid', () => {
     const result = validateLevelData(minimalLevel);
     expect(result).toEqual(minimalLevel);
+  });
+
+  it('accepts optional environments when each entry has required fields', () => {
+    const levelWithEnvironments: LevelData = {
+      ...minimalLevel,
+      environments: [
+        {
+          id: 'wall-1',
+          displayName: 'Stone Wall',
+          x: 3,
+          y: 4,
+          isBlocking: true,
+        },
+      ],
+    };
+
+    expect(validateLevelData(levelWithEnvironments)).toEqual(levelWithEnvironments);
+  });
+
+  it('throws when an environment entry is missing required fields', () => {
+    const invalidLevel = {
+      ...minimalLevel,
+      environments: [
+        {
+          id: 'wall-1',
+          displayName: 'Stone Wall',
+          x: 3,
+          y: 4,
+        },
+      ],
+    };
+
+    expect(() => validateLevelData(invalidLevel)).toThrowError(
+      'Invalid level data: environment at index 0 must have id, displayName, x, y, and isBlocking',
+    );
   });
 
   it('throws when version is missing', () => {

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -1,4 +1,4 @@
-import type { GridPosition, LevelData, Npc, WorldState } from './types';
+import type { Environment, GridPosition, LevelData, Npc, WorldState } from './types';
 import { validateSpatialLayout } from './spatialRules';
 
 const DEFAULT_TILE_SIZE = 48;
@@ -506,6 +506,30 @@ export function validateLevelData(input: unknown): LevelData {
     }
   }
 
+  if (raw['environments'] !== undefined) {
+    if (!Array.isArray(raw['environments'])) {
+      throw new Error('Invalid level data: environments must be an array');
+    }
+
+    for (let i = 0; i < (raw['environments'] as unknown[]).length; i++) {
+      const environment = (raw['environments'] as unknown[])[i] as Record<string, unknown>;
+
+      if (
+        typeof environment !== 'object' ||
+        environment === null ||
+        typeof environment['id'] !== 'string' ||
+        typeof environment['displayName'] !== 'string' ||
+        typeof environment['x'] !== 'number' ||
+        typeof environment['y'] !== 'number' ||
+        typeof environment['isBlocking'] !== 'boolean'
+      ) {
+        throw new Error(
+          `Invalid level data: environment at index ${i} must have id, displayName, x, y, and isBlocking`,
+        );
+      }
+    }
+  }
+
   return raw as unknown as LevelData;
 }
 
@@ -638,6 +662,14 @@ export function deserializeLevel(levelData: LevelData): WorldState {
       capabilities: o.capabilities,
       itemUseRules: o.itemUseRules,
     })),
+    environments: (levelData.environments ?? []).map(
+      (environment): Environment => ({
+        id: environment.id,
+        displayName: environment.displayName,
+        position: { x: environment.x, y: environment.y },
+        isBlocking: environment.isBlocking,
+      }),
+    ),
     actorConversationHistoryByActorId: {},
     lastItemUseAttemptEvent: null,
     levelOutcome: null,

--- a/src/world/spatialRules.test.ts
+++ b/src/world/spatialRules.test.ts
@@ -29,6 +29,33 @@ describe('spatialRules', () => {
     expect(canMovePlayerTo(worldState, { x: 8, y: 3 })).toBe(false);
   });
 
+  it('treats blocking environments as movement blockers and ignores non-blocking environments', () => {
+    const worldState = createInitialWorldState();
+    const withEnvironments = {
+      ...worldState,
+      environments: [
+        {
+          id: 'wall-1',
+          displayName: 'Stone Wall',
+          position: { x: 2, y: 1 },
+          isBlocking: true,
+        },
+        {
+          id: 'grass-1',
+          displayName: 'Tall Grass',
+          position: { x: 3, y: 1 },
+          isBlocking: false,
+        },
+      ],
+    };
+
+    expect(canMovePlayerTo(withEnvironments, { x: 2, y: 1 })).toBe(false);
+    expect(canMovePlayerTo(withEnvironments, { x: 3, y: 1 })).toBe(true);
+    expect(getBlockingOccupants(withEnvironments, { x: 2, y: 1 }).map((blocker) => blocker.label)).toEqual([
+      'environment:wall-1',
+    ]);
+  });
+
   it('validates a non-overlapping in-bounds layout', () => {
     const worldState = createInitialWorldState();
 
@@ -62,6 +89,25 @@ describe('spatialRules', () => {
 
     expect(() => validateSpatialLayout(overlapping)).toThrowError(
       `Invalid world layout: overlapping coordinates at (${worldState.player.position.x}, ${worldState.player.position.y}) between player:${worldState.player.id} and npc:${worldState.npcs[0].id}`,
+    );
+  });
+
+  it('includes environments in overlap validation', () => {
+    const worldState = createInitialWorldState();
+    const withOverlappingEnvironment = {
+      ...worldState,
+      environments: [
+        {
+          id: 'wall-1',
+          displayName: 'Stone Wall',
+          position: { ...worldState.player.position },
+          isBlocking: true,
+        },
+      ],
+    };
+
+    expect(() => validateSpatialLayout(withOverlappingEnvironment)).toThrowError(
+      `Invalid world layout: overlapping coordinates at (${worldState.player.position.x}, ${worldState.player.position.y}) between player:${worldState.player.id} and environment:wall-1`,
     );
   });
 });

--- a/src/world/spatialRules.ts
+++ b/src/world/spatialRules.ts
@@ -13,6 +13,12 @@ export const isInBounds = (position: GridPosition, grid: WorldGrid): boolean =>
 export const getBlockingOccupants = (worldState: WorldState, position: GridPosition): SpatialEntity[] => {
   const blockers: SpatialEntity[] = [];
 
+  for (const environment of worldState.environments ?? []) {
+    if (environment.isBlocking && samePosition(environment.position, position)) {
+      blockers.push({ label: `environment:${environment.id}`, position: environment.position });
+    }
+  }
+
   for (const npc of worldState.npcs) {
     if (samePosition(npc.position, position)) {
       blockers.push({ label: `npc:${npc.id}`, position: npc.position });
@@ -48,6 +54,10 @@ export const canMovePlayerTo = (worldState: WorldState, target: GridPosition): b
 
 const collectSpatialEntities = (worldState: WorldState): SpatialEntity[] => [
   { label: `player:${worldState.player.id}`, position: worldState.player.position },
+  ...(worldState.environments ?? []).map((environment) => ({
+    label: `environment:${environment.id}`,
+    position: environment.position,
+  })),
   ...worldState.npcs.map((npc) => ({ label: `npc:${npc.id}`, position: npc.position })),
   ...worldState.interactiveObjects.map((interactiveObject) => ({
     label: `interactiveObject:${interactiveObject.id}`,

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -46,6 +46,7 @@ export const createInitialWorldState = (): WorldState => ({
       spriteAssetPath: '/assets/medieval_supply_crate_inspect.svg',
     },
   ],
+  environments: [],
   actorConversationHistoryByActorId: {},
   lastItemUseAttemptEvent: null,
   levelOutcome: null,

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -202,6 +202,13 @@ export interface InteractiveObject extends GameEntity {
   itemUseRules?: Record<string, ItemUseRule>;
 }
 
+export interface Environment {
+  id: string;
+  displayName: string;
+  position: GridPosition;
+  isBlocking: boolean;
+}
+
 export interface WorldGrid {
   width: number;
   height: number;
@@ -296,6 +303,13 @@ export interface LevelData {
     /** Deterministic item-use rules: item ID → rule definition */
     itemUseRules?: Record<string, ItemUseRule>;
   }>;
+  environments?: Array<{
+    id: string;
+    displayName: string;
+    x: number;
+    y: number;
+    isBlocking: boolean;
+  }>;
 }
 
 export interface WorldState {
@@ -308,6 +322,7 @@ export interface WorldState {
   guards: Guard[];
   doors: Door[];
   interactiveObjects: InteractiveObject[];
+  environments?: Environment[];
   actorConversationHistoryByActorId: ActorConversationHistoryByActorId;
   lastItemUseAttemptEvent?: ItemUseAttemptResultEvent | null;
   levelOutcome: 'win' | 'lose' | null;


### PR DESCRIPTION
## Summary
- add optional environments DTO/state shape with id, displayName, x, y, isBlocking
- validate and deserialize environments through the level pipeline
- include blocking environments in movement collision and include environments in spatial overlap validation
- verify interaction target resolution ignores environments
- add focused tests for environment blocking, interaction exclusion, and environment validation/deserialization

Closes #146