### PR TITLE
#149 item domain model transfer semantics

### DIFF
--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -91,8 +91,10 @@ The runtime bridge and tests use the shared actor-neutral helper in `src/interac
 
 Current behavior:
 - Reads `worldState.player.inventory.selectedItem`.
+- Verifies selected slot metadata against the actual inventory DTO using the runtime `Item` model before applying rules.
 - Emits one `ItemUseAttemptResultEvent` per `useSelectedItem` command, preserving the command index from the tick command list.
 - Returns `no-selection` when no selected item exists.
+- Returns `no-selection` when selected metadata points to a missing slot or mismatched `itemId`.
 - Returns `no-target` when an item is selected but no adjacent target exists or the adjacent target doesn't accept item-use.
 - Emits target info (door/guard/npc/interactiveObject) for debugging and event logging.
 
@@ -210,6 +212,7 @@ Pickup behavior is deterministic and code-owned:
 - if an interactive object has `pickupItem` and is interacted with in `idle` state, the item is added to `player.inventory.items`
 - pickup entries include `sourceObjectId` and `pickedUpAtTick` to keep state auditable and replay-friendly
 - repeated interactions on the same object instance cannot duplicate pickup entries
+- pickup, give, and take transfers use the shared runtime `Item` contract and convert back to serializable `InventoryItem` DTOs at the world-state boundary
 - no LLM call participates in pickup rule enforcement
 
 ## LLM Boundary

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -103,8 +103,25 @@ Serializable input contract consumed by `WorldObject.interact(...)` implementati
 Deterministic output contract returned by `WorldObject.interact(...)` implementations.
 
 ### ItemInit
-Extends `EntityInit`:
-- `itemType: string`
+- `itemId: string`
+- `displayName: string`
+- `sourceObjectId: string`
+- `pickedUpAtTick: number`
+
+Runtime constructor contract for the item domain model used in inventory and transfer flows.
+
+### PickupItemDescriptor
+- `sourceObjectId: string`
+- `pickedUpAtTick: number`
+- `pickupItem: { itemId: string; displayName: string }`
+
+Deterministic input contract for converting world pickup descriptors into `Item` instances.
+
+### ItemTransferResult
+- `item: Item | null`
+- `remainingItems: InventoryItem[]`
+
+Deterministic transfer result contract used for NPC/player give/take flows.
 
 ### EnvironmentInit
 Extends `EntityInit`:
@@ -188,6 +205,8 @@ Optional trigger hooks for deterministic NPC state updates.
 - `displayName: string`
 - `sourceObjectId: string`
 - `pickedUpAtTick: number`
+
+Serializable DTO shape. Runtime item logic is modeled by `Item` in `src/world/entities/items/Item.ts`, with explicit conversion helpers (`fromInventoryItem`, `fromPickup`, `toInventoryItem`) to keep JSON boundaries intact.
 
 ### PlayerInventory
 - `items: InventoryItem[]`

--- a/src/interaction/itemUse.test.ts
+++ b/src/interaction/itemUse.test.ts
@@ -68,6 +68,29 @@ describe('itemUseResolver', () => {
     expect(event.target).toBeNull();
   });
 
+  it('returns no-selection when selected slot metadata does not match inventory item id', () => {
+    const worldState = createTestWorldState({
+      player: {
+        id: 'player-1',
+        displayName: 'Hero',
+        position: { x: 5, y: 5 },
+        inventory: {
+          items: [{ itemId: 'gift-token', displayName: 'Gift Token', sourceObjectId: 'obj-1', pickedUpAtTick: 10 }],
+          selectedItem: { slotIndex: 0, itemId: 'wrong-item-id' },
+        },
+      },
+    });
+
+    const event = resolver.resolveItemUseAttempt({
+      worldState,
+      commandIndex: 1,
+    });
+
+    expect(event.result).toBe('no-selection');
+    expect(event.selectedItem).toBeNull();
+    expect(event.target).toBeNull();
+  });
+
   it('returns no-target with door target when adjacent door has no requiredItemId', () => {
     const worldState = createTestWorldState({
       player: {

--- a/src/interaction/itemUse.ts
+++ b/src/interaction/itemUse.ts
@@ -1,4 +1,5 @@
 import type { ItemUseAttemptResultEvent, WorldState } from '../world/types';
+import { Item } from '../world/entities/items/Item';
 import { resolveAdjacentTarget } from './adjacencyResolver';
 
 export interface ItemUseResolutionInput {
@@ -24,6 +25,28 @@ export const createDefaultItemUseResolver = (): ItemUseResolver => {
 
       // No item selected: fail early
       if (!selectedItem) {
+        return {
+          tick: worldState.tick,
+          commandIndex,
+          selectedItem: null,
+          result: 'no-selection',
+          target: null,
+        };
+      }
+
+      const selectedInventoryDto = worldState.player.inventory.items[selectedItem.slotIndex];
+      if (!selectedInventoryDto) {
+        return {
+          tick: worldState.tick,
+          commandIndex,
+          selectedItem: null,
+          result: 'no-selection',
+          target: null,
+        };
+      }
+
+      const selectedInventoryItem = Item.fromInventoryItem(selectedInventoryDto);
+      if (!selectedInventoryItem.matchesItemId(selectedItem.itemId)) {
         return {
           tick: worldState.tick,
           commandIndex,
@@ -66,7 +89,7 @@ export const createDefaultItemUseResolver = (): ItemUseResolver => {
         }
 
         // Door requires an item. Check if selected item matches.
-        if (selectedItem.itemId === door.requiredItemId) {
+        if (selectedInventoryItem.matchesItemId(door.requiredItemId)) {
           // Correct key: unlock the door
           return {
             tick: worldState.tick,
@@ -97,7 +120,7 @@ export const createDefaultItemUseResolver = (): ItemUseResolver => {
       // Handle guard item-use (rules)
       if (adjacentTarget.kind === 'guard') {
         const guard = adjacentTarget.target;
-        const rule = guard.itemUseRules?.[selectedItem.itemId];
+        const rule = guard.itemUseRules?.[selectedInventoryItem.itemId];
 
         // No rule defined for this item on this guard
         if (!rule) {
@@ -148,7 +171,7 @@ export const createDefaultItemUseResolver = (): ItemUseResolver => {
       // Handle interactive object item-use (rules)
       if (adjacentTarget.kind === 'interactiveObject') {
         const obj = adjacentTarget.target;
-        const rule = obj.itemUseRules?.[selectedItem.itemId];
+        const rule = obj.itemUseRules?.[selectedInventoryItem.itemId];
 
         // No rule defined for this item on this object
         if (!rule) {

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -373,4 +373,73 @@ describe('createNpcInteractionService', () => {
       },
     ]);
   });
+
+  it('produces deterministic give/take transfer world state for identical input state and action', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({ text: 'We can trade.', outcome: { giveItem: 'npc-token', takeItem: 'player-token' } }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      inventory: [
+        {
+          itemId: 'npc-token',
+          displayName: 'NPC Token',
+          sourceObjectId: 'npc-1',
+          pickedUpAtTick: 0,
+        },
+      ],
+    };
+    const player = {
+      ...worldState.player,
+      inventory: {
+        ...worldState.player.inventory,
+        items: [
+          {
+            itemId: 'player-token',
+            displayName: 'Player Token',
+            sourceObjectId: 'object-2',
+            pickedUpAtTick: 1,
+          },
+        ],
+      },
+    };
+    const sharedInputState = {
+      ...worldState,
+      player,
+      npcs: [npc],
+    };
+
+    const first = await service.handleNpcInteraction({
+      npc,
+      player,
+      worldState: sharedInputState,
+      playerMessage: 'Trade?',
+    });
+    const second = await service.handleNpcInteraction({
+      npc,
+      player,
+      worldState: sharedInputState,
+      playerMessage: 'Trade?',
+    });
+
+    expect(first.updatedWorldState).toEqual(second.updatedWorldState);
+    expect(first.updatedWorldState.player.inventory.items).toEqual([
+      {
+        itemId: 'npc-token',
+        displayName: 'NPC Token',
+        sourceObjectId: 'npc-1',
+        pickedUpAtTick: 0,
+      },
+    ]);
+    expect(first.updatedWorldState.npcs[0].inventory).toEqual([
+      {
+        itemId: 'player-token',
+        displayName: 'Player Token',
+        sourceObjectId: 'object-2',
+        pickedUpAtTick: 1,
+      },
+    ]);
+  });
 });

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -1,4 +1,5 @@
 import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
+import { Item } from '../world/entities/items/Item';
 import type { ConversationMessage, Npc, Player, WorldState } from '../world/types';
 import { buildNpcPromptContext } from './npcPromptContext';
 
@@ -60,10 +61,10 @@ const applyInventoryOutcome = (
   let playerInventoryChanged = false;
 
   if (typeof outcome.giveItem === 'string') {
-    const npcItemIndex = npcItems.findIndex((item) => item.itemId === outcome.giveItem);
-    if (npcItemIndex >= 0) {
-      const [transferredItem] = npcItems.splice(npcItemIndex, 1);
-      playerItems.push(transferredItem);
+    const transferResult = Item.takeFirstByItemId(npcItems, outcome.giveItem);
+    npcItems.splice(0, npcItems.length, ...transferResult.remainingItems);
+    if (transferResult.item) {
+      playerItems.push(transferResult.item.toInventoryItem());
       npcInventoryChanged = true;
       playerInventoryChanged = true;
     }
@@ -71,10 +72,11 @@ const applyInventoryOutcome = (
 
   if (typeof outcome.takeItem === 'string') {
     const playerItemIndex = playerItems.findIndex((item) => item.itemId === outcome.takeItem);
-    if (playerItemIndex >= 0) {
-      const [transferredItem] = playerItems.splice(playerItemIndex, 1);
+    const transferResult = Item.takeFirstByItemId(playerItems, outcome.takeItem);
+    playerItems.splice(0, playerItems.length, ...transferResult.remainingItems);
+    if (transferResult.item) {
       selectedItem = reindexSelectedSlotAfterRemoval(selectedItem, playerItemIndex) ?? null;
-      npcItems.push(transferredItem);
+      npcItems.push(transferResult.item.toInventoryItem());
       npcInventoryChanged = true;
       playerInventoryChanged = true;
     }

--- a/src/interaction/objectInteraction.test.ts
+++ b/src/interaction/objectInteraction.test.ts
@@ -175,6 +175,60 @@ describe('handleObjectInteraction', () => {
       });
     });
 
+    it('preserves selected inventory slot while adding a picked item', () => {
+      const container = makeContainerObject('container-selected-slot', 'idle', {
+        pickupItem: {
+          itemId: 'new-token',
+          displayName: 'New Token',
+        },
+      });
+      const worldState = {
+        ...createWorldState(container),
+        player: {
+          ...player,
+          inventory: {
+            items: [
+              {
+                itemId: 'existing-token',
+                displayName: 'Existing Token',
+                sourceObjectId: 'stash-1',
+                pickedUpAtTick: 0,
+              },
+            ],
+            selectedItem: {
+              slotIndex: 0,
+              itemId: 'existing-token',
+            },
+          },
+        },
+      };
+
+      const result = handleObjectInteraction({
+        interactiveObject: container,
+        player: worldState.player,
+        worldState,
+      });
+
+      expect(result.updatedWorldState.player.inventory.selectedItem).toEqual({
+        slotIndex: 0,
+        itemId: 'existing-token',
+      });
+      expect(result.updatedWorldState.player.inventory.items).toEqual([
+        {
+          itemId: 'existing-token',
+          displayName: 'Existing Token',
+          sourceObjectId: 'stash-1',
+          pickedUpAtTick: 0,
+        },
+        {
+          itemId: 'new-token',
+          displayName: 'New Token',
+          sourceObjectId: 'container-selected-slot',
+          pickedUpAtTick: 0,
+        },
+      ]);
+    });
+
     it('keeps per-instance outcomes distinct between different containers', () => {
       const winningContainer = makeContainerObject('container-win', 'idle', {
         idleMessage: 'You find the evacuation signal flare.',

--- a/src/world/entities/dtoRuntimeSeams.test.ts
+++ b/src/world/entities/dtoRuntimeSeams.test.ts
@@ -11,10 +11,10 @@ import { MechanismObject } from './objects/MechanismObject';
 describe('domain class foundation seams', () => {
   it('instantiates foundational classes and maps NPC dto to runtime class without runtime integration', () => {
     const item = new Item({
-      id: 'item-1',
-      position: { x: 1, y: 2 },
+      itemId: 'item-1',
       displayName: 'Bronze Key',
-      itemType: 'key',
+      sourceObjectId: 'crate-1',
+      pickedUpAtTick: 3,
     });
     const environment = new Environment({
       id: 'env-1',
@@ -32,7 +32,12 @@ describe('domain class foundation seams', () => {
       patrol: { path: [{ x: 5, y: 6 }, { x: 6, y: 6 }] },
     });
 
-    expect(item.itemType).toBe('key');
+    expect(item.toInventoryItem()).toEqual({
+      itemId: 'item-1',
+      displayName: 'Bronze Key',
+      sourceObjectId: 'crate-1',
+      pickedUpAtTick: 3,
+    });
     expect(environment.isBlocking).toBe(true);
     expect(npc).toBeInstanceOf(Npc);
     expect(npc.npcType).toBe('archive_keeper');

--- a/src/world/entities/items/Item.test.ts
+++ b/src/world/entities/items/Item.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { InventoryItem } from '../../types';
+import { Item } from './Item';
+
+describe('Item', () => {
+  it('creates an inventory item from pickup descriptor deterministically', () => {
+    const item = Item.fromPickup({
+      sourceObjectId: 'crate-1',
+      pickedUpAtTick: 12,
+      pickupItem: {
+        itemId: 'brass-key',
+        displayName: 'Brass Key',
+      },
+    });
+
+    expect(item.toInventoryItem()).toEqual({
+      itemId: 'brass-key',
+      displayName: 'Brass Key',
+      sourceObjectId: 'crate-1',
+      pickedUpAtTick: 12,
+    });
+  });
+
+  it('takes first matching item by itemId without mutating input array', () => {
+    const inventory: InventoryItem[] = [
+      {
+        itemId: 'apple',
+        displayName: 'Apple',
+        sourceObjectId: 'crate-a',
+        pickedUpAtTick: 1,
+      },
+      {
+        itemId: 'token',
+        displayName: 'Token',
+        sourceObjectId: 'crate-b',
+        pickedUpAtTick: 2,
+      },
+      {
+        itemId: 'token',
+        displayName: 'Token (Spare)',
+        sourceObjectId: 'crate-c',
+        pickedUpAtTick: 3,
+      },
+    ];
+
+    const result = Item.takeFirstByItemId(inventory, 'token');
+
+    expect(result.item?.toInventoryItem()).toEqual({
+      itemId: 'token',
+      displayName: 'Token',
+      sourceObjectId: 'crate-b',
+      pickedUpAtTick: 2,
+    });
+    expect(result.remainingItems).toEqual([
+      {
+        itemId: 'apple',
+        displayName: 'Apple',
+        sourceObjectId: 'crate-a',
+        pickedUpAtTick: 1,
+      },
+      {
+        itemId: 'token',
+        displayName: 'Token (Spare)',
+        sourceObjectId: 'crate-c',
+        pickedUpAtTick: 3,
+      },
+    ]);
+    expect(inventory).toHaveLength(3);
+  });
+
+  it('returns null transfer result when itemId is absent', () => {
+    const inventory: InventoryItem[] = [
+      {
+        itemId: 'apple',
+        displayName: 'Apple',
+        sourceObjectId: 'crate-a',
+        pickedUpAtTick: 1,
+      },
+    ];
+
+    const result = Item.takeFirstByItemId(inventory, 'token');
+
+    expect(result.item).toBeNull();
+    expect(result.remainingItems).toEqual(inventory);
+  });
+});

--- a/src/world/entities/items/Item.ts
+++ b/src/world/entities/items/Item.ts
@@ -1,14 +1,82 @@
-import { Entity, type EntityInit } from '../base/Entity';
+import type { InventoryItem, InteractiveObject } from '../../types';
 
-export interface ItemInit extends EntityInit {
-  itemType: string;
+export interface ItemInit {
+  itemId: string;
+  displayName: string;
+  sourceObjectId: string;
+  pickedUpAtTick: number;
 }
 
-export class Item extends Entity {
-  public itemType: string;
+export interface PickupItemDescriptor {
+  sourceObjectId: string;
+  pickedUpAtTick: number;
+  pickupItem: NonNullable<InteractiveObject['pickupItem']>;
+}
+
+export interface ItemTransferResult {
+  item: Item | null;
+  remainingItems: InventoryItem[];
+}
+
+export class Item {
+  public readonly itemId: string;
+  public readonly displayName: string;
+  public readonly sourceObjectId: string;
+  public readonly pickedUpAtTick: number;
 
   public constructor(init: ItemInit) {
-    super(init);
-    this.itemType = init.itemType;
+    this.itemId = init.itemId;
+    this.displayName = init.displayName;
+    this.sourceObjectId = init.sourceObjectId;
+    this.pickedUpAtTick = init.pickedUpAtTick;
+  }
+
+  public static fromInventoryItem(item: InventoryItem): Item {
+    return new Item({
+      itemId: item.itemId,
+      displayName: item.displayName,
+      sourceObjectId: item.sourceObjectId,
+      pickedUpAtTick: item.pickedUpAtTick,
+    });
+  }
+
+  public static fromPickup(descriptor: PickupItemDescriptor): Item {
+    return new Item({
+      itemId: descriptor.pickupItem.itemId,
+      displayName: descriptor.pickupItem.displayName,
+      sourceObjectId: descriptor.sourceObjectId,
+      pickedUpAtTick: descriptor.pickedUpAtTick,
+    });
+  }
+
+  public static takeFirstByItemId(inventoryItems: InventoryItem[], itemId: string): ItemTransferResult {
+    const index = inventoryItems.findIndex((item) => item.itemId === itemId);
+    if (index < 0) {
+      return {
+        item: null,
+        remainingItems: [...inventoryItems],
+      };
+    }
+
+    const remainingItems = [...inventoryItems];
+    const [transferredItem] = remainingItems.splice(index, 1);
+
+    return {
+      item: Item.fromInventoryItem(transferredItem),
+      remainingItems,
+    };
+  }
+
+  public matchesItemId(itemId: string): boolean {
+    return this.itemId === itemId;
+  }
+
+  public toInventoryItem(): InventoryItem {
+    return {
+      itemId: this.itemId,
+      displayName: this.displayName,
+      sourceObjectId: this.sourceObjectId,
+      pickedUpAtTick: this.pickedUpAtTick,
+    };
   }
 }

--- a/src/world/entities/objects/ContainerObject.ts
+++ b/src/world/entities/objects/ContainerObject.ts
@@ -1,4 +1,5 @@
 import type { InteractiveObject, InventoryItem } from '../../types';
+import { Item } from '../items/Item';
 import { WorldObject, type WorldObjectInteractionRequest, type WorldObjectInteractionResult } from './WorldObject';
 
 export class ContainerObject extends WorldObject {
@@ -36,12 +37,11 @@ export class ContainerObject extends WorldObject {
     const nextInventoryItems: InventoryItem[] = canPickup
       ? [
           ...inventoryItems,
-          {
-            itemId: pickupItem.itemId,
-            displayName: pickupItem.displayName,
+          Item.fromPickup({
+            pickupItem,
             sourceObjectId: request.interactiveObject.id,
             pickedUpAtTick: request.worldState.tick,
-          },
+          }).toInventoryItem(),
         ]
       : inventoryItems;
 
@@ -50,6 +50,7 @@ export class ContainerObject extends WorldObject {
       player: {
         ...request.worldState.player,
         inventory: {
+          ...request.worldState.player.inventory,
           items: nextInventoryItems,
         },
       },


### PR DESCRIPTION
## Summary
- introduce a runtime `Item` domain model with deterministic conversion and transfer helpers
- route active pickup/use/give/take paths through shared item semantics while preserving JSON-serializable world state boundaries
- add focused regression tests for pickup, use-selected-item validation, and deterministic NPC give/take transfer behavior
- update interaction and type docs for the item contract

## Validation
- `npm run test`
- `npm run build`
- `npm run lint`

## Closes #149
