### PR TITLE
#167 realign runtime composition documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The game enforces strict layer separation to support LLM-driven gameplay:
   /input          — Input command buffering
   /llm            — LLM client boundary and stubs
   /runtime        — Runtime composition (app wiring, fixed tick loop, bridge/coordinator modules)
+  runtimeController.ts — Simulation gate for pause state, command drain, and item-use callback boundaries
   main.ts         — Thin browser bootstrap that starts the runtime app
 ```
 
@@ -54,12 +55,14 @@ The game enforces strict layer separation to support LLM-driven gameplay:
 
 The current baseline runtime is composed in `src/runtime/createRuntimeApp.ts` and follows this loop:
 
-1. Keyboard input maps to `WorldCommand` values and is enqueued into `CommandBuffer`.
-2. A fixed simulation tick of 100ms drains buffered commands.
-3. `world.applyCommands(commands)` updates deterministic state and advances `tick`, including inventory slot selection state.
-4. If any `useSelectedItem` commands were issued, runtime orchestration resolves a deterministic item-use attempt event for each command and stores the latest event in serialized world state.
-5. If an `interact` command was issued, one adjacent target is resolved through the interaction dispatcher; conversational turns may cross the LLM boundary, while door/object paths stay deterministic.
-6. Every animation frame renders the latest world state through the Pixi render port and prints JSON state in the debug panel.
+1. `src/main.ts` validates `#app` and starts `createRuntimeApp(...)`.
+2. `src/runtime/createRuntimeApp.ts` wires the world, `RuntimeController`, render ports, modal coordinator, interaction bridge, and level-load orchestration.
+3. Keyboard input maps to `WorldCommand` values and is enqueued into `CommandBuffer`.
+4. `src/runtime/fixedTickLoop.ts` drives a fixed simulation tick of 100ms plus a per-frame render callback.
+5. `src/runtimeController.ts` drains buffered commands, gates them while paused or after level completion, applies deterministic world commands, and invokes the selected-item resolver callback boundary.
+6. `src/runtime/interactionResultBridge.ts` handles interact commands: door/object targets stay deterministic, while guard/NPC targets open the action-modal flow first and only cross the LLM boundary after chat is chosen.
+7. `src/runtime/modalCoordinator.ts` owns action/chat/inventory modal lifecycles and viewport pause presentation; `src/runtime/levelLoadOrchestration.ts` owns manifest loading, default-level startup, and reset flows.
+8. Every animation frame renders the latest world state through the Pixi render port and prints JSON state in the debug panel.
 
 ## Architecture Documentation
 
@@ -163,9 +166,9 @@ Guard Game uses specialized Copilot agents to manage the full development workfl
 - `@coordinator: Run full flow for ticket #15`
 
 ### Locating Agents & Skills
-- **Agents:** [.github/agents/](/.github/agents/) — Each agent is an `.agent.md` file with description and behavior
-- **Skills:** [.github/skills/](/.github/skills/) — Workflows and best practices for specialized tasks
-- **Project Instructions:** [.github/copilot-instructions.md](/.github/copilot-instructions.md) — Baseline requirements and architecture constraints
+- **Agents:** [.github/agents/](.github/agents/) — Each agent is an `.agent.md` file with description and behavior
+- **Skills:** [.github/skills/](.github/skills/) — Workflows and best practices for specialized tasks
+- **Project Instructions:** [.github/copilot-instructions.md](.github/copilot-instructions.md) — Baseline requirements and architecture constraints
 
 ## Project Management
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The game enforces strict layer separation to support LLM-driven gameplay:
   /interaction    — NPC interaction flow and response formatting
   /input          — Input command buffering
   /llm            — LLM client boundary and stubs
-  main.ts         — Runtime bootstrap and frame/tick loop
+  /runtime        — Runtime composition (app wiring, fixed tick loop, bridge/coordinator modules)
+  main.ts         — Thin browser bootstrap that starts the runtime app
 ```
 
 ### Key Principles
@@ -51,7 +52,7 @@ The game enforces strict layer separation to support LLM-driven gameplay:
 
 ### Baseline Runtime Loop
 
-The current baseline runtime in `src/main.ts` follows this loop:
+The current baseline runtime is composed in `src/runtime/createRuntimeApp.ts` and follows this loop:
 
 1. Keyboard input maps to `WorldCommand` values and is enqueued into `CommandBuffer`.
 2. A fixed simulation tick of 100ms drains buffered commands.

--- a/docs/ADD_COMMAND.md
+++ b/docs/ADD_COMMAND.md
@@ -64,7 +64,12 @@ const applyCommand = (worldState: WorldState, command: WorldCommand): WorldState
 If your command produces an event consumed by runtime orchestration (without direct world mutation):
 - add a deterministic resolver boundary in `src/interaction/*`
 - wire it through `src/runtimeController.ts` dependency callbacks
-- commit resulting serializable event/state from `src/runtime/createRuntimeApp.ts`
+- commit the resulting serializable event/state from the callback wiring in `src/runtime/createRuntimeApp.ts`
+
+If your command needs new runtime UI handoff behavior (for example, a modal or bridge callback):
+- keep command draining/gating in `src/runtimeController.ts`
+- keep interaction/result routing in `src/runtime/interactionResultBridge.ts`
+- keep modal lifecycle behavior in `src/runtime/modalCoordinator.ts`
 
 If your command changes visual appearance through world state:
 - Update `src/render/scene.ts` to render any new state
@@ -75,6 +80,7 @@ Add focused tests:
 - input mapping tests in `src/input/keyboard.test.ts`
 - world command determinism tests in `src/world/world.test.ts`
 - runtime orchestration tests in `src/runtimeController.test.ts` when command effects route through runtime callbacks
+- runtime bridge or modal-coordinator tests in `src/runtime/*.test.ts` when the command changes runtime handoff behavior
 
 ```typescript
 test('selects valid inventory slot deterministically', () => {

--- a/docs/ADD_COMMAND.md
+++ b/docs/ADD_COMMAND.md
@@ -64,7 +64,7 @@ const applyCommand = (worldState: WorldState, command: WorldCommand): WorldState
 If your command produces an event consumed by runtime orchestration (without direct world mutation):
 - add a deterministic resolver boundary in `src/interaction/*`
 - wire it through `src/runtimeController.ts` dependency callbacks
-- commit resulting serializable event/state from `src/main.ts`
+- commit resulting serializable event/state from `src/runtime/createRuntimeApp.ts`
 
 If your command changes visual appearance through world state:
 - Update `src/render/scene.ts` to render any new state

--- a/docs/ADD_INTERACTION.md
+++ b/docs/ADD_INTERACTION.md
@@ -36,11 +36,11 @@ In `src/interaction/interactionDispatcher.ts` result registry:
 - map conversational result kind with `isConversational: true` to `onConversationStarted(...)` for LLM response display
 - rely on `getConversationHistory(...)` for modal preload consistency
 
-### 5. Keep main loop generic
-`src/main.ts` should not branch by target kind for interaction logic.
+### 5. Keep runtime bridge generic
+`src/runtime/interactionResultBridge.ts` should not branch by target kind for interaction logic.
 - `runInteractionIfRequested()` dispatches once and forwards result to `resultDispatcher`
 - chat submit path resolves target by id and reuses dispatcher with `playerMessage`
-- action modal routing (if present) handles player choice to Chat/Inventory/Back without main-loop changes
+- action modal routing (if present) handles player choice to Chat/Inventory/Back without runtime bridge changes
 
 ### 6. Test
 - Unit tests in `src/interaction/*Interaction.test.ts`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,14 +66,14 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 
 2. **Tick Phase** (fixed 100ms): `runtimeController.stepSimulation()` is called. It drains the command buffer, gates commands based on current pause state and level outcome, then applies the resolved command set to world state via `world.applyCommands(commands)`. This same step also captures every `useSelectedItem` command index from the drained tick list and, after command application, routes those use attempts through the deterministic item-use resolver boundary. If the runtime is paused (a guard or NPC conversation is open), buffered commands are discarded and no world update, item-use resolution, or interaction dispatch occurs for that tick.
 
-3. **Deterministic Use-Attempt Routing:** When `useSelectedItem` commands are present, `RuntimeController` calls the injected item-use resolver with the post-command `WorldState` and each original command index. `main.ts` commits the latest emitted `ItemUseAttemptResultEvent` back into serialized world state through `world.resetToState(...)`. When a door is unlocked (event.doorUnlockedId is present), the corresponding door's `isUnlocked` flag is set to true, allowing future movement through that door via spatial rules checks.
+3. **Deterministic Use-Attempt Routing:** When `useSelectedItem` commands are present, `RuntimeController` calls the injected item-use resolver with the post-command `WorldState` and each original command index. `createRuntimeApp.ts` commits the latest emitted `ItemUseAttemptResultEvent` back into serialized world state through `world.resetToState(...)`. When a door is unlocked (`event.doorUnlockedId` is present), the corresponding door's `isUnlocked` flag is set to true, allowing future movement through that door via spatial rules checks.
 
 4. **Interaction Dispatch:** If an `interact` command was issued and the runtime is not paused, `runInteractionIfRequested()` resolves one adjacent target and calls `interactionDispatcher.dispatch(...)`.
    - **Action Modal Routing:** If target is action-modal-eligible (guard/npc), dispatcher returns conversational result. Result dispatcher routes to either action modal open (if available) or directly to chat modal (backward compatible).
    - **Deterministic Routing:** If target is non-modal (door/object), dispatcher resolves interaction locally and returns deterministic result. Result dispatcher commits world state mutations without opening modals.
 
-5. **Result Routing:** Returned `InteractionHandlerResult` (sync or async) is routed through `resultDispatcher.dispatch(...)` into main-loop side effects.
-   - Conversational results (guard/npc, `isConversational: false` or `true`) call `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`.
+5. **Result Routing:** Returned `InteractionHandlerResult` (sync or async) is routed through `resultDispatcher.dispatch(...)` into runtime bridge side effects.
+       - Conversational results (guard/npc, `isConversational: false` or `true`) are routed through `interactionResultBridge` and `modalCoordinator` to call `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`.
    - Deterministic results (door/object) stay local to world-state reset and level-outcome callbacks.
    - Door and object interactions do not open modals and do not pause gameplay.
 
@@ -114,7 +114,7 @@ Runtime composition entry points:
 **Conversation Pause Flow:**
 1. Player presses `e` (interact) adjacent to a guard or NPC.
 2. `interactionDispatcher.dispatch(target)` returns conversational result (initial open, `isConversational: false`).
-3. `resultDispatcher.dispatch(result)` calls `runtimeController.openConversation(actorId)`, which:
+3. `resultDispatcher.dispatch(result)` (inside `src/runtime/interactionResultBridge.ts`) routes the conversational start callback to `src/runtime/modalCoordinator.ts`, which calls `runtimeController.openConversation(actorId)`, then:
    - Sets `paused = true` in runtime controller
    - Next `stepSimulation()` tick will drain buffered commands without processing
 4. Main loop calls `viewportPauseOverlay.show()` → adds `.viewport-pause-overlay` div, sets `inert` on viewport, blocks pointer/focus
@@ -193,7 +193,7 @@ Guarantees:
 When implementing a new feature:
 1. **Identify the layer:** Which layer's responsibility does this touch?
 2. **Extend the contract:** Add types, handlers, or state fields as needed.
-3. **Update routing:** Register interaction and result handlers instead of adding ad-hoc branches in `main.ts`.
+3. **Update routing:** Register interaction and result handlers instead of adding ad-hoc branches in runtime composition modules.
 4. **Test the boundary:** Verify layer separation and sync/async behavior parity.
 
 See the relevant layer guide for detailed extension patterns.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,14 +66,14 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 
 2. **Tick Phase** (fixed 100ms): `runtimeController.stepSimulation()` is called. It drains the command buffer, gates commands based on current pause state and level outcome, then applies the resolved command set to world state via `world.applyCommands(commands)`. This same step also captures every `useSelectedItem` command index from the drained tick list and, after command application, routes those use attempts through the deterministic item-use resolver boundary. If the runtime is paused (a guard or NPC conversation is open), buffered commands are discarded and no world update, item-use resolution, or interaction dispatch occurs for that tick.
 
-3. **Deterministic Use-Attempt Routing:** When `useSelectedItem` commands are present, `RuntimeController` calls the injected item-use resolver with the post-command `WorldState` and each original command index. `createRuntimeApp.ts` commits the latest emitted `ItemUseAttemptResultEvent` back into serialized world state through `world.resetToState(...)`. When a door is unlocked (`event.doorUnlockedId` is present), the corresponding door's `isUnlocked` flag is set to true, allowing future movement through that door via spatial rules checks.
+3. **Deterministic Use-Attempt Routing:** When `useSelectedItem` commands are present, `RuntimeController` calls the injected item-use resolver with the post-command `WorldState` and each original command index. `src/runtime/createRuntimeApp.ts` wires the `onItemUseAttemptResolved(...)` callback that commits the latest emitted `ItemUseAttemptResultEvent` back into serialized world state through `world.resetToState(...)`. When a door is unlocked (`event.doorUnlockedId` is present), that same callback sets the corresponding door's `isUnlocked` flag to true, allowing future movement through that door via spatial rules checks.
 
-4. **Interaction Dispatch:** If an `interact` command was issued and the runtime is not paused, `runInteractionIfRequested()` resolves one adjacent target and calls `interactionDispatcher.dispatch(...)`.
-   - **Action Modal Routing:** If target is action-modal-eligible (guard/npc), dispatcher returns conversational result. Result dispatcher routes to either action modal open (if available) or directly to chat modal (backward compatible).
-   - **Deterministic Routing:** If target is non-modal (door/object), dispatcher resolves interaction locally and returns deterministic result. Result dispatcher commits world state mutations without opening modals.
+4. **Interaction Routing:** If an `interact` command was issued and the runtime is not paused, `src/runtime/interactionResultBridge.ts` resolves one adjacent target.
+       - **Action Modal Routing:** If the target is action-modal-eligible (`guard` or `npc`), the bridge opens an action-modal session immediately through `src/runtime/modalCoordinator.ts`. If the player chooses Chat, the bridge resolves the conversational target by id and then calls `interactionDispatcher.dispatch(...)` to start the chat flow.
+       - **Deterministic Routing:** If the target is non-modal (`door` or `interactiveObject`), the bridge dispatches immediately. Result handlers commit world-state mutations without opening modals.
 
 5. **Result Routing:** Returned `InteractionHandlerResult` (sync or async) is routed through `resultDispatcher.dispatch(...)` into runtime bridge side effects.
-       - Conversational results (guard/npc, `isConversational: false` or `true`) are routed through `interactionResultBridge` and `modalCoordinator` to call `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`.
+       - Conversational results (`guard`/`npc`) are routed through `interactionResultBridge` into `modalCoordinator`, which calls `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`.
    - Deterministic results (door/object) stay local to world-state reset and level-outcome callbacks.
    - Door and object interactions do not open modals and do not pause gameplay.
 
@@ -84,6 +84,7 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 Runtime composition entry points:
 - `src/main.ts`: validates `#app` and starts the runtime app.
 - `src/runtime/createRuntimeApp.ts`: composition root that wires world, runtime controller, render ports, interaction bridge, modal coordinator, and level orchestration.
+- `src/runtimeController.ts`: drains command input, enforces pause and level-outcome gating, and invokes deterministic item-use callback boundaries.
 - `src/runtime/fixedTickLoop.ts`: fixed-timestep simulation loop + per-frame render callback.
 - `src/runtime/interactionResultBridge.ts`: interaction dispatch/result routing and conversation send bridge.
 - `src/runtime/modalCoordinator.ts`: chat/action/inventory modal lifecycle and viewport pause overlay semantics.
@@ -111,14 +112,12 @@ Runtime composition entry points:
 
 ### Modal Lifecycle and Pause Semantics
 
-**Conversation Pause Flow:**
+**Action Modal + Conversation Pause Flow:**
 1. Player presses `e` (interact) adjacent to a guard or NPC.
-2. `interactionDispatcher.dispatch(target)` returns conversational result (initial open, `isConversational: false`).
-3. `resultDispatcher.dispatch(result)` (inside `src/runtime/interactionResultBridge.ts`) routes the conversational start callback to `src/runtime/modalCoordinator.ts`, which calls `runtimeController.openConversation(actorId)`, then:
-   - Sets `paused = true` in runtime controller
-   - Next `stepSimulation()` tick will drain buffered commands without processing
-4. Main loop calls `viewportPauseOverlay.show()` → adds `.viewport-pause-overlay` div, sets `inert` on viewport, blocks pointer/focus
-5. Chat modal opens: `chatModal.open(actorId, displayName, history)` → renders conversation interface in DOM
+2. `src/runtime/interactionResultBridge.ts` resolves an action-modal-eligible target and creates a `RuntimeActionModalSession` instead of dispatching the interaction immediately.
+3. `src/runtime/modalCoordinator.ts` opens the action modal, calls `runtimeController.openActionModal(session)`, shows the viewport overlay, and pauses gameplay.
+4. If the player chooses Chat, `modalCoordinator` asks `interactionResultBridge.openConversationForActionSession(...)` to resolve the conversational target by id and dispatch the initial interaction result.
+5. The result dispatcher routes the conversational start callback back into `modalCoordinator`, which calls `runtimeController.openConversation(actorId)` and opens `chatModal.open(actorId, displayName, history)`.
 6. **While paused:**
    - Gameplay ticks don't advance (`stepSimulation()` drains but doesn't apply commands)
    - Input layer suppresses movement/interact commands via `isModalOpen()` callback

--- a/docs/EXTEND_STATE.md
+++ b/docs/EXTEND_STATE.md
@@ -18,7 +18,7 @@ Validation/deserialization:
 - `src/world/level.ts`
 
 Runtime state commit:
-- `src/world/world.ts` and routing in `src/main.ts`
+- `src/world/world.ts` and runtime composition wiring in `src/runtime/createRuntimeApp.ts`
 
 ## State Extension Workflow
 
@@ -117,7 +117,7 @@ Required follow-up updates:
 - deterministic default initialization in `src/world/state.ts` and `src/world/level.ts`
 - deterministic command handling in `src/world/world.ts` for `selectInventorySlot`
 - runtime command-indexed event emission in `src/runtimeController.ts` using an item-use resolver boundary
-- immutable event commit wiring in `src/main.ts`
+- immutable event commit wiring in `src/runtime/createRuntimeApp.ts`
 - regression tests in `src/world/world.test.ts`, `src/runtimeController.test.ts`, and `src/input/keyboard.test.ts`
 
 ## Checklist

--- a/docs/EXTEND_STATE.md
+++ b/docs/EXTEND_STATE.md
@@ -18,7 +18,7 @@ Validation/deserialization:
 - `src/world/level.ts`
 
 Runtime state commit:
-- `src/world/world.ts` and runtime composition wiring in `src/runtime/createRuntimeApp.ts`
+- `src/world/world.ts`, `src/runtimeController.ts`, and callback wiring in `src/runtime/createRuntimeApp.ts`
 
 ## State Extension Workflow
 

--- a/docs/GAME_DESIGN_BASELINE.md
+++ b/docs/GAME_DESIGN_BASELINE.md
@@ -64,7 +64,7 @@ Implemented systems:
   - Item-use attempt resolver boundary:
     - Runtime detects each `useSelectedItem` command in tick order.
     - Resolver emits deterministic per-command result events (`no-selection` or `no-target` currently).
-    - Main loop commits latest event to `worldState.lastItemUseAttemptEvent`.
+    - `src/runtimeController.ts` resolves item-use attempt events during tick processing, and `src/runtime/createRuntimeApp.ts` commits the latest event to `worldState.lastItemUseAttemptEvent` through the runtime callback.
 - Runtime UI wiring:
   - Level picker and reset.
   - Level objective panel in runtime controls.

--- a/docs/INPUT_LAYER.md
+++ b/docs/INPUT_LAYER.md
@@ -62,7 +62,7 @@ The binding optionally accepts an `isModalOpen?: () => boolean` callback in `Key
 
 ```typescript
 bindKeyboardCommands(window, commandBuffer, {
-  isModalOpen: () => chatModal.isOpen(),
+  isModalOpen: () => runtimeController.isPaused(),
 });
 ```
 

--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -27,8 +27,8 @@ It also defines the deterministic item-use resolver boundary used by runtime sel
 - `interactiveObject` (deterministic state transition and optional outcome)
 
 This classification enables the runtime to route interactions appropriately:
-1. If target is action-modal-eligible (guard/npc), the interaction dispatcher forwards to conversational handlers and result dispatcher opens chat modal on success.
-2. If target is deterministic (door/object), the interaction dispatcher handles locally and commits result-world-state mutations without opening any modal.
+1. If target is action-modal-eligible (guard/npc), `src/runtime/interactionResultBridge.ts` opens an action-modal session first. The bridge only calls conversational handlers after the player chooses Chat from that action modal.
+2. If target is deterministic (door/object), the interaction bridge dispatches immediately and commits result-world-state mutations without opening any modal.
 
 **Type Guard Pattern:**
 
@@ -67,7 +67,7 @@ Dispatcher contract:
 `createResultDispatcher()` in `src/interaction/interactionDispatcher.ts` owns a second registry keyed by `InteractionHandlerResult['kind']`.
 
 Registered result handlers:
-- `guard`/`npc` -> open chat modal with the latest actor conversation thread for that target id
+- `guard`/`npc` -> open chat modal with the latest actor conversation thread for that target id after the runtime chooses the chat path
 - `door` -> apply level outcome callback if present
 - `interactiveObject` -> apply immutable world-state reset callback if present
 
@@ -75,13 +75,15 @@ Result dispatcher keeps runtime side effects centralized and testable.
 
 ## Runtime Bridge Routing Pattern
 
-`runInteractionIfRequested()` in `src/runtime/interactionResultBridge.ts` uses one routing path:
-1. Resolve adjacent target.
-2. Call `interactionDispatcher.dispatch(...)`.
-3. If promise-like, resolve asynchronously then call `resultDispatcher.dispatch(...)`.
-4. If sync result, call `resultDispatcher.dispatch(...)` immediately.
+`src/runtime/interactionResultBridge.ts` owns two related routing paths:
+1. `runInteractionIfRequested()` resolves one adjacent target.
+2. If the target is action-modal-eligible (`guard`/`npc`), it creates a `RuntimeActionModalSession` and hands it to `src/runtime/modalCoordinator.ts` instead of dispatching immediately.
+3. If the target is deterministic (`door`/`interactiveObject`), it calls `interactionDispatcher.dispatch(...)` immediately.
+4. `openConversationForActionSession()` resolves the stored conversational target by id when the player chooses Chat and then dispatches the initial open-chat interaction.
+5. If a dispatch result is promise-like, the bridge resolves it asynchronously and then calls `resultDispatcher.dispatch(...)`.
+6. If a dispatch result is sync, the bridge calls `resultDispatcher.dispatch(...)` immediately.
 
-This removes target-kind branching from runtime composition and preserves behavior parity from pre-refactor logic.
+This keeps target-kind branching isolated to the runtime bridge and action-modal helper, while preserving sync/async behavior parity within the dispatcher itself.
 
 The runtime bridge and tests use the shared actor-neutral helper in `src/interaction/actorConversationThread.ts` to read and render conversation history.
 
@@ -117,7 +119,7 @@ When an adjacent target is a guard or interactive object, the resolver checks fo
 
 All rules are deterministic and code-owned. No LLM involvement in item-use success/failure determination. Response text is narrative only.
 
-Runtime app wiring in `src/runtime/createRuntimeApp.ts` commits the latest emitted event to `worldState.lastItemUseAttemptEvent` via immutable `world.resetToState(...)`.
+The item-use callback wiring in `src/runtime/createRuntimeApp.ts` commits the latest emitted event to `worldState.lastItemUseAttemptEvent` via immutable `world.resetToState(...)`.
 
 LLM boundary note:
 - Item-use attempt resolution is deterministic and code-owned.
@@ -126,7 +128,7 @@ LLM boundary note:
 
 ## Conversation Pause Lifecycle
 
-When the result dispatcher opens a guard or NPC conversation (`onConversationStarted` routed from [src/runtime/interactionResultBridge.ts](../src/runtime/interactionResultBridge.ts) into [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts)), the runtime bridge + modal coordinator perform three side effects in order:
+When the player chooses Chat from an action-modal session, `onConversationStarted` is routed from [src/runtime/interactionResultBridge.ts](../src/runtime/interactionResultBridge.ts) into [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts). The runtime bridge + modal coordinator then perform three side effects in order:
 1. `runtimeController.openConversation(actorId)` sets the runtime to paused state, records the active `RuntimeConversationSession`, and clears buffered commands.
 2. `viewportPauseOverlay.show()` reveals the grey viewport overlay and makes `#viewport` inert.
 3. `chatModal.open(targetId, displayName, conversationHistory)` opens the conversation UI and focuses the input.
@@ -139,7 +141,7 @@ When the chat modal closes, both exit controls follow the same path:
 3. `onClose` in [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts) calls `runtimeController.closeConversation()` and `viewportPauseOverlay.hide()`.
 4. `runtimeController.closeConversation()` clears the active conversation session, clears buffered commands accumulated during the conversation, and resumes simulation on the next tick.
 
-Door and interactive object results never trigger `onConversationStarted`, so they never cause a pause and never show the viewport overlay. This is enforced by the result dispatcher and verified in `src/interaction/interactionDispatcher.test.ts` under the `result dispatcher timing parity` suite.
+Door and interactive object results never trigger `onConversationStarted`, so they never cause a pause and never show the viewport overlay. This is enforced by the runtime bridge + result dispatcher flow and verified in `src/interaction/interactionDispatcher.test.ts` under the `result dispatcher timing parity` suite.
 
 Gameplay pause state is kept outside `WorldState`. UI pause presentation is also transient render-layer DOM state. Neither belongs in serialized world state or LLM context.
 
@@ -226,6 +228,7 @@ See `src/interaction/guardInteraction.ts`, `src/interaction/npcInteraction.ts`, 
 ## Tests
 
 - `src/interaction/interactionDispatcher.test.ts`: dispatch routing by kind, sync/async behavior parity, result dispatcher timing parity, door/object non-pause guarantee
+- `src/interaction/actionModalRouting.test.ts`: action-modal eligibility and session creation for guard/NPC targets
 - `src/runtimeController.test.ts`: pause entry/exit lifecycle, command gating while paused, resume without command leak, level-outcome gating independent of pause state
 - `src/interaction/npcPromptContext.test.ts`: profile registry resolution, deterministic fallback, world knowledge builder registry keys, alias resolution (`archive_keeper → villager`), self-exclusion from `otherVillagers`, unknown-type `null` fallback, context shape determinism
 - `src/interaction/objectInteraction.test.ts`: polymorphic object dispatch, first-use outcomes, repeat interactions

--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -14,7 +14,7 @@ It also defines the deterministic item-use resolver boundary used by runtime sel
 - Route target kinds to registered interaction handlers
 - Keep deterministic interactions local and synchronous
 - Keep LLM-backed conversational turns behind the LLM boundary
-- Route normalized results through result handlers to main-loop side effects
+- Route normalized results through result handlers to runtime bridge side effects
 
 ## Action Modal Routing
 
@@ -71,17 +71,17 @@ Registered result handlers:
 - `door` -> apply level outcome callback if present
 - `interactiveObject` -> apply immutable world-state reset callback if present
 
-Result dispatcher keeps main-loop side effects centralized and testable.
+Result dispatcher keeps runtime side effects centralized and testable.
 
-## Main Loop Routing Pattern
+## Runtime Bridge Routing Pattern
 
-`runInteractionIfRequested()` in `src/main.ts` uses one routing path:
+`runInteractionIfRequested()` in `src/runtime/interactionResultBridge.ts` uses one routing path:
 1. Resolve adjacent target.
 2. Call `interactionDispatcher.dispatch(...)`.
 3. If promise-like, resolve asynchronously then call `resultDispatcher.dispatch(...)`.
 4. If sync result, call `resultDispatcher.dispatch(...)` immediately.
 
-This removes target-kind branching from `main.ts` and preserves behavior parity from pre-refactor logic.
+This removes target-kind branching from runtime composition and preserves behavior parity from pre-refactor logic.
 
 The runtime bridge and tests use the shared actor-neutral helper in `src/interaction/actorConversationThread.ts` to read and render conversation history.
 
@@ -117,7 +117,7 @@ When an adjacent target is a guard or interactive object, the resolver checks fo
 
 All rules are deterministic and code-owned. No LLM involvement in item-use success/failure determination. Response text is narrative only.
 
-Main-loop wiring in `src/main.ts` commits the latest emitted event to `worldState.lastItemUseAttemptEvent` via immutable `world.resetToState(...)`.
+Runtime app wiring in `src/runtime/createRuntimeApp.ts` commits the latest emitted event to `worldState.lastItemUseAttemptEvent` via immutable `world.resetToState(...)`.
 
 LLM boundary note:
 - Item-use attempt resolution is deterministic and code-owned.
@@ -126,7 +126,7 @@ LLM boundary note:
 
 ## Conversation Pause Lifecycle
 
-When the result dispatcher opens a guard or NPC conversation (`onConversationStarted` in [src/main.ts](../src/main.ts)), the runtime bridge performs three side effects in order:
+When the result dispatcher opens a guard or NPC conversation (`onConversationStarted` routed from [src/runtime/interactionResultBridge.ts](../src/runtime/interactionResultBridge.ts) into [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts)), the runtime bridge + modal coordinator perform three side effects in order:
 1. `runtimeController.openConversation(actorId)` sets the runtime to paused state, records the active `RuntimeConversationSession`, and clears buffered commands.
 2. `viewportPauseOverlay.show()` reveals the grey viewport overlay and makes `#viewport` inert.
 3. `chatModal.open(targetId, displayName, conversationHistory)` opens the conversation UI and focuses the input.
@@ -136,7 +136,7 @@ While paused, `runtimeController.stepSimulation()` drains and discards buffered 
 When the chat modal closes, both exit controls follow the same path:
 1. The close button or Escape key triggers `closePanel()` in [src/render/chatModal.ts](../src/render/chatModal.ts).
 2. `closePanel()` hides the modal, removes the Escape listener, invokes `onClose`, and then restores focus to `document.body` if focus was still inside the modal.
-3. `onClose` in [src/main.ts](../src/main.ts) calls `runtimeController.closeConversation()` and `viewportPauseOverlay.hide()`.
+3. `onClose` in [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts) calls `runtimeController.closeConversation()` and `viewportPauseOverlay.hide()`.
 4. `runtimeController.closeConversation()` clears the active conversation session, clears buffered commands accumulated during the conversation, and resumes simulation on the next tick.
 
 Door and interactive object results never trigger `onConversationStarted`, so they never cause a pause and never show the viewport overlay. This is enforced by the result dispatcher and verified in `src/interaction/interactionDispatcher.test.ts` under the `result dispatcher timing parity` suite.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,4 +53,4 @@ Documentation is maintained alongside code changes. When implementing a feature:
 - Keep types in sync with the Type Reference
 - Link to actual code files for concrete examples
 
-See the [documenter agent](../.github/agents/documenter.agent.md) for how documentation updates are handled during code review.
+See the [content manager agent](../.github/agents/content-manager.agent.md) for how documentation updates are handled during code review.

--- a/docs/RENDER_LAYER.md
+++ b/docs/RENDER_LAYER.md
@@ -62,7 +62,7 @@ The runtime mounts a small set of DOM-only helpers alongside the Pixi canvas:
 - `createViewportOverlay()` manages the grey paused-world overlay inside `#viewport`.
 - `createOutcomeOverlay()` manages win/lose overlay messaging.
 
-These utilities are wired in [src/main.ts](../src/main.ts) and remain presentation-only. They do not hold gameplay state.
+These utilities are wired in [src/runtime/createRuntimeApp.ts](../src/runtime/createRuntimeApp.ts) and remain presentation-only. They do not hold gameplay state.
 
 ## Entity Marker Mapping
 
@@ -81,7 +81,7 @@ The paused-world presentation is intentionally split from gameplay pause state:
 - `createViewportOverlay()` owns how the paused viewport is presented in the DOM.
 
 Current behavior:
-1. Conversational open results in [src/main.ts](../src/main.ts) call `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`.
+1. Conversational open results are routed from [src/runtime/interactionResultBridge.ts](../src/runtime/interactionResultBridge.ts) into [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts), which calls `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`.
 2. `createViewportOverlay(viewportElement)` appends a hidden `.viewport-pause-overlay` child inside `#viewport`.
 3. `show()` reveals the overlay and sets the `inert` attribute on the viewport element.
 4. `hide()` hides the overlay and removes `inert`.
@@ -150,7 +150,7 @@ The inventory overlay does not pause gameplay directly. Pause state is managed e
 `createChatModal()` provides the current conversation exit behavior:
 - The close button and the document-level Escape listener both route through the same `closePanel()` path.
 - `closePanel()` hides the modal, unregisters the Escape listener, invokes `onClose`, and then restores focus to `document.body` if focus was still inside the modal.
-- In [src/main.ts](../src/main.ts), `onClose` is wired to `runtimeController.closeConversation()` and `viewportPauseOverlay.hide()`.
+- In [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts), `onClose` is wired to `runtimeController.closeConversation()` and `viewportPauseOverlay.hide()`.
 - The chat input stops `keydown` and `keyup` propagation so typing does not reach the global movement binding. Enter submission stays local to the modal.
 
 ## Asset Metadata and Usage

--- a/docs/RENDER_LAYER.md
+++ b/docs/RENDER_LAYER.md
@@ -8,12 +8,15 @@ The render layer translates `WorldState` into visual state and DOM-only runtime 
 - Keep viewport/camera centered around player with clamped world bounds
 - Map world entities to deterministic visuals by type and optional asset metadata
 - Consume world-owned player-facing direction when choosing player directional sprites
-- Manage DOM-only render utilities for runtime layout, level controls UI, chat UI, viewport pause presentation, and level-outcome presentation
+- Manage DOM-only render utilities for runtime layout, level briefing, inventory panel, level controls UI, action/chat/inventory overlays, viewport pause presentation, and level-outcome presentation
 
 Implementation entry points:
 - [src/render/scene.ts](../src/render/scene.ts)
 - [src/render/runtimeLayout.ts](../src/render/runtimeLayout.ts)
+- [src/render/levelBriefing.ts](../src/render/levelBriefing.ts)
+- [src/render/inventoryPanel.ts](../src/render/inventoryPanel.ts)
 - [src/render/levelUi.ts](../src/render/levelUi.ts)
+- [src/render/actionModal.ts](../src/render/actionModal.ts)
 - [src/render/chatModal.ts](../src/render/chatModal.ts)
 - [src/render/inventoryOverlay.ts](../src/render/inventoryOverlay.ts)
 - [src/render/viewportOverlay.ts](../src/render/viewportOverlay.ts)
@@ -57,12 +60,16 @@ This keeps rendering deterministic even with partially configured sprite sets.
 
 The runtime mounts a small set of DOM-only helpers alongside the Pixi canvas:
 - `getRuntimeLayoutMarkup()` creates the host structure for viewport, side panels, modal host, and outcome host.
+- `createLevelBriefingPanel()` renders the active level premise and goal text.
+- `createInventoryPanel()` renders the always-visible inventory summary panel.
 - `createLevelUi()` manages level picker controls and the objective text panel in the runtime controls area.
+- `createActionModal()` manages the action selection UI for guard/NPC interactions.
 - `createChatModal()` manages the conversation dialog DOM and local focus behavior.
+- `createInventoryOverlay()` manages the view-only inventory modal opened from the action modal.
 - `createViewportOverlay()` manages the grey paused-world overlay inside `#viewport`.
 - `createOutcomeOverlay()` manages win/lose overlay messaging.
 
-These utilities are wired in [src/runtime/createRuntimeApp.ts](../src/runtime/createRuntimeApp.ts) and remain presentation-only. They do not hold gameplay state.
+`src/runtime/createRuntimeApp.ts` wires these render utilities into the runtime shell, while [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts) owns the modal lifecycle callbacks and [src/runtime/levelLoadOrchestration.ts](../src/runtime/levelLoadOrchestration.ts) owns level-control data flow. The render utilities themselves remain presentation-only and do not hold gameplay state.
 
 ## Entity Marker Mapping
 
@@ -81,7 +88,7 @@ The paused-world presentation is intentionally split from gameplay pause state:
 - `createViewportOverlay()` owns how the paused viewport is presented in the DOM.
 
 Current behavior:
-1. Conversational open results are routed from [src/runtime/interactionResultBridge.ts](../src/runtime/interactionResultBridge.ts) into [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts), which calls `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`.
+1. Guard/NPC interact commands first open the action modal through [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts). When Chat or Inventory is chosen, the same coordinator keeps the viewport overlay visible while the selected modal remains open.
 2. `createViewportOverlay(viewportElement)` appends a hidden `.viewport-pause-overlay` child inside `#viewport`.
 3. `show()` reveals the overlay and sets the `inert` attribute on the viewport element.
 4. `hide()` hides the overlay and removes `inert`.
@@ -141,8 +148,8 @@ interface InventoryOverlay {
 ### Pause Semantics
 
 The inventory overlay does not pause gameplay directly. Pause state is managed externally by runtime logic:
-- If a conversational interaction is open (chat modal visible), the inventory remains accessible as a view-only reference
-- The overlay visibility is controlled by runtime callbacks, not by modal open state
+- If a guard/NPC action-modal session is active, the player can choose Inventory and keep the runtime paused while the overlay is visible
+- The overlay visibility is controlled by [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts), not by the overlay component itself
 - Inventory slot selection remains available while any modal is visible
 
 ## Conversation Exit Controls
@@ -152,6 +159,8 @@ The inventory overlay does not pause gameplay directly. Pause state is managed e
 - `closePanel()` hides the modal, unregisters the Escape listener, invokes `onClose`, and then restores focus to `document.body` if focus was still inside the modal.
 - In [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts), `onClose` is wired to `runtimeController.closeConversation()` and `viewportPauseOverlay.hide()`.
 - The chat input stops `keydown` and `keyup` propagation so typing does not reach the global movement binding. Enter submission stays local to the modal.
+
+`createActionModal()` and `createInventoryOverlay()` follow the same ownership split: render owns DOM behavior, while `modalCoordinator` decides whether closing the UI resumes gameplay or swaps back to another paused modal state.
 
 ## Asset Metadata and Usage
 

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -142,7 +142,7 @@ Deterministic rules:
 - New runtime state initializes all doors with `isUnlocked: false` (default, omitted if false).
 - Level deserialization also initializes all doors with `isUnlocked: false` unless explicitly set in the level JSON.
 - Item-use resolver emits `doorUnlockedId` when player's selected item matches a door's `requiredItemId`.
-- Main-loop wiring commits unlock mutations: when `event.doorUnlockedId` is present, the corresponding door is mutated to set `isUnlocked: true` (`src/main.ts` line 198).
+- Runtime app wiring commits unlock mutations: when `event.doorUnlockedId` is present, the corresponding door is mutated to set `isUnlocked: true` (`src/runtime/createRuntimeApp.ts`).
 - Once `isUnlocked` is true, the door allows traversal: `canMovePlayerTo()` in [src/world/spatialRules.ts](../src/world/spatialRules.ts#L38) skips blocked-door checks for unlocked doors.
 - Unlock state persists through JSON serialization and level state save/restore, enabling preserved progress across play sessions.
 
@@ -325,7 +325,7 @@ References:
 
 ## Interaction State Updates
 
-Conversational interactions write immutable updates into `actorConversationHistoryByActorId`, keyed by the interacting actor id. Object interactions return immutable state updates (for `interactiveObjects` and optional `levelOutcome`) and are then committed through world reset in `src/main.ts`.
+Conversational interactions write immutable updates into `actorConversationHistoryByActorId`, keyed by the interacting actor id. Object interactions return immutable state updates (for `interactiveObjects` and optional `levelOutcome`) and are then committed through world reset in `src/runtime/interactionResultBridge.ts`.
 
 Movement commands also update immutable player-facing state in `src/world/world.ts`, coupling orientation to input intent while preserving deterministic world transitions.
 

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -131,8 +131,8 @@ Deterministic rules:
 Deterministic rules:
 - New runtime state initializes `lastItemUseAttemptEvent` to `null`.
 - Level deserialization also initializes `lastItemUseAttemptEvent` to `null`.
-- Runtime emits one event per `useSelectedItem` command using command index ordering within the tick.
-- Main-loop wiring commits each emitted event immutably, so the last one in a tick becomes the stored event.
+- `src/runtimeController.ts` emits one event per `useSelectedItem` command using command index ordering within the tick.
+- The callback wiring in `src/runtime/createRuntimeApp.ts` commits each emitted event immutably, so the last one in a tick becomes the stored event.
 
 ### Door Unlock State
 
@@ -142,7 +142,7 @@ Deterministic rules:
 - New runtime state initializes all doors with `isUnlocked: false` (default, omitted if false).
 - Level deserialization also initializes all doors with `isUnlocked: false` unless explicitly set in the level JSON.
 - Item-use resolver emits `doorUnlockedId` when player's selected item matches a door's `requiredItemId`.
-- Runtime app wiring commits unlock mutations: when `event.doorUnlockedId` is present, the corresponding door is mutated to set `isUnlocked: true` (`src/runtime/createRuntimeApp.ts`).
+- The item-use callback wiring in `src/runtime/createRuntimeApp.ts` commits unlock mutations: when `event.doorUnlockedId` is present, the corresponding door is mutated to set `isUnlocked: true`.
 - Once `isUnlocked` is true, the door allows traversal: `canMovePlayerTo()` in [src/world/spatialRules.ts](../src/world/spatialRules.ts#L38) skips blocked-door checks for unlocked doors.
 - Unlock state persists through JSON serialization and level state save/restore, enabling preserved progress across play sessions.
 


### PR DESCRIPTION
## Summary
- update runtime and layer docs to reflect `src/runtime/createRuntimeApp.ts` as the composition root and `src/main.ts` as bootstrap-only
- align interaction, render, world, and extension guides with the current runtime handoff modules (`runtimeController`, `fixedTickLoop`, `interactionResultBridge`, `modalCoordinator`, `levelLoadOrchestration`)
- fix the stale agent link in `docs/README.md` and validate local markdown links

## Validation
- `npm run lint`
- `npm run build`
- `npm run test`
- local markdown link audit across `README.md` and `docs/*.md`

Closes #167