### PR TITLE
#169 Type Contract Partitioning: split world/types.ts into domain-focused modules

### DIFF
--- a/docs/ADD_COMMAND.md
+++ b/docs/ADD_COMMAND.md
@@ -9,7 +9,7 @@ Commands represent player actions that are buffered and then applied determinist
 ## Steps
 
 ### 1. Define the Command
-Add a new command variant to `WorldCommand` in `src/world/types.ts`:
+Add a new command variant to `WorldCommand` in `src/world/types/command.ts` (exported from `src/world/types.ts`):
 
 ```typescript
 export type WorldCommand =
@@ -98,7 +98,7 @@ test('emits deterministic item-use event for each useSelectedItem command', () =
 
 ## Checklist
 
-- [ ] Command type added to `WorldCommand` union in `src/world/types.ts`
+- [ ] Command type added to `WorldCommand` union in `src/world/types/command.ts` (re-exported from `src/world/types.ts`)
 - [ ] Input mapping added to `src/input/keyboard.ts`
 - [ ] Command application logic added to `src/world/world.ts`
 - [ ] Unit tests written in `src/world/world.test.ts`

--- a/docs/ADD_INTERACTION.md
+++ b/docs/ADD_INTERACTION.md
@@ -50,9 +50,10 @@ In `src/interaction/interactionDispatcher.ts` result registry:
 ## Pattern B: Add a New Deterministic Interaction Kind
 
 ### 1. Extend world types
-In `src/world/types.ts`:
+In `src/world/types/` domain modules (see [TYPES_REFERENCE.md](TYPES_REFERENCE.md)):
 - add/extend the required model fields
 - keep JSON-serializable shape
+- (Types are re-exported from `src/world/types.ts` for import stability)
 
 ### 2. Validate and deserialize level data
 In `src/world/level.ts`:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ All world state must serialize to JSON. This enables LLM systems to reason about
 **Implication:** Avoid circular references, functions, or non-serializable objects in `WorldState` and related types.
 
 ### DTO/Runtime Boundary
-Level JSON ingress/egress remains DTO-shaped (`src/world/types.ts`). During deserialization, DTOs are mapped into runtime classes via `src/world/entities/dtoRuntimeSeams.ts`.
+Level JSON ingress/egress remains DTO-shaped (types exported from `src/world/types.ts`, organized across domain-focused modules in `src/world/types/`). During deserialization, DTOs are mapped into runtime classes via `src/world/entities/dtoRuntimeSeams.ts`.
 
 **Implication:** Runtime classes can enforce structure and polymorphism, while serialized `WorldState` keeps stable JSON contracts for tests, debugging, and LLM context.
 

--- a/docs/EXTEND_STATE.md
+++ b/docs/EXTEND_STATE.md
@@ -12,7 +12,7 @@ This pattern describes how to expand `WorldState` safely while preserving determ
 ## Current State Anchors
 
 Source types:
-- `src/world/types.ts`
+- `src/world/types.ts` (barrel export; see [TYPES_REFERENCE.md](TYPES_REFERENCE.md) for domain module organization in `src/world/types/`)
 
 Validation/deserialization:
 - `src/world/level.ts`
@@ -23,7 +23,7 @@ Runtime state commit:
 ## State Extension Workflow
 
 ### 1. Define or extend type fields
-Update type interfaces in `src/world/types.ts` (for example `InteractiveObject` or `WorldState`).
+Update type interfaces in the appropriate `src/world/types/` domain module (see [TYPES_REFERENCE.md](TYPES_REFERENCE.md); types re-export from `src/world/types.ts` for import stability). For example, extend `InteractiveObject` in `src/world/types/object.ts` or `WorldState` in `src/world/types/world-state.ts`.
 
 Prefer explicit unions over free-form strings when the allowed values are known.
 

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -3,7 +3,20 @@
 This document tracks the core serializable types and selected transient runtime interfaces used by the runtime.
 
 Source of truth:
-- `src/world/types.ts`
+- `src/world/types.ts` (barrel export; organized across domain-focused modules in `src/world/types/`)
+  - `src/world/types/grid.ts` - GridPosition, SpriteDirection, SpriteSet
+  - `src/world/types/entity.ts` - GameEntity, EntityCapabilities
+  - `src/world/types/player.ts` - Player
+  - `src/world/types/inventory.ts` - Inventory and item-use types
+  - `src/world/types/guard.ts` - Guard
+  - `src/world/types/npc.ts` - Npc, RiddleClue, RiddleClueConstraint
+  - `src/world/types/door.ts` - Door
+  - `src/world/types/object.ts` - InteractiveObject, ObjectCapabilities
+  - `src/world/types/environment.ts` - Environment
+  - `src/world/types/conversation.ts` - ConversationMessage, ActorConversationHistoryByActorId
+  - `src/world/types/world-state.ts` - WorldState, WorldGrid, LevelMetadata
+  - `src/world/types/level.ts` - LevelData, Level*Dto types
+  - `src/world/types/command.ts` - WorldCommand, Intent, World interface
 - `src/world/entities/base/Entity.ts`
 - `src/world/entities/base/Actor.ts`
 - `src/world/entities/npcs/Npc.ts`
@@ -53,7 +66,7 @@ Used by runtime to distinguish between:
 
 ## World Domain Runtime-Class Seams
 
-These interfaces and classes provide a typed construction seam between serializable DTOs in `src/world/types.ts` and runtime class instances in `src/world/entities/`.
+These interfaces and classes provide a typed construction seam between serializable DTOs in `src/world/types/` modules and runtime class instances in `src/world/entities/`. (All types are re-exported from `src/world/types.ts` for import stability.)
 
 ### EntityInit
 - `id: string`

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -16,7 +16,7 @@ The **Intent Pipeline** provides a unified, source-agnostic mechanism for all ac
 
 ### Intent Model
 
-`Intent` in `src/world/types.ts` has the structure:
+`Intent` in `src/world/types/command.ts` (exported from `src/world/types.ts`) has the structure:
 ```typescript
 interface Intent {
   actorId: string;
@@ -54,7 +54,7 @@ Legacy `WorldCommand` objects (`move`, `selectInventorySlot`, `useSelectedItem`,
 
 ## Current Deterministic State Model
 
-`WorldState` in `src/world/types.ts` includes:
+`WorldState` in `src/world/types/world-state.ts` (exported from `src/world/types.ts`) includes:
 - `tick`
 - `grid`
 - `levelMetadata`
@@ -82,7 +82,7 @@ These classes establish a typed DTO-to-runtime boundary for future incremental m
 
 ### DTO vs Runtime Class Boundary
 
-- **DTO boundary:** `LevelData` and nested `Level*Dto` shapes in `src/world/types.ts` define file/network JSON contracts.
+- **DTO boundary:** `LevelData` and nested `Level*Dto` shapes in `src/world/types/level.ts` (exported from `src/world/types.ts`) define file/network JSON contracts.
 - **Runtime boundary:** `src/world/entities/*` classes provide constructor guarantees, polymorphic behavior hooks, and explicit conversion helpers.
 - **Seam boundary:** `src/world/entities/dtoRuntimeSeams.ts` is the only place that should map DTO shapes into runtime classes.
 
@@ -296,7 +296,7 @@ This enables shared behavior per object type while preserving instance-specific 
 
 When adding a new world subclass, keep changes localized and deterministic:
 
-1. Add/extend DTO shape in `src/world/types.ts` only if new serializable data is required.
+1. Add/extend DTO shape in `src/world/types/` domain modules (see [TYPES_REFERENCE.md](TYPES_REFERENCE.md) for module organization) only if new serializable data is required. Types are re-exported from `src/world/types.ts` for import stability.
 2. Implement runtime subclass under `src/world/entities/npcs` or `src/world/entities/objects`.
 3. Wire DTO-to-runtime mapping in `src/world/entities/dtoRuntimeSeams.ts`.
 4. Keep deterministic behavior in world/interaction layers; render only consumes resulting state.

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -1,390 +1,90 @@
-export interface GridPosition {
-  x: number;
-  y: number;
-}
-
-export type SpriteDirection = 'front' | 'away' | 'left' | 'right';
-
 /**
- * Serializable sprite configuration for entities with optional directional variants.
- * `default` provides a deterministic base asset when a directional key is missing.
+ * Barrel export file for world type contracts.
+ * 
+ * This file re-exports types from domain-focused modules under `src/world/types/`,
+ * providing a stable compatibility layer for existing imports.
+ * 
+ * # Module Organization
+ * 
+ * - `grid.ts` - GridPosition, SpriteDirection, SpriteSet
+ * - `entity.ts` - GameEntity, EntityCapabilities (base entity types)
+ * - `player.ts` - Player
+ * - `inventory.ts` - Inventory management and item-use rules
+ * - `guard.ts` - Guard entities
+ * - `npc.ts` - NPC entities, riddle clues, triggers
+ * - `door.ts` - Door entities
+ * - `object.ts` - InteractiveObject and ObjectCapabilities
+ * - `environment.ts` - Environment entities
+ * - `conversation.ts` - Conversation history contracts
+ * - `level.ts` - Level DTOs and LevelData format
+ * - `world-state.ts` - WorldState, WorldGrid, LevelMetadata
+ * - `command.ts` - WorldCommand, Intent, World interface
+ * 
+ * # Usage
+ * 
+ * Existing imports from `src/world/types` continue to work:
+ * ```typescript
+ * import type { WorldState, Player, Guard } from '../world/types';
+ * ```
+ * 
+ * For new code, consider importing from domain-focused modules:
+ * ```typescript
+ * import type { WorldState } from '../world/types/world-state';
+ * import type { Player } from '../world/types/player';
+ * ```
  */
-export interface SpriteSet {
-  default?: string;
-  front?: string;
-  away?: string;
-  left?: string;
-  right?: string;
-}
 
-export interface InventoryItem {
-  itemId: string;
-  displayName: string;
-  sourceObjectId: string;
-  pickedUpAtTick: number;
-}
+// Grid and sprite types
+export type { GridPosition, SpriteDirection, SpriteSet } from './types/grid.js';
 
-export interface PlayerInventory {
-  items: InventoryItem[];
-  selectedItem?: SelectedInventoryItem | null;
-}
+// Entity base types
+export type { GameEntity, EntityCapabilities } from './types/entity.js';
 
-export interface SelectedInventoryItem {
-  slotIndex: number;
-  itemId: string;
-}
+// Player types
+export type { Player } from './types/player.js';
 
-/**
- * Deterministic item-use rule for guards or objects.
- * Defines whether an item can be used and what response to provide.
- */
-export interface ItemUseRule {
-  allowed: boolean;
-  responseText: string;
-}
+// Inventory and item-use types
+export type {
+  InventoryItem,
+  PlayerInventory,
+  SelectedInventoryItem,
+  ItemUseRule,
+  ItemUseAttemptResult,
+  ItemUseAttemptResultEvent,
+} from './types/inventory.js';
 
-export type ItemUseAttemptResult = 'no-selection' | 'no-target' | 'blocked' | 'success' | 'no-rule';
+// Guard types
+export type { Guard } from './types/guard.js';
 
-export interface ItemUseAttemptResultEvent {
-  tick: number;
-  commandIndex: number;
-  selectedItem: SelectedInventoryItem | null;
-  result: ItemUseAttemptResult;
-  target: {
-    kind: 'door' | 'guard' | 'npc' | 'interactiveObject';
-    targetId: string;
-  } | null;
-  /** If a door was unlocked via correct item-use, contains the door ID */
-  doorUnlockedId?: string;
-  /** Type of entity affected by successful item-use rule (guard or object) */
-  affectedEntityType?: 'guard' | 'object';
-  /** ID of entity affected by successful item-use rule */
-  affectedEntityId?: string;
-  /** Response text from the applied item-use rule */
-  ruleResponseText?: string;
-}
+// NPC types
+export type { RiddleClue, RiddleClueConstraint, TriggerEffect, NpcTriggers, Npc } from './types/npc.js';
 
-export interface Player {
-  id: string;
-  displayName: string;
-  position: GridPosition;
-  inventory: PlayerInventory;
-  facingDirection?: SpriteDirection;
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
-}
+// Door types
+export type { Door } from './types/door.js';
 
-/**
- * Riddle clue constraint for an NPC in a logic puzzle.
- * Defines what claim the NPC must make about a door's safety.
- */
-export interface RiddleClue {
-  clueId: string;
-  doorId: string;
-  truthBehavior: 'truthful' | 'inverse';
-  /** Computed field: what the NPC must claim about the door's safety */
-  mustStateDoorAs: 'safe' | 'danger';
-}
+// Interactive object types
+export type { ObjectCapabilities, InteractiveObject } from './types/object.js';
 
-/**
- * Human-readable riddle clue constraint for prompt context.
- */
-export interface RiddleClueConstraint {
-  doorId: string;
-  mustStateDoorAs: 'safe' | 'danger';
-  constraint: string;
-}
+// Environment types
+export type { Environment } from './types/environment.js';
 
-/**
- * Shared structural base for all game entities.
- * All world entities share this common root. JSON-serializable.
- */
-export interface GameEntity {
-  id: string;
-  position: GridPosition;
-  displayName: string;
-  spriteSet?: SpriteSet;
-  spriteAssetPath?: string;
-  /** Open-ended behavioral traits bag, readable by LLM prompt builders. */
-  traits?: Record<string, string>;
-  /** Open-ended facts bag for arbitrary key/value data, readable by LLM prompt builders. */
-  facts?: Record<string, string | number | boolean>;
-}
+// Conversation types
+export type { ConversationMessage, ActorConversationHistoryByActorId } from './types/conversation.js';
 
-/**
- * Opt-in capability container for game entities.
- * Capabilities are typed sub-objects; omit a key if the entity lacks that capability.
- */
-export interface EntityCapabilities {
-  inventory?: { items: InventoryItem[] };
-  dialogue?: { threadId?: string };
-  patrol?: { path: GridPosition[] };
-  lock?: { isLocked: boolean; requiredItemId?: string };
-}
+// World state types
+export type { WorldState, WorldGrid, LevelMetadata } from './types/world-state.js';
 
-export interface TriggerEffect {
-  setFact: string;
-  value: string | boolean | number;
-}
+// Level DTO types
+export type {
+  LevelPlayerDto,
+  LevelGuardDto,
+  LevelDoorDto,
+  LevelNpcRiddleClueDto,
+  LevelNpcDto,
+  LevelInteractiveObjectDto,
+  LevelEnvironmentDto,
+  LevelData,
+} from './types/level.js';
 
-export interface NpcTriggers {
-  onApproach?: TriggerEffect;
-  onTalk?: TriggerEffect;
-}
-
-export interface Npc extends GameEntity {
-  npcType: string;
-  dialogueContextKey: string;
-  patrol?: { path: Array<{ x: number; y: number }> };
-  triggers?: NpcTriggers;
-  inventory?: InventoryItem[];
-  /** Instance-specific knowledge this NPC has (overrides or extends type-level knowledge). */
-  instanceKnowledge?: string;
-  /** Instance-specific behavior traits for this NPC (overrides or extends type-level behavior). */
-  instanceBehavior?: string;
-  /** Riddle clue constraint for logic puzzle NPCs. */
-  riddleClue?: RiddleClue;
-}
-
-export interface ConversationMessage {
-  role: 'player' | 'assistant';
-  text: string;
-}
-
-export type ActorConversationHistoryByActorId = Record<string, ConversationMessage[]>;
-
-/** A guard entity that the player can interact with. */
-export interface Guard extends GameEntity {
-  guardState: 'idle' | 'patrolling' | 'alert';
-  facingDirection?: SpriteDirection;
-  /** Instance-specific knowledge this guard has (overrides or extends type-level knowledge). */
-  instanceKnowledge?: string;
-  /** Instance-specific behavior traits for this guard (overrides or extends type-level behavior). */
-  instanceBehavior?: string;
-  /** Deterministic item-use rules: item ID → rule definition */
-  itemUseRules?: Record<string, ItemUseRule>;
-}
-
-/** A door that the player can pass through or be blocked by. */
-export interface Door extends GameEntity {
-  doorState: 'open' | 'closed' | 'locked';
-  outcome?: 'safe' | 'danger';
-  /** Item ID required to unlock this door (if set, door must be interacted with using this item) */
-  requiredItemId?: string;
-  /** Whether this door has been unlocked via item-use (persists unlock state; default: false) */
-  isUnlocked?: boolean;
-}
-
-/**
- * Capability flags define what an interactive object can do.
- * Objects declare capabilities, and the interaction handler applies matching effects.
- */
-export interface ObjectCapabilities {
-  containsItems?: boolean;
-  isActivatable?: boolean;
-  isLockable?: boolean;
-}
-
-export interface InteractiveObject extends GameEntity {
-  objectType: string;
-  interactionType: 'inspect' | 'use' | 'talk';
-  state: 'idle' | 'used';
-  pickupItem?: {
-    itemId: string;
-    displayName: string;
-  };
-  idleMessage?: string;
-  usedMessage?: string;
-  firstUseOutcome?: 'win' | 'lose';
-  /** Capability flags that drive behavior dispatch */
-  capabilities?: ObjectCapabilities;
-  /** Deterministic item-use rules: item ID → rule definition */
-  itemUseRules?: Record<string, ItemUseRule>;
-}
-
-export interface Environment {
-  id: string;
-  displayName: string;
-  position: GridPosition;
-  isBlocking: boolean;
-}
-
-export interface WorldGrid {
-  width: number;
-  height: number;
-  tileSize: number;
-}
-
-export interface LevelMetadata {
-  name: string;
-  premise: string;
-  goal: string;
-}
-
-export interface LevelPlayerDto {
-  x: number;
-  y: number;
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
-}
-
-export interface LevelGuardDto {
-  id: string;
-  displayName: string;
-  x: number;
-  y: number;
-  guardState: 'patrolling' | 'alert' | 'idle';
-  /** Behavioral traits bag. Use traits.truthMode for guard honesty ('truth-teller' | 'liar'). */
-  traits?: Record<string, string>;
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
-  /** Instance-specific knowledge this guard has. */
-  instanceKnowledge?: string;
-  /** Instance-specific behavior traits for this guard. */
-  instanceBehavior?: string;
-  /** Deterministic item-use rules: item ID -> rule definition */
-  itemUseRules?: Record<string, ItemUseRule>;
-}
-
-export interface LevelDoorDto {
-  id: string;
-  displayName: string;
-  x: number;
-  y: number;
-  doorState: 'open' | 'closed' | 'locked';
-  outcome?: 'safe' | 'danger';
-  /** Item ID required to unlock this door */
-  requiredItemId?: string;
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
-}
-
-export interface LevelNpcRiddleClueDto {
-  clueId: string;
-  doorId: string;
-  truthBehavior: 'truthful' | 'inverse';
-}
-
-export interface LevelNpcDto {
-  id: string;
-  displayName: string;
-  x: number;
-  y: number;
-  npcType: string;
-  patrol?: { path: GridPosition[] };
-  triggers?: NpcTriggers;
-  inventory?: InventoryItem[];
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
-  /** Instance-specific knowledge this NPC has. */
-  instanceKnowledge?: string;
-  /** Instance-specific behavior traits for this NPC. */
-  instanceBehavior?: string;
-  /** Riddle clue constraint for logic puzzle NPCs. */
-  riddleClue?: LevelNpcRiddleClueDto;
-}
-
-export interface LevelInteractiveObjectDto {
-  id: string;
-  displayName: string;
-  x: number;
-  y: number;
-  objectType: string;
-  interactionType: 'inspect' | 'use' | 'talk';
-  state: 'idle' | 'used';
-  pickupItem?: {
-    itemId: string;
-    displayName: string;
-  };
-  idleMessage?: string;
-  usedMessage?: string;
-  firstUseOutcome?: 'win' | 'lose';
-  spriteAssetPath?: string;
-  spriteSet?: SpriteSet;
-  capabilities?: ObjectCapabilities;
-  /** Deterministic item-use rules: item ID -> rule definition */
-  itemUseRules?: Record<string, ItemUseRule>;
-}
-
-export interface LevelEnvironmentDto {
-  id: string;
-  displayName: string;
-  x: number;
-  y: number;
-  isBlocking: boolean;
-}
-
-/** Flat JSON representation of a level file (public/levels/*.json). Version-stamped for future migrations. */
-export interface LevelData {
-  version: number;
-  name: string;
-  premise: string;
-  goal: string;
-  objective?: string;
-  width: number;
-  height: number;
-  player: LevelPlayerDto;
-  guards: LevelGuardDto[];
-  doors: LevelDoorDto[];
-  npcs?: LevelNpcDto[];
-  interactiveObjects?: LevelInteractiveObjectDto[];
-  environments?: LevelEnvironmentDto[];
-}
-
-export interface WorldState {
-  tick: number;
-  grid: WorldGrid;
-  levelMetadata: LevelMetadata;
-  levelObjective?: string;
-  player: Player;
-  npcs: Npc[];
-  guards: Guard[];
-  doors: Door[];
-  interactiveObjects: InteractiveObject[];
-  environments?: Environment[];
-  actorConversationHistoryByActorId: ActorConversationHistoryByActorId;
-  lastItemUseAttemptEvent?: ItemUseAttemptResultEvent | null;
-  levelOutcome: 'win' | 'lose' | null;
-}
-
-export type WorldCommand =
-  | {
-      type: 'move';
-      dx: number;
-      dy: number;
-    }
-  | {
-      type: 'interact';
-    }
-  | {
-      type: 'selectInventorySlot';
-      slotIndex: number;
-    }
-  | {
-      type: 'useSelectedItem';
-    };
-
-export type IntentType = 'move' | 'wait' | 'interact';
-
-/**
- * Represents an action requested by any actor (player, NPC, scripted).
- * Intent is decoupled from input source (keyboard, LLM, etc.).
- * Deterministically resolved by resolveIntent() function.
- */
-export interface Intent {
-  actorId: string;
-  type: IntentType;
-  payload?: {
-    direction?: 'up' | 'down' | 'left' | 'right';
-    targetId?: string;
-    // Support arbitrary delta movement for backward compatibility during transition.
-    // Preferred path uses direction; delta is fallback for legacy movement vectors.
-    delta?: { dx: number; dy: number };
-  };
-}
-
-export interface World {
-  getState(): WorldState;
-  applyCommands(commands: WorldCommand[]): void;
-  resetToState(state: WorldState): void;
-}
+// Command and intent types
+export type { WorldCommand, IntentType, Intent, World } from './types/command.js';

--- a/src/world/types/command.ts
+++ b/src/world/types/command.ts
@@ -1,0 +1,43 @@
+import type { WorldState } from './world-state.js';
+
+export type WorldCommand =
+  | {
+      type: 'move';
+      dx: number;
+      dy: number;
+    }
+  | {
+      type: 'interact';
+    }
+  | {
+      type: 'selectInventorySlot';
+      slotIndex: number;
+    }
+  | {
+      type: 'useSelectedItem';
+    };
+
+export type IntentType = 'move' | 'wait' | 'interact';
+
+/**
+ * Represents an action requested by any actor (player, NPC, scripted).
+ * Intent is decoupled from input source (keyboard, LLM, etc.).
+ * Deterministically resolved by resolveIntent() function.
+ */
+export interface Intent {
+  actorId: string;
+  type: IntentType;
+  payload?: {
+    direction?: 'up' | 'down' | 'left' | 'right';
+    targetId?: string;
+    // Support arbitrary delta movement for backward compatibility during transition.
+    // Preferred path uses direction; delta is fallback for legacy movement vectors.
+    delta?: { dx: number; dy: number };
+  };
+}
+
+export interface World {
+  getState(): WorldState;
+  applyCommands(commands: WorldCommand[]): void;
+  resetToState(state: WorldState): void;
+}

--- a/src/world/types/conversation.ts
+++ b/src/world/types/conversation.ts
@@ -1,0 +1,6 @@
+export interface ConversationMessage {
+  role: 'player' | 'assistant';
+  text: string;
+}
+
+export type ActorConversationHistoryByActorId = Record<string, ConversationMessage[]>;

--- a/src/world/types/door.ts
+++ b/src/world/types/door.ts
@@ -1,0 +1,11 @@
+import type { GameEntity } from './entity.js';
+
+/** A door that the player can pass through or be blocked by. */
+export interface Door extends GameEntity {
+  doorState: 'open' | 'closed' | 'locked';
+  outcome?: 'safe' | 'danger';
+  /** Item ID required to unlock this door (if set, door must be interacted with using this item) */
+  requiredItemId?: string;
+  /** Whether this door has been unlocked via item-use (persists unlock state; default: false) */
+  isUnlocked?: boolean;
+}

--- a/src/world/types/entity.ts
+++ b/src/world/types/entity.ts
@@ -1,0 +1,29 @@
+import type { GridPosition, SpriteSet } from './grid.js';
+import type { InventoryItem } from './inventory.js';
+
+/**
+ * Shared structural base for all game entities.
+ * All world entities share this common root. JSON-serializable.
+ */
+export interface GameEntity {
+  id: string;
+  position: GridPosition;
+  displayName: string;
+  spriteSet?: SpriteSet;
+  spriteAssetPath?: string;
+  /** Open-ended behavioral traits bag, readable by LLM prompt builders. */
+  traits?: Record<string, string>;
+  /** Open-ended facts bag for arbitrary key/value data, readable by LLM prompt builders. */
+  facts?: Record<string, string | number | boolean>;
+}
+
+/**
+ * Opt-in capability container for game entities.
+ * Capabilities are typed sub-objects; omit a key if the entity lacks that capability.
+ */
+export interface EntityCapabilities {
+  inventory?: { items: InventoryItem[] };
+  dialogue?: { threadId?: string };
+  patrol?: { path: GridPosition[] };
+  lock?: { isLocked: boolean; requiredItemId?: string };
+}

--- a/src/world/types/environment.ts
+++ b/src/world/types/environment.ts
@@ -1,0 +1,8 @@
+import type { GridPosition } from './grid.js';
+
+export interface Environment {
+  id: string;
+  displayName: string;
+  position: GridPosition;
+  isBlocking: boolean;
+}

--- a/src/world/types/grid.ts
+++ b/src/world/types/grid.ts
@@ -1,0 +1,18 @@
+export interface GridPosition {
+  x: number;
+  y: number;
+}
+
+export type SpriteDirection = 'front' | 'away' | 'left' | 'right';
+
+/**
+ * Serializable sprite configuration for entities with optional directional variants.
+ * `default` provides a deterministic base asset when a directional key is missing.
+ */
+export interface SpriteSet {
+  default?: string;
+  front?: string;
+  away?: string;
+  left?: string;
+  right?: string;
+}

--- a/src/world/types/guard.ts
+++ b/src/world/types/guard.ts
@@ -1,0 +1,15 @@
+import type { GameEntity } from './entity.js';
+import type { SpriteDirection } from './grid.js';
+import type { ItemUseRule } from './inventory.js';
+
+/** A guard entity that the player can interact with. */
+export interface Guard extends GameEntity {
+  guardState: 'idle' | 'patrolling' | 'alert';
+  facingDirection?: SpriteDirection;
+  /** Instance-specific knowledge this guard has (overrides or extends type-level knowledge). */
+  instanceKnowledge?: string;
+  /** Instance-specific behavior traits for this guard (overrides or extends type-level behavior). */
+  instanceBehavior?: string;
+  /** Deterministic item-use rules: item ID → rule definition */
+  itemUseRules?: Record<string, ItemUseRule>;
+}

--- a/src/world/types/inventory.ts
+++ b/src/world/types/inventory.ts
@@ -1,0 +1,46 @@
+export interface InventoryItem {
+  itemId: string;
+  displayName: string;
+  sourceObjectId: string;
+  pickedUpAtTick: number;
+}
+
+export interface PlayerInventory {
+  items: InventoryItem[];
+  selectedItem?: SelectedInventoryItem | null;
+}
+
+export interface SelectedInventoryItem {
+  slotIndex: number;
+  itemId: string;
+}
+
+/**
+ * Deterministic item-use rule for guards or objects.
+ * Defines whether an item can be used and what response to provide.
+ */
+export interface ItemUseRule {
+  allowed: boolean;
+  responseText: string;
+}
+
+export type ItemUseAttemptResult = 'no-selection' | 'no-target' | 'blocked' | 'success' | 'no-rule';
+
+export interface ItemUseAttemptResultEvent {
+  tick: number;
+  commandIndex: number;
+  selectedItem: SelectedInventoryItem | null;
+  result: ItemUseAttemptResult;
+  target: {
+    kind: 'door' | 'guard' | 'npc' | 'interactiveObject';
+    targetId: string;
+  } | null;
+  /** If a door was unlocked via correct item-use, contains the door ID */
+  doorUnlockedId?: string;
+  /** Type of entity affected by successful item-use rule (guard or object) */
+  affectedEntityType?: 'guard' | 'object';
+  /** ID of entity affected by successful item-use rule */
+  affectedEntityId?: string;
+  /** Response text from the applied item-use rule */
+  ruleResponseText?: string;
+}

--- a/src/world/types/level.ts
+++ b/src/world/types/level.ts
@@ -1,0 +1,118 @@
+import type { GridPosition, SpriteSet } from './grid.js';
+import type { InventoryItem, ItemUseRule } from './inventory.js';
+import type { NpcTriggers } from './npc.js';
+import type { LevelMetadata } from './world-state.js';
+
+export interface LevelPlayerDto {
+  x: number;
+  y: number;
+  spriteAssetPath?: string;
+  spriteSet?: SpriteSet;
+}
+
+export interface LevelGuardDto {
+  id: string;
+  displayName: string;
+  x: number;
+  y: number;
+  guardState: 'patrolling' | 'alert' | 'idle';
+  /** Behavioral traits bag. Use traits.truthMode for guard honesty ('truth-teller' | 'liar'). */
+  traits?: Record<string, string>;
+  spriteAssetPath?: string;
+  spriteSet?: SpriteSet;
+  /** Instance-specific knowledge this guard has. */
+  instanceKnowledge?: string;
+  /** Instance-specific behavior traits for this guard. */
+  instanceBehavior?: string;
+  /** Deterministic item-use rules: item ID -> rule definition */
+  itemUseRules?: Record<string, ItemUseRule>;
+}
+
+export interface LevelDoorDto {
+  id: string;
+  displayName: string;
+  x: number;
+  y: number;
+  doorState: 'open' | 'closed' | 'locked';
+  outcome?: 'safe' | 'danger';
+  /** Item ID required to unlock this door */
+  requiredItemId?: string;
+  spriteAssetPath?: string;
+  spriteSet?: SpriteSet;
+}
+
+export interface LevelNpcRiddleClueDto {
+  clueId: string;
+  doorId: string;
+  truthBehavior: 'truthful' | 'inverse';
+}
+
+export interface LevelNpcDto {
+  id: string;
+  displayName: string;
+  x: number;
+  y: number;
+  npcType: string;
+  patrol?: { path: GridPosition[] };
+  triggers?: NpcTriggers;
+  inventory?: InventoryItem[];
+  spriteAssetPath?: string;
+  spriteSet?: SpriteSet;
+  /** Instance-specific knowledge this NPC has. */
+  instanceKnowledge?: string;
+  /** Instance-specific behavior traits for this NPC. */
+  instanceBehavior?: string;
+  /** Riddle clue constraint for logic puzzle NPCs. */
+  riddleClue?: LevelNpcRiddleClueDto;
+}
+
+export interface LevelInteractiveObjectDto {
+  id: string;
+  displayName: string;
+  x: number;
+  y: number;
+  objectType: string;
+  interactionType: 'inspect' | 'use' | 'talk';
+  state: 'idle' | 'used';
+  pickupItem?: {
+    itemId: string;
+    displayName: string;
+  };
+  idleMessage?: string;
+  usedMessage?: string;
+  firstUseOutcome?: 'win' | 'lose';
+  spriteAssetPath?: string;
+  spriteSet?: SpriteSet;
+  capabilities?: {
+    containsItems?: boolean;
+    isActivatable?: boolean;
+    isLockable?: boolean;
+  };
+  /** Deterministic item-use rules: item ID -> rule definition */
+  itemUseRules?: Record<string, ItemUseRule>;
+}
+
+export interface LevelEnvironmentDto {
+  id: string;
+  displayName: string;
+  x: number;
+  y: number;
+  isBlocking: boolean;
+}
+
+/** Flat JSON representation of a level file (public/levels/*.json). Version-stamped for future migrations. */
+export interface LevelData {
+  version: number;
+  name: string;
+  premise: string;
+  goal: string;
+  objective?: string;
+  width: number;
+  height: number;
+  player: LevelPlayerDto;
+  guards: LevelGuardDto[];
+  doors: LevelDoorDto[];
+  npcs?: LevelNpcDto[];
+  interactiveObjects?: LevelInteractiveObjectDto[];
+  environments?: LevelEnvironmentDto[];
+}

--- a/src/world/types/level.ts
+++ b/src/world/types/level.ts
@@ -1,7 +1,6 @@
 import type { GridPosition, SpriteSet } from './grid.js';
 import type { InventoryItem, ItemUseRule } from './inventory.js';
 import type { NpcTriggers } from './npc.js';
-import type { LevelMetadata } from './world-state.js';
 
 export interface LevelPlayerDto {
   x: number;

--- a/src/world/types/npc.ts
+++ b/src/world/types/npc.ts
@@ -1,0 +1,48 @@
+import type { GameEntity } from './entity.js';
+import type { GridPosition } from './grid.js';
+import type { InventoryItem } from './inventory.js';
+
+/**
+ * Riddle clue constraint for an NPC in a logic puzzle.
+ * Defines what claim the NPC must make about a door's safety.
+ */
+export interface RiddleClue {
+  clueId: string;
+  doorId: string;
+  truthBehavior: 'truthful' | 'inverse';
+  /** Computed field: what the NPC must claim about the door's safety */
+  mustStateDoorAs: 'safe' | 'danger';
+}
+
+/**
+ * Human-readable riddle clue constraint for prompt context.
+ */
+export interface RiddleClueConstraint {
+  doorId: string;
+  mustStateDoorAs: 'safe' | 'danger';
+  constraint: string;
+}
+
+export interface TriggerEffect {
+  setFact: string;
+  value: string | boolean | number;
+}
+
+export interface NpcTriggers {
+  onApproach?: TriggerEffect;
+  onTalk?: TriggerEffect;
+}
+
+export interface Npc extends GameEntity {
+  npcType: string;
+  dialogueContextKey: string;
+  patrol?: { path: Array<{ x: number; y: number }> };
+  triggers?: NpcTriggers;
+  inventory?: InventoryItem[];
+  /** Instance-specific knowledge this NPC has (overrides or extends type-level knowledge). */
+  instanceKnowledge?: string;
+  /** Instance-specific behavior traits for this NPC (overrides or extends type-level behavior). */
+  instanceBehavior?: string;
+  /** Riddle clue constraint for logic puzzle NPCs. */
+  riddleClue?: RiddleClue;
+}

--- a/src/world/types/npc.ts
+++ b/src/world/types/npc.ts
@@ -1,5 +1,4 @@
 import type { GameEntity } from './entity.js';
-import type { GridPosition } from './grid.js';
 import type { InventoryItem } from './inventory.js';
 
 /**

--- a/src/world/types/object.ts
+++ b/src/world/types/object.ts
@@ -1,0 +1,29 @@
+import type { GameEntity } from './entity.js';
+import type { ItemUseRule } from './inventory.js';
+
+/**
+ * Capability flags define what an interactive object can do.
+ * Objects declare capabilities, and the interaction handler applies matching effects.
+ */
+export interface ObjectCapabilities {
+  containsItems?: boolean;
+  isActivatable?: boolean;
+  isLockable?: boolean;
+}
+
+export interface InteractiveObject extends GameEntity {
+  objectType: string;
+  interactionType: 'inspect' | 'use' | 'talk';
+  state: 'idle' | 'used';
+  pickupItem?: {
+    itemId: string;
+    displayName: string;
+  };
+  idleMessage?: string;
+  usedMessage?: string;
+  firstUseOutcome?: 'win' | 'lose';
+  /** Capability flags that drive behavior dispatch */
+  capabilities?: ObjectCapabilities;
+  /** Deterministic item-use rules: item ID → rule definition */
+  itemUseRules?: Record<string, ItemUseRule>;
+}

--- a/src/world/types/player.ts
+++ b/src/world/types/player.ts
@@ -1,0 +1,12 @@
+import type { GridPosition, SpriteDirection, SpriteSet } from './grid.js';
+import type { PlayerInventory } from './inventory.js';
+
+export interface Player {
+  id: string;
+  displayName: string;
+  position: GridPosition;
+  inventory: PlayerInventory;
+  facingDirection?: SpriteDirection;
+  spriteAssetPath?: string;
+  spriteSet?: SpriteSet;
+}

--- a/src/world/types/world-state.ts
+++ b/src/world/types/world-state.ts
@@ -1,0 +1,36 @@
+import type { Player } from './player.js';
+import type { Npc } from './npc.js';
+import type { Guard } from './guard.js';
+import type { Door } from './door.js';
+import type { InteractiveObject } from './object.js';
+import type { Environment } from './environment.js';
+import type { ActorConversationHistoryByActorId } from './conversation.js';
+import type { ItemUseAttemptResultEvent } from './inventory.js';
+
+export interface WorldGrid {
+  width: number;
+  height: number;
+  tileSize: number;
+}
+
+export interface LevelMetadata {
+  name: string;
+  premise: string;
+  goal: string;
+}
+
+export interface WorldState {
+  tick: number;
+  grid: WorldGrid;
+  levelMetadata: LevelMetadata;
+  levelObjective?: string;
+  player: Player;
+  npcs: Npc[];
+  guards: Guard[];
+  doors: Door[];
+  interactiveObjects: InteractiveObject[];
+  environments?: Environment[];
+  actorConversationHistoryByActorId: ActorConversationHistoryByActorId;
+  lastItemUseAttemptEvent?: ItemUseAttemptResultEvent | null;
+  levelOutcome: 'win' | 'lose' | null;
+}


### PR DESCRIPTION
## Summary

Partitions `src/world/types.ts` into domain-focused modules under `src/world/types/` while maintaining runtime behavior and preserving import stability through a barrel export.

## Changes

- Created domain-focused type modules:
  - `grid.ts` - GridPosition, SpriteDirection, SpriteSet
  - `entity.ts` - GameEntity, EntityCapabilities  
  - `player.ts` - Player
  - `inventory.ts` - Inventory and item-use types
  - `guard.ts` - Guard entities
  - `npc.ts` - NPC entities, riddle clues, triggers
  - `door.ts` - Door entities
  - `object.ts` - InteractiveObject and ObjectCapabilities
  - `environment.ts` - Environment entities
  - `conversation.ts` - Conversation history contracts
  - `level.ts` - Level DTOs and LevelData format
  - `world-state.ts` - WorldState, WorldGrid, LevelMetadata
  - `command.ts` - WorldCommand, Intent, World interface

- Maintained `src/world/types.ts` as a stable barrel export/facade
- Updated documentation to reflect the new modular structure
- All imports throughout the codebase continue to work without breaking changes

## Validation

- ✅ `npm run lint` - passes
- ✅ `npm run build` - passes
- ✅ `npm run test` - 443 tests pass
- ✅ No functional behavior changes
- ✅ No circular type imports

## Closes #169