### PR TITLE
#151 Class-Based World Test and Documentation Realignment

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,8 +6,13 @@ Guard Game enforces strict layer separation to support deterministic world updat
 
 ```
 /src
-  /world               - Deterministic world model (state, command application, ticks)
-/world/entities      - Domain class foundation and DTO-to-runtime seam mappings
+       /world               - Deterministic world model (state, command application, ticks)
+              /entities          - Runtime domain classes + DTO-to-runtime seam mappings
+                     /base            - Entity/Actor base classes
+                     /npcs            - Npc/GuardNpc runtime classes
+                     /objects         - WorldObject polymorphic hierarchy
+                     /items           - Item lifecycle helpers
+                     /environment     - Environment runtime class
   /render              - PixiJS rendering port plus DOM overlays for viewport pause, chat, and outcomes
   /interaction         - Interaction dispatch + result routing across target kinds
   /input               - Input command buffering and keyboard mapping
@@ -27,6 +32,11 @@ All game state changes are deterministic and command-driven. There are no random
 All world state must serialize to JSON. This enables LLM systems to reason about game state, and allows debugging via inspection in the browser console.
 
 **Implication:** Avoid circular references, functions, or non-serializable objects in `WorldState` and related types.
+
+### DTO/Runtime Boundary
+Level JSON ingress/egress remains DTO-shaped (`src/world/types.ts`). During deserialization, DTOs are mapped into runtime classes via `src/world/entities/dtoRuntimeSeams.ts`.
+
+**Implication:** Runtime classes can enforce structure and polymorphism, while serialized `WorldState` keeps stable JSON contracts for tests, debugging, and LLM context.
 
 ### Layer Isolation
 - Game logic lives in the world model only.

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -249,7 +249,7 @@ Serializable DTO shape. Runtime item logic is modeled by `Item` in `src/world/en
 References one selected inventory slot by index and item id. Invalid slot selection clears this field to `null`.
 
 ### ItemUseAttemptResult
-`'no-selection' | 'no-target' | 'blocked' | 'success'`
+`'no-selection' | 'no-target' | 'blocked' | 'success' | 'no-rule'`
 
 ### ItemUseRule
 - `allowed: boolean` - Whether use of the item is permitted on this entity
@@ -296,7 +296,6 @@ Extends `GameEntity`:
 - `doorState: 'open' | 'closed' | 'locked'`
 - `outcome?: 'safe' | 'danger'`
 - `requiredItemId?: string` - Item id required to unlock this door via item-use. If set, door must be interacted with using this item before traversal is allowed.
-- `consumeOnUse?: boolean` - Whether the required item should be consumed when used to unlock (default: false)
 - `isUnlocked?: boolean` - Whether this door has been unlocked via item-use. Once set to true, door allows traversal regardless of doorState. Persists through world state serialization (default: false).
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`
@@ -335,6 +334,27 @@ Environment entities are world-level spatial entities only. They can block movem
 - `environments?: Array<{ id: string; displayName: string; x: number; y: number; isBlocking: boolean }>`
 
 Optional level schema section for environment entries. During deserialization, level coordinates (`x`, `y`) are mapped to runtime `position`.
+
+## Subclass Extension Guidelines
+
+### Adding a New NPC Subclass
+1. Keep serializable data in `src/world/types.ts` (`LevelNpcDto` / `Npc`) and avoid runtime-only fields at DTO boundaries.
+2. Implement subclass behavior in `src/world/entities/npcs`.
+3. Add deterministic mapping in `mapNpcDtoToRuntime` (or adjacent seam helper).
+4. Preserve JSON parity (`JSON.parse(JSON.stringify(instance))`) for world snapshots.
+5. Add tests for class instantiation and deterministic behavior impact.
+
+### Adding a New Interactive Object Subclass
+1. Keep object DTO shape serializable in `LevelInteractiveObjectDto` / `InteractiveObject`.
+2. Implement subclass in `src/world/entities/objects`.
+3. Route deterministic classification in `mapInteractiveObjectDtoToRuntime` and level-load mapping in `mapLevelInteractiveObjectDtoToRuntime`.
+4. Ensure object interaction outcomes are deterministic and local to world/interaction layers.
+5. Add tests for polymorphic mapping, state transitions, and serialized shape parity.
+
+### Adding Environment Variants
+1. Keep runtime variants under `src/world/entities/environment` while preserving serializable `Environment` shape.
+2. Map DTOs in `mapEnvironmentDtoToRuntime`.
+3. Verify blocking behavior through `canMovePlayerTo` / `getBlockingOccupants` tests.
 
 ### WorldGrid
 - `width: number`

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -80,6 +80,17 @@ The world layer now includes a domain-class foundation in `src/world/entities/`:
 
 These classes establish a typed DTO-to-runtime boundary for future incremental migration away from direct object-literal construction.
 
+### DTO vs Runtime Class Boundary
+
+- **DTO boundary:** `LevelData` and nested `Level*Dto` shapes in `src/world/types.ts` define file/network JSON contracts.
+- **Runtime boundary:** `src/world/entities/*` classes provide constructor guarantees, polymorphic behavior hooks, and explicit conversion helpers.
+- **Seam boundary:** `src/world/entities/dtoRuntimeSeams.ts` is the only place that should map DTO shapes into runtime classes.
+
+Boundary invariants:
+- Validation (`validateLevelData`) remains DTO-only.
+- Deserialization (`deserializeLevel`) performs DTO-to-runtime mapping, then spatial validation.
+- Runtime class instances must remain enumerable/serializable so `JSON.stringify(worldState)` stays stable.
+
 Determinism/serialization contract remains unchanged:
 - `WorldState` remains JSON-serializable data
 - command application and interaction outcomes remain code-owned and deterministic
@@ -255,6 +266,26 @@ Environment fields deserialize directly:
 - `isBlocking`
 
 This enables shared behavior per object type while preserving instance-specific text, outcomes, and asset metadata.
+
+## Subclass Extension Guidelines
+
+When adding a new world subclass, keep changes localized and deterministic:
+
+1. Add/extend DTO shape in `src/world/types.ts` only if new serializable data is required.
+2. Implement runtime subclass under `src/world/entities/npcs` or `src/world/entities/objects`.
+3. Wire DTO-to-runtime mapping in `src/world/entities/dtoRuntimeSeams.ts`.
+4. Keep deterministic behavior in world/interaction layers; render only consumes resulting state.
+5. Add/adjust tests for seam mapping, serialized runtime shape parity, and deterministic behavior.
+
+NPC-specific checklist:
+- Ensure `npcType` mapping remains deterministic.
+- Keep `dialogueContextKey` derivation stable for prompt routing.
+- Preserve optional instance fields (`instanceKnowledge`, `instanceBehavior`) as serializable strings.
+
+Object-specific checklist:
+- Map object classification deterministically (capabilities/objectType to subclass).
+- Keep state transitions (`idle`/`used`) and item transfer behavior deterministic.
+- Ensure first-use outcomes and item-use rules remain data-driven and LLM-independent.
 
 ## Shipped Level Demonstrations
 

--- a/src/world/entities/classModelRealignment.test.ts
+++ b/src/world/entities/classModelRealignment.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import { canMovePlayerTo } from '../spatialRules';
+import { createInitialWorldState } from '../state';
+import { Item } from './items/Item';
+import {
+  mapEnvironmentDtoToRuntime,
+  mapGuardDtoToRuntime,
+  mapInteractiveObjectDtoToRuntime,
+  mapInventoryItemDtoToRuntime,
+  mapNpcDtoToRuntime,
+} from './dtoRuntimeSeams';
+import { Environment } from './environment/Environment';
+import { GuardNpc } from './npcs/GuardNpc';
+import { Npc } from './npcs/Npc';
+import { ContainerObject } from './objects/ContainerObject';
+import { DoorObject } from './objects/DoorObject';
+import { InertObject } from './objects/InertObject';
+import { MechanismObject } from './objects/MechanismObject';
+
+describe('class-based world realignment', () => {
+  it('maps DTOs to runtime class instances with stable JSON shape', () => {
+    const npc = mapNpcDtoToRuntime({
+      id: 'npc-1',
+      displayName: 'Archivist',
+      x: 2,
+      y: 3,
+      npcType: 'archive_keeper',
+    });
+    const guard = mapGuardDtoToRuntime({
+      id: 'guard-1',
+      displayName: 'Gate Guard',
+      x: 4,
+      y: 3,
+      guardState: 'idle',
+    });
+    const environment = mapEnvironmentDtoToRuntime({
+      id: 'env-1',
+      displayName: 'Stone Wall',
+      x: 5,
+      y: 3,
+      isBlocking: true,
+    });
+
+    expect(npc).toBeInstanceOf(Npc);
+    expect(guard).toBeInstanceOf(GuardNpc);
+    expect(environment).toBeInstanceOf(Environment);
+    expect(JSON.parse(JSON.stringify(npc))).toMatchObject({
+      id: 'npc-1',
+      position: { x: 2, y: 3 },
+      npcType: 'archive_keeper',
+      dialogueContextKey: 'npc_archive_keeper',
+    });
+  });
+
+  it('keeps polymorphic interactive-object mapping deterministic', () => {
+    const container = mapInteractiveObjectDtoToRuntime({
+      id: 'obj-container',
+      displayName: 'Crate',
+      position: { x: 1, y: 1 },
+      objectType: 'supply-crate',
+      interactionType: 'inspect',
+      state: 'idle',
+      capabilities: { containsItems: true },
+    });
+    const mechanism = mapInteractiveObjectDtoToRuntime({
+      id: 'obj-mechanism',
+      displayName: 'Mechanism',
+      position: { x: 2, y: 1 },
+      objectType: 'mechanism',
+      interactionType: 'use',
+      state: 'idle',
+    });
+    const door = mapInteractiveObjectDtoToRuntime({
+      id: 'obj-door',
+      displayName: 'Service Door',
+      position: { x: 3, y: 1 },
+      objectType: 'service-door',
+      interactionType: 'use',
+      state: 'idle',
+    });
+    const inert = mapInteractiveObjectDtoToRuntime({
+      id: 'obj-inert',
+      displayName: 'Statue',
+      position: { x: 4, y: 1 },
+      objectType: 'decoration',
+      interactionType: 'inspect',
+      state: 'idle',
+    });
+
+    expect(container).toBeInstanceOf(ContainerObject);
+    expect(mechanism).toBeInstanceOf(MechanismObject);
+    expect(door).toBeInstanceOf(DoorObject);
+    expect(inert).toBeNull();
+
+    const storedInert = new InertObject({
+      id: 'obj-inert',
+      displayName: 'Statue',
+      position: { x: 4, y: 1 },
+      objectType: 'decoration',
+      interactionType: 'inspect',
+      state: 'idle',
+    });
+    expect(JSON.parse(JSON.stringify(storedInert))).toEqual({
+      id: 'obj-inert',
+      displayName: 'Statue',
+      position: { x: 4, y: 1 },
+      objectType: 'decoration',
+      interactionType: 'inspect',
+      state: 'idle',
+    });
+  });
+
+  it('preserves deterministic item lifecycle conversions and transfer ordering', () => {
+    const mappedItem = mapInventoryItemDtoToRuntime({
+      itemId: 'token',
+      displayName: 'Token',
+      sourceObjectId: 'crate-1',
+      pickedUpAtTick: 7,
+    });
+
+    expect(mappedItem).toBeInstanceOf(Item);
+    expect(mappedItem.toInventoryItem()).toEqual({
+      itemId: 'token',
+      displayName: 'Token',
+      sourceObjectId: 'crate-1',
+      pickedUpAtTick: 7,
+    });
+
+    const transfer = Item.takeFirstByItemId(
+      [
+        { itemId: 'apple', displayName: 'Apple', sourceObjectId: 'crate-a', pickedUpAtTick: 1 },
+        { itemId: 'token', displayName: 'Token A', sourceObjectId: 'crate-b', pickedUpAtTick: 2 },
+        { itemId: 'token', displayName: 'Token B', sourceObjectId: 'crate-c', pickedUpAtTick: 3 },
+      ],
+      'token',
+    );
+
+    expect(transfer.item?.toInventoryItem()).toEqual({
+      itemId: 'token',
+      displayName: 'Token A',
+      sourceObjectId: 'crate-b',
+      pickedUpAtTick: 2,
+    });
+    expect(transfer.remainingItems).toEqual([
+      { itemId: 'apple', displayName: 'Apple', sourceObjectId: 'crate-a', pickedUpAtTick: 1 },
+      { itemId: 'token', displayName: 'Token B', sourceObjectId: 'crate-c', pickedUpAtTick: 3 },
+    ]);
+  });
+
+  it('applies environment blocking flags through shared spatial rules', () => {
+    const base = createInitialWorldState();
+    const wall = mapEnvironmentDtoToRuntime({
+      id: 'wall-1',
+      displayName: 'Wall',
+      x: 2,
+      y: 1,
+      isBlocking: true,
+    });
+    const grass = mapEnvironmentDtoToRuntime({
+      id: 'grass-1',
+      displayName: 'Grass',
+      x: 3,
+      y: 1,
+      isBlocking: false,
+    });
+
+    const withEnvironments = {
+      ...base,
+      environments: [wall, grass],
+    };
+
+    expect(canMovePlayerTo(withEnvironments, { x: 2, y: 1 })).toBe(false);
+    expect(canMovePlayerTo(withEnvironments, { x: 3, y: 1 })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused class-model regression suite covering DTO-to-runtime class instantiation, object polymorphism, deterministic item lifecycle behavior, and environment blocking integration
- realign architecture and world/type documentation with the class-based world model and current folder structure
- document DTO vs runtime-class boundary invariants and extension guidelines for new NPC/object/environment subclasses

## Validation
- `npm run lint`
- `npm run build`
- `npm run test`

## Closes #151