### PR TITLE
#173 Runtime Ownership Cleanup: move runtimeController into src/runtime and align imports/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ The game enforces strict layer separation to support LLM-driven gameplay:
   /interaction    — NPC interaction flow and response formatting
   /input          — Input command buffering
   /llm            — LLM client boundary and stubs
-  /runtime        — Runtime composition (app wiring, fixed tick loop, bridge/coordinator modules)
-  runtimeController.ts — Simulation gate for pause state, command drain, and item-use callback boundaries
+  /runtime        — Runtime composition (app wiring, fixed tick loop, runtime controller, bridge/coordinator modules)
   main.ts         — Thin browser bootstrap that starts the runtime app
 ```
 
@@ -59,7 +58,7 @@ The current baseline runtime is composed in `src/runtime/createRuntimeApp.ts` an
 2. `src/runtime/createRuntimeApp.ts` wires the world, `RuntimeController`, render ports, modal coordinator, interaction bridge, and level-load orchestration.
 3. Keyboard input maps to `WorldCommand` values and is enqueued into `CommandBuffer`.
 4. `src/runtime/fixedTickLoop.ts` drives a fixed simulation tick of 100ms plus a per-frame render callback.
-5. `src/runtimeController.ts` drains buffered commands, gates them while paused or after level completion, applies deterministic world commands, and invokes the selected-item resolver callback boundary.
+5. `src/runtime/runtimeController.ts` drains buffered commands, gates them while paused or after level completion, applies deterministic world commands, and invokes the selected-item resolver callback boundary.
 6. `src/runtime/interactionResultBridge.ts` handles interact commands: door/object targets stay deterministic, while guard/NPC targets open the action-modal flow first and only cross the LLM boundary after chat is chosen.
 7. `src/runtime/modalCoordinator.ts` owns action/chat/inventory modal lifecycles and viewport pause presentation; `src/runtime/levelLoadOrchestration.ts` owns manifest loading, default-level startup, and reset flows.
 8. Every animation frame renders the latest world state through the Pixi render port and prints JSON state in the debug panel.

--- a/docs/ADD_COMMAND.md
+++ b/docs/ADD_COMMAND.md
@@ -63,11 +63,11 @@ const applyCommand = (worldState: WorldState, command: WorldCommand): WorldState
 ### 4. (Optional) Add Rendering
 If your command produces an event consumed by runtime orchestration (without direct world mutation):
 - add a deterministic resolver boundary in `src/interaction/*`
-- wire it through `src/runtimeController.ts` dependency callbacks
+- wire it through `src/runtime/runtimeController.ts` dependency callbacks
 - commit the resulting serializable event/state from the callback wiring in `src/runtime/createRuntimeApp.ts`
 
 If your command needs new runtime UI handoff behavior (for example, a modal or bridge callback):
-- keep command draining/gating in `src/runtimeController.ts`
+- keep command draining/gating in `src/runtime/runtimeController.ts`
 - keep interaction/result routing in `src/runtime/interactionResultBridge.ts`
 - keep modal lifecycle behavior in `src/runtime/modalCoordinator.ts`
 
@@ -79,7 +79,7 @@ If your command changes visual appearance through world state:
 Add focused tests:
 - input mapping tests in `src/input/keyboard.test.ts`
 - world command determinism tests in `src/world/world.test.ts`
-- runtime orchestration tests in `src/runtimeController.test.ts` when command effects route through runtime callbacks
+- runtime orchestration tests in `src/runtime/runtimeController.test.ts` when command effects route through runtime callbacks
 - runtime bridge or modal-coordinator tests in `src/runtime/*.test.ts` when the command changes runtime handoff behavior
 
 ```typescript
@@ -102,7 +102,7 @@ test('emits deterministic item-use event for each useSelectedItem command', () =
 - [ ] Input mapping added to `src/input/keyboard.ts`
 - [ ] Command application logic added to `src/world/world.ts`
 - [ ] Unit tests written in `src/world/world.test.ts`
-- [ ] Runtime-controller tests added in `src/runtimeController.test.ts` when command uses callback/resolver boundaries
+- [ ] Runtime-controller tests added in `src/runtime/runtimeController.test.ts` when command uses callback/resolver boundaries
 - [ ] (Optional) Render updates in `src/render/scene.ts`
 - [ ] Input layer tests in `src/input/keyboard.test.ts`
 - [ ] State remains JSON-serializable

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,7 +84,7 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 Runtime composition entry points:
 - `src/main.ts`: validates `#app` and starts the runtime app.
 - `src/runtime/createRuntimeApp.ts`: composition root that wires world, runtime controller, render ports, interaction bridge, modal coordinator, and level orchestration.
-- `src/runtimeController.ts`: drains command input, enforces pause and level-outcome gating, and invokes deterministic item-use callback boundaries.
+- `src/runtime/runtimeController.ts`: drains command input, enforces pause and level-outcome gating, and invokes deterministic item-use callback boundaries.
 - `src/runtime/fixedTickLoop.ts`: fixed-timestep simulation loop + per-frame render callback.
 - `src/runtime/interactionResultBridge.ts`: interaction dispatch/result routing and conversation send bridge.
 - `src/runtime/modalCoordinator.ts`: chat/action/inventory modal lifecycle and viewport pause overlay semantics.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,8 +17,8 @@ Guard Game enforces strict layer separation to support deterministic world updat
   /interaction         - Interaction dispatch + result routing across target kinds
   /input               - Input command buffering and keyboard mapping
   /llm                 - LLM client boundary and context generation stubs
-  /runtime             - Runtime composition modules (bootstrap app, loop, level orchestration, modal + interaction bridges)
-  runtimeController.ts - Runtime simulation coordinator: pause/resume and command drain semantics
+       /runtime             - Runtime composition modules (bootstrap app, loop, level orchestration, simulation control, and modal + interaction bridges)
+                             runtimeController.ts - Runtime simulation coordinator: pause/resume and command drain semantics
   main.ts              - Thin bootstrap shell that invokes runtime composition root
 ```
 

--- a/docs/EXTEND_STATE.md
+++ b/docs/EXTEND_STATE.md
@@ -18,7 +18,7 @@ Validation/deserialization:
 - `src/world/level.ts`
 
 Runtime state commit:
-- `src/world/world.ts`, `src/runtimeController.ts`, and callback wiring in `src/runtime/createRuntimeApp.ts`
+- `src/world/world.ts`, `src/runtime/runtimeController.ts`, and callback wiring in `src/runtime/createRuntimeApp.ts`
 
 ## State Extension Workflow
 
@@ -116,9 +116,9 @@ Required follow-up updates:
 - type updates in `src/world/types.ts`
 - deterministic default initialization in `src/world/state.ts` and `src/world/level.ts`
 - deterministic command handling in `src/world/world.ts` for `selectInventorySlot`
-- runtime command-indexed event emission in `src/runtimeController.ts` using an item-use resolver boundary
+- runtime command-indexed event emission in `src/runtime/runtimeController.ts` using an item-use resolver boundary
 - immutable event commit wiring in `src/runtime/createRuntimeApp.ts`
-- regression tests in `src/world/world.test.ts`, `src/runtimeController.test.ts`, and `src/input/keyboard.test.ts`
+- regression tests in `src/world/world.test.ts`, `src/runtime/runtimeController.test.ts`, and `src/input/keyboard.test.ts`
 
 ## Checklist
 

--- a/docs/GAME_DESIGN_BASELINE.md
+++ b/docs/GAME_DESIGN_BASELINE.md
@@ -64,7 +64,7 @@ Implemented systems:
   - Item-use attempt resolver boundary:
     - Runtime detects each `useSelectedItem` command in tick order.
     - Resolver emits deterministic per-command result events (`no-selection` or `no-target` currently).
-    - `src/runtimeController.ts` resolves item-use attempt events during tick processing, and `src/runtime/createRuntimeApp.ts` commits the latest event to `worldState.lastItemUseAttemptEvent` through the runtime callback.
+    - `src/runtime/runtimeController.ts` resolves item-use attempt events during tick processing, and `src/runtime/createRuntimeApp.ts` commits the latest event to `worldState.lastItemUseAttemptEvent` through the runtime callback.
 - Runtime UI wiring:
   - Level picker and reset.
   - Level objective panel in runtime controls.

--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -229,7 +229,7 @@ See `src/interaction/guardInteraction.ts`, `src/interaction/npcInteraction.ts`, 
 
 - `src/interaction/interactionDispatcher.test.ts`: dispatch routing by kind, sync/async behavior parity, result dispatcher timing parity, door/object non-pause guarantee
 - `src/interaction/actionModalRouting.test.ts`: action-modal eligibility and session creation for guard/NPC targets
-- `src/runtimeController.test.ts`: pause entry/exit lifecycle, command gating while paused, resume without command leak, level-outcome gating independent of pause state
+- `src/runtime/runtimeController.test.ts`: pause entry/exit lifecycle, command gating while paused, resume without command leak, level-outcome gating independent of pause state
 - `src/interaction/npcPromptContext.test.ts`: profile registry resolution, deterministic fallback, world knowledge builder registry keys, alias resolution (`archive_keeper → villager`), self-exclusion from `otherVillagers`, unknown-type `null` fallback, context shape determinism
 - `src/interaction/objectInteraction.test.ts`: polymorphic object dispatch, first-use outcomes, repeat interactions
 - `src/integration/riddleLevel.test.ts`: end-to-end adjacent door resolution and deterministic outcome mapping

--- a/docs/TESTING_PATTERNS.md
+++ b/docs/TESTING_PATTERNS.md
@@ -111,7 +111,7 @@ Guard Game uses a layered testing approach aligned with architectural boundaries
 - **What to test:** Tick-time command gating, pause semantics, command-indexed callbacks, and state-commit orchestration that intentionally lives outside the pure world layer
 - **Type:** Unit tests
 - **Pattern:** Enqueue commands into `CommandBuffer`, step `RuntimeController`, then assert callback order and payloads against the resulting world snapshot
-- **Item-use pipeline checks** (`src/runtimeController.test.ts`):
+- **Item-use pipeline checks** (`src/runtime/runtimeController.test.ts`):
   - each `useSelectedItem` command emits exactly one deterministic `ItemUseAttemptResultEvent`
   - emitted events preserve the original command index from the drained tick list
   - no selected item resolves to `no-selection`

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -31,7 +31,7 @@ Source of truth:
 - `src/interaction/npcPromptContext.ts`
 - `src/interaction/objectInteraction.ts`
 - `src/interaction/adjacencyResolver.ts`
-- `src/runtimeController.ts`
+- `src/runtime/runtimeController.ts`
 - `src/render/viewportOverlay.ts`
 - `src/render/chatModal.ts`
 - `src/render/inventoryOverlay.ts`

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -131,7 +131,7 @@ Deterministic rules:
 Deterministic rules:
 - New runtime state initializes `lastItemUseAttemptEvent` to `null`.
 - Level deserialization also initializes `lastItemUseAttemptEvent` to `null`.
-- `src/runtimeController.ts` emits one event per `useSelectedItem` command using command index ordering within the tick.
+- `src/runtime/runtimeController.ts` emits one event per `useSelectedItem` command using command index ordering within the tick.
 - The callback wiring in `src/runtime/createRuntimeApp.ts` commits each emitted event immutably, so the last one in a tick becomes the stored event.
 
 ### Door Unlock State

--- a/src/interaction/actionModalRouting.ts
+++ b/src/interaction/actionModalRouting.ts
@@ -1,4 +1,4 @@
-import type { RuntimeActionModalSession } from '../runtimeController';
+import type { RuntimeActionModalSession } from '../runtime/runtimeController';
 import type { AdjacentTarget } from './adjacencyResolver';
 
 export type ActionModalEligibleTarget = Extract<AdjacentTarget, { kind: 'guard' | 'npc' }>;

--- a/src/runtime/createRuntimeApp.ts
+++ b/src/runtime/createRuntimeApp.ts
@@ -12,7 +12,7 @@ import {
   createRuntimeController,
   type RuntimeActionModalSession,
   type RuntimeController,
-} from '../runtimeController';
+} from './runtimeController';
 import { createDefaultItemUseResolver } from '../interaction/itemUse';
 import { createInteractionDispatcher } from '../interaction/interactionDispatcher';
 import { createWorld } from '../world/world';

--- a/src/runtime/interactionResultBridge.ts
+++ b/src/runtime/interactionResultBridge.ts
@@ -10,7 +10,7 @@ import {
   type InteractionDispatcher,
 } from '../interaction/interactionDispatcher';
 import { getActorConversationHistory } from '../interaction/actorConversationThread';
-import type { RuntimeActionModalSession } from '../runtimeController';
+import type { RuntimeActionModalSession } from './runtimeController';
 
 export interface RuntimeInteractionResultBridgeDependencies {
   world: Pick<{ getState: () => WorldState; resetToState: (worldState: WorldState) => void }, 'getState' | 'resetToState'>;

--- a/src/runtime/modalCoordinator.test.ts
+++ b/src/runtime/modalCoordinator.test.ts
@@ -6,7 +6,7 @@ import type {
   RuntimeActionModalSession,
   RuntimeController,
   RuntimeConversationSession,
-} from '../runtimeController';
+} from './runtimeController';
 import type { WorldState } from '../world/types';
 
 const createWorldState = (): WorldState => ({

--- a/src/runtime/modalCoordinator.ts
+++ b/src/runtime/modalCoordinator.ts
@@ -6,7 +6,7 @@ import type {
   RuntimeActionModalSession,
   RuntimeController,
   RuntimeConversationSession,
-} from '../runtimeController';
+} from './runtimeController';
 import type { ConversationMessage, WorldState } from '../world/types';
 
 export interface RuntimeModalCoordinatorDependencies {

--- a/src/runtime/runtimeController.test.ts
+++ b/src/runtime/runtimeController.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createCommandBuffer } from './input/commands';
+import { createCommandBuffer } from '../input/commands';
 import { createRuntimeController } from './runtimeController';
-import { createDefaultItemUseResolver } from './interaction/itemUse';
-import type { World, WorldCommand, WorldState } from './world/types';
+import { createDefaultItemUseResolver } from '../interaction/itemUse';
+import type { World, WorldCommand, WorldState } from '../world/types';
 
 const createTestWorldState = (
   overrides?: Omit<Partial<WorldState>, 'player'> & { player?: Partial<WorldState['player']> },

--- a/src/runtime/runtimeController.ts
+++ b/src/runtime/runtimeController.ts
@@ -1,7 +1,7 @@
-import type { CommandBuffer } from './input/commands';
-import type { ItemUseResolver } from './interaction/itemUse';
-import type { ItemUseAttemptResultEvent } from './world/types';
-import type { World, WorldCommand, WorldState } from './world/types';
+import type { CommandBuffer } from '../input/commands';
+import type { ItemUseResolver } from '../interaction/itemUse';
+import type { ItemUseAttemptResultEvent } from '../world/types';
+import type { World, WorldCommand, WorldState } from '../world/types';
 
 export interface RuntimeConversationSession {
   actorId: string;


### PR DESCRIPTION
## Summary
- move the runtime controller and its focused test into `src/runtime/`
- update all code imports to the new runtime module path without adding a compatibility re-export
- align README and architecture/testing docs with the new controller location

## Validation
- `npm run lint`
- `npm run build`
- `npm run test`

Closes #173