### PR TITLE
#161 CI hardening: add PR lint-build-test workflow and required check docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-build-test:
+    name: lint-build-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ Issues are tracked as GitHub issues instead of Jira. Each issue includes:
 
 ## Testing & Validation
 
+### CI Required Checks
+
+All pull requests targeting `main` must pass the GitHub Actions CI check before merge.
+
+- Required check name: `lint-build-test`
+- Required command order in CI: `npm ci`, `npm run lint`, `npm run build`, `npm run test`
+- CI runs on pull requests to `main` and on pushes to `main`
+
 Before opening a PR, ensure:
 - `npm run build` completes without errors
 - `npm run lint` passes without warnings

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,13 @@ Recipes and walkthroughs for common extension tasks:
 
 See [Game Design Baseline](GAME_DESIGN_BASELINE.md) for the documenter-maintained source used by the game designer for direction, feasibility checks, and feature-gap analysis.
 
+## CI Merge Gate
+
+Pull requests to `main` are expected to pass the required CI status check before merge.
+
+- Required check name: `lint-build-test`
+- CI command sequence: `npm ci`, `npm run lint`, `npm run build`, `npm run test`
+
 ## Documentation Maintenance
 
 Documentation is maintained alongside code changes. When implementing a feature:


### PR DESCRIPTION
## Summary
- add `.github/workflows/ci.yml` with deterministic CI execution for pull requests to `main` and pushes to `main`
- use `actions/checkout@v4` and `actions/setup-node@v4` with npm cache
- enforce command order in one stable job/check: `npm ci`, `npm run lint`, `npm run build`, `npm run test`
- update contributor docs to state required CI check before merge and exact check name

## Validation
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm run test`

All commands passed locally.

## Closes #161
Closes #161