### PR TITLE
Object Class Hierarchy with Abstract Interact

### DIFF
--- a/docs/GAME_DESIGN_BASELINE.md
+++ b/docs/GAME_DESIGN_BASELINE.md
@@ -53,10 +53,11 @@ Implemented systems:
   - Door interaction:
     - Returns door state text.
     - Door outcome safe maps to win; danger maps to lose.
-  - Interactive object interaction (supply-crate):
-    - Sets object state to used.
-    - Returns idle/used response text.
-    - Can set levelOutcome from firstUseOutcome on first use.
+  - Interactive object interaction (polymorphic world-object runtime seam):
+    - DTOs are mapped at interaction time to runtime subclasses (`ContainerObject`, `MechanismObject`, `DoorObject`) and dispatched through abstract `WorldObject.interact(...)`.
+    - Container behavior preserves deterministic pickup exposure and object `idle -> used` state transition.
+    - Mechanism behavior preserves deterministic activation semantics and first-use outcome behavior.
+    - Door-like object behavior preserves deterministic `idle -> used` semantics and maps facts outcome (`safe`/`danger`) to level outcome when explicit `firstUseOutcome` is absent.
   - Guard and NPC conversation pipeline:
     - First interact opens conversation context.
     - Player message turns call LLM and append actor-scoped conversation history.
@@ -123,7 +124,10 @@ Design-level entity model in current implementation:
     - outcome safe maps to win.
     - outcome danger maps to lose.
 - Interactive object:
-  - Core fields: id, displayName, position, objectType (currently supply-crate), interactionType, state, idle/used messages, optional firstUseOutcome, optional sprite fields.
+  - Core fields: id, displayName, position, objectType, interactionType, state, idle/used messages, optional firstUseOutcome, optional sprite fields.
+  - Runtime interaction seam:
+    - `objectType` and `capabilities` are used to map to runtime object subclasses at interaction time.
+    - mapping currently supports container, mechanism, and door-like object semantics.
   - Deterministic outcome contract:
     - On first use, may set levelOutcome from firstUseOutcome if no existing outcome.
     - Subsequent uses keep used state and do not overwrite an existing levelOutcome.
@@ -135,7 +139,7 @@ Current constraints to design against:
 - Inventory supports deterministic pickup plus selected-slot state and use-attempt signaling, but no applied use effects on world targets yet.
 - No combat, stealth detection, patrol simulation, or line-of-sight system.
 - No deterministic dialogue consequence system beyond text history capture.
-- Interactive object types are currently limited to supply-crate.
+- Level validation still restricts serialized `interactiveObjects[].objectType` to `supply-crate`; broader object-type level-schema support is tracked separately from this interaction-layer runtime seam.
 - Selected-item use outcomes are currently placeholder-level (`no-selection` / `no-target`) and do not yet mutate targets.
 - Level progression/meta-progression is not implemented; level selection/reset is manual through UI controls.
 - Actor world knowledge builder coverage is partial (guard and villager path only).

--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -193,14 +193,18 @@ The following timing guarantees are intentional and must remain stable:
 
 Related tests live in `src/interaction/interactionDispatcher.test.ts` under dispatch routing and result dispatcher timing parity cases.
 
-## Interactive Object Type Handling
+## Interactive Object Polymorphic Dispatch
 
-`src/interaction/objectInteraction.ts` provides object-type dispatch:
-- `OBJECT_TYPE_HANDLERS` maps `InteractiveObject['objectType']` to a handler
-- Current supported type: `supply-crate`
-- Handler reads instance fields (`idleMessage`, `usedMessage`, `firstUseOutcome`) while reusing shared object-type logic
+`src/interaction/objectInteraction.ts` now routes interactive objects through runtime class mapping:
+- `mapInteractiveObjectDtoToRuntime(...)` in `src/world/entities/dtoRuntimeSeams.ts` adapts JSON DTOs to a `WorldObject` subclass
+- `handleObjectInteraction(...)` calls `worldObject.interact(...)` for polymorphic behavior
+- current subclasses:
+  - `ContainerObject` (pickup/container behavior)
+  - `MechanismObject` (activation behavior)
+  - `DoorObject` (door-like object behavior with safe/danger fact fallback)
+- unsupported object DTOs map to `null` and remain inert through fallback behavior
 
-This allows multiple objects to share one behavior implementation while retaining per-instance outcomes/messages from level JSON.
+This keeps serialized `interactiveObjects` state unchanged while moving behavior branching out of the interaction module and into deterministic world-object subclasses.
 
 Pickup behavior is deterministic and code-owned:
 - if an interactive object has `pickupItem` and is interacted with in `idle` state, the item is added to `player.inventory.items`
@@ -221,6 +225,6 @@ See `src/interaction/guardInteraction.ts`, `src/interaction/npcInteraction.ts`, 
 - `src/interaction/interactionDispatcher.test.ts`: dispatch routing by kind, sync/async behavior parity, result dispatcher timing parity, door/object non-pause guarantee
 - `src/runtimeController.test.ts`: pause entry/exit lifecycle, command gating while paused, resume without command leak, level-outcome gating independent of pause state
 - `src/interaction/npcPromptContext.test.ts`: profile registry resolution, deterministic fallback, world knowledge builder registry keys, alias resolution (`archive_keeper → villager`), self-exclusion from `otherVillagers`, unknown-type `null` fallback, context shape determinism
-- `src/interaction/objectInteraction.test.ts`: object-type dispatcher behavior, first-use outcomes, repeat interactions
+- `src/interaction/objectInteraction.test.ts`: polymorphic object dispatch, first-use outcomes, repeat interactions
 - `src/integration/riddleLevel.test.ts`: end-to-end adjacent door resolution and deterministic outcome mapping
 - `src/interaction/adjacencyResolver.test.ts`: deterministic target resolution with interactive objects

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -9,6 +9,9 @@ Source of truth:
 - `src/world/entities/npcs/Npc.ts`
 - `src/world/entities/npcs/GuardNpc.ts`
 - `src/world/entities/objects/WorldObject.ts`
+- `src/world/entities/objects/ContainerObject.ts`
+- `src/world/entities/objects/MechanismObject.ts`
+- `src/world/entities/objects/DoorObject.ts`
 - `src/world/entities/items/Item.ts`
 - `src/world/entities/environment/Environment.ts`
 - `src/world/entities/dtoRuntimeSeams.ts`
@@ -86,6 +89,19 @@ Extends `NpcInit` with guard-specialized constraints:
 Extends `EntityInit`:
 - `objectType: string`
 
+### WorldObjectInteractionRequest
+- `interactiveObject: InteractiveObject`
+- `player: Player`
+- `worldState: WorldState`
+
+Serializable input contract consumed by `WorldObject.interact(...)` implementations.
+
+### WorldObjectInteractionResult
+- `responseText: string`
+- `updatedWorldState: WorldState`
+
+Deterministic output contract returned by `WorldObject.interact(...)` implementations.
+
 ### ItemInit
 Extends `EntityInit`:
 - `itemType: string`
@@ -104,6 +120,12 @@ Alias of serializable `Guard` DTO used by the guard runtime seam adapter:
 - `type GuardDtoContract = Guard`
 
 Mapped by `mapGuardDtoToRuntime(dto)` to runtime `GuardNpc` while preserving guard JSON shape.
+
+### InteractiveObjectDtoContract
+Alias of serializable `InteractiveObject` DTO used by the world-object runtime seam adapter:
+- `type InteractiveObjectDtoContract = InteractiveObject`
+
+Mapped by `mapInteractiveObjectDtoToRuntime(dto)` to `ContainerObject`, `MechanismObject`, `DoorObject`, or `null` for inert/unsupported objects.
 
 ## World Types
 
@@ -231,23 +253,23 @@ Extends `GameEntity`:
 - `spriteSet?: SpriteSet`
 
 ### ObjectCapabilities
-Capability flags that drive object behavior through feature composition (not type branching):
+Capability flags that annotate object behavior capabilities:
 - `containsItems?: boolean` - Object contains items that can be inspected and picked up
 - `isActivatable?: boolean` - Object can be activated to trigger an effect (e.g., mechanism, lever)
 - `isLockable?: boolean` - Object has a lock mechanism (reserved for future use)
 
-Objects declare what they can do via capabilities. The interaction handler checks these flags in order and applies the matching effect. If no capabilities are present, the object is inert.
+Capabilities are consumed by runtime seam mapping for container and mechanism selection. Objects without a supported mapping remain inert.
 
 ### InteractiveObject
 Extends `GameEntity`:
-- `objectType: string` - Display label for the object type (e.g., "supply-crate", "mechanism", "decoration"). Not used for behavior routing; use only for UI context and LLM awareness. Previously used for type-based dispatch; now deprecated in favor of capabilities.
+- `objectType: string` - Object classification token (e.g., "supply-crate", "mechanism", "service-door", "decoration") used by runtime seam mapping alongside capabilities.
 - `interactionType: 'inspect' | 'use' | 'talk'`
 - `state: 'idle' | 'used'`
 - `pickupItem?: { itemId: string; displayName: string }` - Item available for pickup when this object is inspected (only used if capabilities.containsItems is true)
 - `idleMessage?: string` - Narrative response on first interaction
 - `usedMessage?: string` - Narrative response on subsequent interactions
 - `firstUseOutcome?: 'win' | 'lose'` - Level outcome triggered on first use (if any)
-- `capabilities?: ObjectCapabilities` - Feature flags that drive behavior via capability dispatch. If omitted or empty, object is inert.
+- `capabilities?: ObjectCapabilities` - Optional capability flags used by runtime seam mapping (for example container/mechanism classification).
 - `itemUseRules?: Record<string, ItemUseRule>` - Deterministic item-use rules keyed by item ID. When player uses a matching item on this object, the rule determines success/blocked outcome. Successful use transitions object state to 'used'.
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -76,14 +76,14 @@ All fields are serializable primitives, arrays, or plain objects.
 The world layer now includes a domain-class foundation in `src/world/entities/`:
 - base classes: `Entity`, `Actor`
 - specialized classes: `Npc`, `GuardNpc`, `Item`, `Environment`, `WorldObject`
-- seam adapters: `dtoRuntimeSeams.ts` (`mapEntityDtoToRuntime`, `mapNpcDtoToRuntime`, `mapGuardDtoToRuntime`)
+- seam adapters: `dtoRuntimeSeams.ts` (`mapEntityDtoToRuntime`, `mapNpcDtoToRuntime`, `mapGuardDtoToRuntime`, `mapInteractiveObjectDtoToRuntime`)
 
 These classes establish a typed DTO-to-runtime boundary for future incremental migration away from direct object-literal construction.
 
 Determinism/serialization contract remains unchanged:
 - `WorldState` is still plain JSON-serializable data
 - command application and interaction outcomes remain code-owned and deterministic
-- class instances are currently seam scaffolding and test-covered (`src/world/entities/dtoRuntimeSeams.test.ts`) rather than a runtime behavior pivot
+- guard and npc classes remain seam-focused, while interactive objects now use seam-mapped runtime subclasses for interaction polymorphism (`src/interaction/objectInteraction.ts`, `src/world/entities/objects/*.ts`)
 
 `actorConversationHistoryByActorId` stores chat history keyed by actor id. It remains JSON-serializable and actor-neutral even though the current conversational actors are guards and NPCs.
 

--- a/src/interaction/objectInteraction.test.ts
+++ b/src/interaction/objectInteraction.test.ts
@@ -59,6 +59,22 @@ const makeInertObject = (
   ...overrides,
 });
 
+const makeDoorLikeObject = (
+  id: string,
+  state: InteractiveObject['state'],
+  overrides: Partial<InteractiveObject> = {},
+): InteractiveObject => ({
+  id,
+  displayName: 'Service Door',
+  position: { x: 2, y: 3 },
+  objectType: 'service-door',
+  interactionType: 'use',
+  state,
+  idleMessage: 'You open the service door.',
+  usedMessage: 'The service door is already open.',
+  ...overrides,
+});
+
 const createWorldState = (...interactiveObjects: InteractiveObject[]): WorldState => ({
   tick: 0,
   grid: { width: 10, height: 10, tileSize: 32 },
@@ -238,6 +254,90 @@ describe('handleObjectInteraction', () => {
       });
 
       expect(result.responseText).toBe('The mechanism is already activated.');
+      expect(result.updatedWorldState.levelOutcome).toBeNull();
+    });
+
+    it('uses polymorphic mechanism dispatch for mechanism objectType even without capabilities flags', () => {
+      const mechanism = makeActivatableObject('mechanism-polymorphic', 'idle', {
+        capabilities: undefined,
+      });
+      const worldState = createWorldState(mechanism);
+
+      const result = handleObjectInteraction({
+        interactiveObject: mechanism,
+        player,
+        worldState,
+      });
+
+      expect(result.responseText).toBe('The device has been activated.');
+      expect(result.updatedWorldState.interactiveObjects[0].state).toBe('used');
+    });
+  });
+
+  describe('door-like interactive objects', () => {
+    it('uses door-object polymorphism and maps safe/danger facts to level outcome when explicit firstUseOutcome is absent', () => {
+      const safeDoorObject = makeDoorLikeObject('door-object-safe', 'idle', {
+        facts: {
+          outcome: 'safe',
+        },
+      });
+
+      const safeResult = handleObjectInteraction({
+        interactiveObject: safeDoorObject,
+        player,
+        worldState: createWorldState(safeDoorObject),
+      });
+
+      expect(safeResult.responseText).toBe('You open the service door.');
+      expect(safeResult.updatedWorldState.levelOutcome).toBe('win');
+      expect(safeResult.updatedWorldState.interactiveObjects[0].state).toBe('used');
+
+      const dangerDoorObject = makeDoorLikeObject('door-object-danger', 'idle', {
+        facts: {
+          outcome: 'danger',
+        },
+      });
+
+      const dangerResult = handleObjectInteraction({
+        interactiveObject: dangerDoorObject,
+        player,
+        worldState: createWorldState(dangerDoorObject),
+      });
+
+      expect(dangerResult.updatedWorldState.levelOutcome).toBe('lose');
+    });
+
+    it('prioritizes explicit firstUseOutcome over door-like facts outcome', () => {
+      const doorObject = makeDoorLikeObject('door-object-explicit', 'idle', {
+        firstUseOutcome: 'lose',
+        facts: {
+          outcome: 'safe',
+        },
+      });
+
+      const result = handleObjectInteraction({
+        interactiveObject: doorObject,
+        player,
+        worldState: createWorldState(doorObject),
+      });
+
+      expect(result.updatedWorldState.levelOutcome).toBe('lose');
+    });
+
+    it('does not retrigger door-like fact outcome after first interaction', () => {
+      const doorObject = makeDoorLikeObject('door-object-repeat', 'used', {
+        facts: {
+          outcome: 'safe',
+        },
+      });
+
+      const result = handleObjectInteraction({
+        interactiveObject: doorObject,
+        player,
+        worldState: createWorldState(doorObject),
+      });
+
+      expect(result.responseText).toBe('The service door is already open.');
       expect(result.updatedWorldState.levelOutcome).toBeNull();
     });
   });

--- a/src/interaction/objectInteraction.ts
+++ b/src/interaction/objectInteraction.ts
@@ -1,4 +1,5 @@
 import type { InteractiveObject, Player, WorldState } from '../world/types';
+import { mapInteractiveObjectDtoToRuntime } from '../world/entities/dtoRuntimeSeams';
 
 export interface InteractiveObjectInteractionRequest {
 	interactiveObject: InteractiveObject;
@@ -12,125 +13,18 @@ export interface InteractiveObjectInteractionResult {
 	updatedWorldState: WorldState;
 }
 
-const replaceInteractiveObjectInWorld = (
-	worldState: WorldState,
-	updatedObject: InteractiveObject,
-): InteractiveObject[] =>
-	worldState.interactiveObjects.map((interactiveObject) =>
-		interactiveObject.id === updatedObject.id ? updatedObject : interactiveObject,
-	);
-
-/**
- * Handles container interaction: reveals items from object.
- * Triggered when object has capabilities.containsItems = true.
- */
-const handleContainerInteraction = (
-	request: InteractiveObjectInteractionRequest,
-): InteractiveObjectInteractionResult => {
-	const wasUsed = request.interactiveObject.state === 'used';
-	const pickupItem = request.interactiveObject.pickupItem;
-	const inventoryItems = request.worldState.player.inventory.items;
-	const inventoryAlreadyContainsObjectPickup = inventoryItems.some(
-		(item) => item.sourceObjectId === request.interactiveObject.id,
-	);
-	const canPickup = !wasUsed && pickupItem !== undefined && !inventoryAlreadyContainsObjectPickup;
-	const responseText = wasUsed
-		? request.interactiveObject.usedMessage ?? `${request.interactiveObject.displayName} is already open.`
-		: request.interactiveObject.idleMessage ??
-			`You inspect ${request.interactiveObject.displayName}.`;
-
-	const updatedObject: InteractiveObject = {
-		...request.interactiveObject,
-		state: 'used',
-	};
-
-	const nextLevelOutcome =
-		request.worldState.levelOutcome ??
-		(!wasUsed ? (request.interactiveObject.firstUseOutcome ?? null) : null);
-
-	const nextInventoryItems = canPickup
-		? [
-				...inventoryItems,
-				{
-					itemId: pickupItem.itemId,
-					displayName: pickupItem.displayName,
-					sourceObjectId: request.interactiveObject.id,
-					pickedUpAtTick: request.worldState.tick,
-				},
-			]
-		: inventoryItems;
-
-	const updatedWorldState: WorldState = {
-		...request.worldState,
-		player: {
-			...request.worldState.player,
-			inventory: {
-				items: nextInventoryItems,
-			},
-		},
-		interactiveObjects: replaceInteractiveObjectInWorld(request.worldState, updatedObject),
-		levelOutcome: nextLevelOutcome,
-	};
-
-	return {
-		objectId: request.interactiveObject.id,
-		responseText,
-		updatedWorldState,
-	};
-};
-
-/**
- * Handles activatable object interaction: triggers an effect (e.g., mechanism activation).
- * Triggered when object has capabilities.isActivatable = true.
- */
-const handleActivationInteraction = (
-	request: InteractiveObjectInteractionRequest,
-): InteractiveObjectInteractionResult => {
-	const wasUsed = request.interactiveObject.state === 'used';
-	const responseText = wasUsed
-		? request.interactiveObject.usedMessage ?? `${request.interactiveObject.displayName} is already activated.`
-		: request.interactiveObject.usedMessage ??
-			`You activate the ${request.interactiveObject.displayName}.`;
-
-	const updatedObject: InteractiveObject = {
-		...request.interactiveObject,
-		state: 'used',
-	};
-
-	const nextLevelOutcome =
-		request.worldState.levelOutcome ??
-		(!wasUsed ? (request.interactiveObject.firstUseOutcome ?? null) : null);
-
-	const updatedWorldState: WorldState = {
-		...request.worldState,
-		interactiveObjects: replaceInteractiveObjectInWorld(request.worldState, updatedObject),
-		levelOutcome: nextLevelOutcome,
-	};
-
-	return {
-		objectId: request.interactiveObject.id,
-		responseText,
-		updatedWorldState,
-	};
-};
-
-/**
- * Main dispatcher: routes object interaction based on declared capabilities.
- * Checks capabilities flags in order and applies the matching handler.
- */
 export const handleObjectInteraction = (
 	request: InteractiveObjectInteractionRequest,
 ): InteractiveObjectInteractionResult => {
-	const { capabilities } = request.interactiveObject;
+	const worldObject = mapInteractiveObjectDtoToRuntime(request.interactiveObject);
 
-	// Check for container capability first
-	if (capabilities?.containsItems) {
-		return handleContainerInteraction(request);
-	}
-
-	// Check for activation capability
-	if (capabilities?.isActivatable) {
-		return handleActivationInteraction(request);
+	if (worldObject !== null) {
+		const result = worldObject.interact(request);
+		return {
+			objectId: request.interactiveObject.id,
+			responseText: result.responseText,
+			updatedWorldState: result.updatedWorldState,
+		};
 	}
 
 	// No recognized capabilities: inert object

--- a/src/world/entities/dtoRuntimeSeams.test.ts
+++ b/src/world/entities/dtoRuntimeSeams.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { Environment } from './environment/Environment';
 import { Item } from './items/Item';
-import { mapGuardDtoToRuntime, mapNpcDtoToRuntime } from './dtoRuntimeSeams';
+import { mapGuardDtoToRuntime, mapInteractiveObjectDtoToRuntime, mapNpcDtoToRuntime } from './dtoRuntimeSeams';
 import { GuardNpc } from './npcs/GuardNpc';
 import { Npc } from './npcs/Npc';
+import { ContainerObject } from './objects/ContainerObject';
+import { DoorObject } from './objects/DoorObject';
+import { MechanismObject } from './objects/MechanismObject';
 
 describe('domain class foundation seams', () => {
   it('instantiates foundational classes and maps NPC dto to runtime class without runtime integration', () => {
@@ -75,5 +78,51 @@ describe('domain class foundation seams', () => {
         },
       },
     });
+  });
+
+  it('maps interactive object dto to the expected polymorphic world object class', () => {
+    const containerRuntime = mapInteractiveObjectDtoToRuntime({
+      id: 'obj-container',
+      displayName: 'Crate',
+      position: { x: 1, y: 1 },
+      objectType: 'supply-crate',
+      interactionType: 'inspect',
+      state: 'idle',
+      capabilities: {
+        containsItems: true,
+      },
+    });
+
+    const mechanismRuntime = mapInteractiveObjectDtoToRuntime({
+      id: 'obj-mechanism',
+      displayName: 'Mechanism',
+      position: { x: 2, y: 1 },
+      objectType: 'mechanism',
+      interactionType: 'use',
+      state: 'idle',
+    });
+
+    const doorRuntime = mapInteractiveObjectDtoToRuntime({
+      id: 'obj-door',
+      displayName: 'Service Door',
+      position: { x: 3, y: 1 },
+      objectType: 'service-door',
+      interactionType: 'use',
+      state: 'idle',
+    });
+
+    const inertRuntime = mapInteractiveObjectDtoToRuntime({
+      id: 'obj-inert',
+      displayName: 'Statue',
+      position: { x: 4, y: 1 },
+      objectType: 'decoration',
+      interactionType: 'inspect',
+      state: 'idle',
+    });
+
+    expect(containerRuntime).toBeInstanceOf(ContainerObject);
+    expect(mechanismRuntime).toBeInstanceOf(MechanismObject);
+    expect(doorRuntime).toBeInstanceOf(DoorObject);
+    expect(inertRuntime).toBeNull();
   });
 });

--- a/src/world/entities/dtoRuntimeSeams.ts
+++ b/src/world/entities/dtoRuntimeSeams.ts
@@ -1,11 +1,16 @@
-import type { GameEntity, Guard as GuardDto, Npc as NpcDto } from '../types';
+import type { GameEntity, Guard as GuardDto, InteractiveObject, Npc as NpcDto } from '../types';
 import { Entity } from './base/Entity';
 import { GuardNpc } from './npcs/GuardNpc';
 import { Npc } from './npcs/Npc';
+import { ContainerObject } from './objects/ContainerObject';
+import { DoorObject } from './objects/DoorObject';
+import { MechanismObject } from './objects/MechanismObject';
+import { WorldObject } from './objects/WorldObject';
 
 export type EntityDtoContract = GameEntity;
 export type NpcDtoContract = NpcDto;
 export type GuardDtoContract = GuardDto;
+export type InteractiveObjectDtoContract = InteractiveObject;
 
 export interface DtoToRuntimeAdapter<TDto, TRuntime> {
   fromDto(dto: TDto): TRuntime;
@@ -56,3 +61,25 @@ export const mapGuardDtoToRuntime = (dto: GuardDtoContract): GuardNpc =>
     instanceBehavior: dto.instanceBehavior,
     itemUseRules: dto.itemUseRules,
   });
+
+const isDoorLikeObjectType = (objectType: string): boolean => {
+  return objectType === 'door' || objectType.endsWith('-door') || objectType.includes('door');
+};
+
+export const mapInteractiveObjectDtoToRuntime = (
+  dto: InteractiveObjectDtoContract,
+): WorldObject | null => {
+  if (dto.capabilities?.containsItems) {
+    return new ContainerObject(dto);
+  }
+
+  if (dto.capabilities?.isActivatable || dto.objectType === 'mechanism') {
+    return new MechanismObject(dto);
+  }
+
+  if (isDoorLikeObjectType(dto.objectType)) {
+    return new DoorObject(dto);
+  }
+
+  return null;
+};

--- a/src/world/entities/objects/ContainerObject.ts
+++ b/src/world/entities/objects/ContainerObject.ts
@@ -1,0 +1,65 @@
+import type { InteractiveObject, InventoryItem } from '../../types';
+import { WorldObject, type WorldObjectInteractionRequest, type WorldObjectInteractionResult } from './WorldObject';
+
+export class ContainerObject extends WorldObject {
+  public constructor(interactiveObject: InteractiveObject) {
+    super({
+      id: interactiveObject.id,
+      position: interactiveObject.position,
+      displayName: interactiveObject.displayName,
+      spriteAssetPath: interactiveObject.spriteAssetPath,
+      spriteSet: interactiveObject.spriteSet,
+      traits: interactiveObject.traits,
+      facts: interactiveObject.facts,
+      objectType: interactiveObject.objectType,
+    });
+  }
+
+  public interact(request: WorldObjectInteractionRequest): WorldObjectInteractionResult {
+    const wasUsed = request.interactiveObject.state === 'used';
+    const pickupItem = request.interactiveObject.pickupItem;
+    const inventoryItems = request.worldState.player.inventory.items;
+    const inventoryAlreadyContainsObjectPickup = inventoryItems.some(
+      (item) => item.sourceObjectId === request.interactiveObject.id,
+    );
+    const canPickup = !wasUsed && pickupItem !== undefined && !inventoryAlreadyContainsObjectPickup;
+    const responseText = wasUsed
+      ? request.interactiveObject.usedMessage ?? `${request.interactiveObject.displayName} is already open.`
+      : request.interactiveObject.idleMessage ??
+        `You inspect ${request.interactiveObject.displayName}.`;
+
+    const updatedObject: InteractiveObject = {
+      ...request.interactiveObject,
+      state: 'used',
+    };
+
+    const nextInventoryItems: InventoryItem[] = canPickup
+      ? [
+          ...inventoryItems,
+          {
+            itemId: pickupItem.itemId,
+            displayName: pickupItem.displayName,
+            sourceObjectId: request.interactiveObject.id,
+            pickedUpAtTick: request.worldState.tick,
+          },
+        ]
+      : inventoryItems;
+
+    const updatedWorldState = {
+      ...request.worldState,
+      player: {
+        ...request.worldState.player,
+        inventory: {
+          items: nextInventoryItems,
+        },
+      },
+      interactiveObjects: this.replaceInteractiveObjectInWorld(request.worldState, updatedObject),
+      levelOutcome: this.resolveFirstUseOutcome(request.worldState, request.interactiveObject, wasUsed),
+    };
+
+    return {
+      responseText,
+      updatedWorldState,
+    };
+  }
+}

--- a/src/world/entities/objects/DoorObject.ts
+++ b/src/world/entities/objects/DoorObject.ts
@@ -1,0 +1,56 @@
+import type { InteractiveObject, WorldState } from '../../types';
+import { WorldObject, type WorldObjectInteractionRequest, type WorldObjectInteractionResult } from './WorldObject';
+
+const readDoorLikeOutcome = (
+  interactiveObject: InteractiveObject,
+): WorldState['levelOutcome'] => {
+  const factOutcome = interactiveObject.facts?.outcome;
+  if (factOutcome === 'safe') {
+    return 'win';
+  }
+  if (factOutcome === 'danger') {
+    return 'lose';
+  }
+  return null;
+};
+
+export class DoorObject extends WorldObject {
+  public constructor(interactiveObject: InteractiveObject) {
+    super({
+      id: interactiveObject.id,
+      position: interactiveObject.position,
+      displayName: interactiveObject.displayName,
+      spriteAssetPath: interactiveObject.spriteAssetPath,
+      spriteSet: interactiveObject.spriteSet,
+      traits: interactiveObject.traits,
+      facts: interactiveObject.facts,
+      objectType: interactiveObject.objectType,
+    });
+  }
+
+  public interact(request: WorldObjectInteractionRequest): WorldObjectInteractionResult {
+    const wasUsed = request.interactiveObject.state === 'used';
+    const responseText = wasUsed
+      ? request.interactiveObject.usedMessage ?? `${request.interactiveObject.displayName} is already open.`
+      : request.interactiveObject.idleMessage ?? `You open ${request.interactiveObject.displayName}.`;
+
+    const updatedObject: InteractiveObject = {
+      ...request.interactiveObject,
+      state: 'used',
+    };
+
+    const explicitOutcome = this.resolveFirstUseOutcome(request.worldState, request.interactiveObject, wasUsed);
+    const doorLikeOutcome = !wasUsed ? readDoorLikeOutcome(request.interactiveObject) : null;
+
+    const updatedWorldState = {
+      ...request.worldState,
+      interactiveObjects: this.replaceInteractiveObjectInWorld(request.worldState, updatedObject),
+      levelOutcome: explicitOutcome ?? doorLikeOutcome,
+    };
+
+    return {
+      responseText,
+      updatedWorldState,
+    };
+  }
+}

--- a/src/world/entities/objects/MechanismObject.ts
+++ b/src/world/entities/objects/MechanismObject.ts
@@ -1,0 +1,41 @@
+import type { InteractiveObject } from '../../types';
+import { WorldObject, type WorldObjectInteractionRequest, type WorldObjectInteractionResult } from './WorldObject';
+
+export class MechanismObject extends WorldObject {
+  public constructor(interactiveObject: InteractiveObject) {
+    super({
+      id: interactiveObject.id,
+      position: interactiveObject.position,
+      displayName: interactiveObject.displayName,
+      spriteAssetPath: interactiveObject.spriteAssetPath,
+      spriteSet: interactiveObject.spriteSet,
+      traits: interactiveObject.traits,
+      facts: interactiveObject.facts,
+      objectType: interactiveObject.objectType,
+    });
+  }
+
+  public interact(request: WorldObjectInteractionRequest): WorldObjectInteractionResult {
+    const wasUsed = request.interactiveObject.state === 'used';
+    const responseText = wasUsed
+      ? request.interactiveObject.usedMessage ?? `${request.interactiveObject.displayName} is already activated.`
+      : request.interactiveObject.usedMessage ??
+        `You activate the ${request.interactiveObject.displayName}.`;
+
+    const updatedObject: InteractiveObject = {
+      ...request.interactiveObject,
+      state: 'used',
+    };
+
+    const updatedWorldState = {
+      ...request.worldState,
+      interactiveObjects: this.replaceInteractiveObjectInWorld(request.worldState, updatedObject),
+      levelOutcome: this.resolveFirstUseOutcome(request.worldState, request.interactiveObject, wasUsed),
+    };
+
+    return {
+      responseText,
+      updatedWorldState,
+    };
+  }
+}

--- a/src/world/entities/objects/WorldObject.test.ts
+++ b/src/world/entities/objects/WorldObject.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import type { InteractiveObject, Player, WorldState } from '../../types';
+import { ContainerObject } from './ContainerObject';
+import { DoorObject } from './DoorObject';
+import { MechanismObject } from './MechanismObject';
+
+const player: Player = {
+  id: 'player-1',
+  displayName: 'Hero',
+  position: { x: 1, y: 1 },
+  inventory: { items: [] },
+};
+
+const createWorldState = (interactiveObject: InteractiveObject): WorldState => ({
+  tick: 5,
+  grid: { width: 10, height: 10, tileSize: 32 },
+  levelMetadata: {
+    name: 'Object Test',
+    premise: 'Polymorphic object interaction tests.',
+    goal: 'Validate deterministic object interactions.',
+  },
+  levelObjective: 'Validate interactions',
+  player,
+  npcs: [],
+  guards: [],
+  doors: [],
+  interactiveObjects: [interactiveObject],
+  actorConversationHistoryByActorId: {},
+  levelOutcome: null,
+});
+
+describe('WorldObject subclasses', () => {
+  it('ContainerObject interact reveals pickup and updates object state', () => {
+    const interactiveObject: InteractiveObject = {
+      id: 'container-1',
+      displayName: 'Supply Crate',
+      position: { x: 2, y: 2 },
+      objectType: 'supply-crate',
+      interactionType: 'inspect',
+      state: 'idle',
+      pickupItem: {
+        itemId: 'key-1',
+        displayName: 'Utility Key',
+      },
+      idleMessage: 'You open the crate.',
+      capabilities: {
+        containsItems: true,
+      },
+    };
+
+    const result = new ContainerObject(interactiveObject).interact({
+      interactiveObject,
+      player,
+      worldState: createWorldState(interactiveObject),
+    });
+
+    expect(result.responseText).toBe('You open the crate.');
+    expect(result.updatedWorldState.player.inventory.items).toEqual([
+      {
+        itemId: 'key-1',
+        displayName: 'Utility Key',
+        sourceObjectId: 'container-1',
+        pickedUpAtTick: 5,
+      },
+    ]);
+    expect(result.updatedWorldState.interactiveObjects[0].state).toBe('used');
+  });
+
+  it('MechanismObject interact marks object used and applies firstUseOutcome once', () => {
+    const interactiveObject: InteractiveObject = {
+      id: 'mechanism-1',
+      displayName: 'Ancient Lever',
+      position: { x: 3, y: 2 },
+      objectType: 'mechanism',
+      interactionType: 'use',
+      state: 'idle',
+      usedMessage: 'You pull the lever.',
+      firstUseOutcome: 'win',
+      capabilities: {
+        isActivatable: true,
+      },
+    };
+
+    const result = new MechanismObject(interactiveObject).interact({
+      interactiveObject,
+      player,
+      worldState: createWorldState(interactiveObject),
+    });
+
+    expect(result.responseText).toBe('You pull the lever.');
+    expect(result.updatedWorldState.interactiveObjects[0].state).toBe('used');
+    expect(result.updatedWorldState.levelOutcome).toBe('win');
+  });
+
+  it('DoorObject interact derives outcome from door-like facts when explicit outcome is absent', () => {
+    const interactiveObject: InteractiveObject = {
+      id: 'door-object-1',
+      displayName: 'Hidden Door',
+      position: { x: 4, y: 2 },
+      objectType: 'hidden-door',
+      interactionType: 'use',
+      state: 'idle',
+      facts: {
+        outcome: 'danger',
+      },
+    };
+
+    const result = new DoorObject(interactiveObject).interact({
+      interactiveObject,
+      player,
+      worldState: createWorldState(interactiveObject),
+    });
+
+    expect(result.responseText).toBe('You open Hidden Door.');
+    expect(result.updatedWorldState.interactiveObjects[0].state).toBe('used');
+    expect(result.updatedWorldState.levelOutcome).toBe('lose');
+  });
+});

--- a/src/world/entities/objects/WorldObject.ts
+++ b/src/world/entities/objects/WorldObject.ts
@@ -1,7 +1,19 @@
 import { Entity, type EntityInit } from '../base/Entity';
+import type { InteractiveObject, Player, WorldState } from '../../types';
 
 export interface WorldObjectInit extends EntityInit {
   objectType: string;
+}
+
+export interface WorldObjectInteractionRequest {
+  interactiveObject: InteractiveObject;
+  player: Player;
+  worldState: WorldState;
+}
+
+export interface WorldObjectInteractionResult {
+  responseText: string;
+  updatedWorldState: WorldState;
 }
 
 export abstract class WorldObject extends Entity {
@@ -10,5 +22,26 @@ export abstract class WorldObject extends Entity {
   protected constructor(init: WorldObjectInit) {
     super(init);
     this.objectType = init.objectType;
+  }
+
+  public abstract interact(
+    request: WorldObjectInteractionRequest,
+  ): WorldObjectInteractionResult;
+
+  protected replaceInteractiveObjectInWorld(
+    worldState: WorldState,
+    updatedObject: InteractiveObject,
+  ): InteractiveObject[] {
+    return worldState.interactiveObjects.map((interactiveObject) =>
+      interactiveObject.id === updatedObject.id ? updatedObject : interactiveObject,
+    );
+  }
+
+  protected resolveFirstUseOutcome(
+    worldState: WorldState,
+    interactiveObject: InteractiveObject,
+    wasUsed: boolean,
+  ): WorldState['levelOutcome'] {
+    return worldState.levelOutcome ?? (!wasUsed ? (interactiveObject.firstUseOutcome ?? null) : null);
   }
 }


### PR DESCRIPTION
## Summary
- introduce a polymorphic object hierarchy with abstract `interact(...)` on `WorldObject`
- add concrete object subclasses for container, mechanism, and door-like interactive objects
- route object interaction handling through DTO-to-runtime mapping and polymorphic dispatch
- preserve existing door entity interaction flow unchanged (`doorInteraction.ts`)

## Validation
- `npm run test`
- `npm run build`
- `npm run lint`

Closes #148