### PR TITLE
#178 propagate LLM unavailability as structured error

### DIFF
--- a/src/interaction/guardInteraction.test.ts
+++ b/src/interaction/guardInteraction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createInitialWorldState } from '../world/state';
-import { MISSING_API_KEY_FALLBACK_TEXT, REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
+import { isLlmRequestError, type LlmClient } from '../llm/client';
 import { GUARD_PERSONA_CONTRACT } from './guardPromptContext';
 import { createGuardInteractionService, handleGuardInteraction } from './guardInteraction';
 import { GuardNpc } from '../world/entities/npcs/GuardNpc';
@@ -132,9 +132,12 @@ describe('createGuardInteractionService', () => {
     expect(parsedContext.world.doors).toEqual([]);
   });
 
-  it('preserves deterministic missing-api-key fallback text from llm boundary', async () => {
+  it('propagates structured error when llm client returns missing-api-key error', async () => {
     const llmClient: LlmClient = {
-      complete: async () => ({ text: MISSING_API_KEY_FALLBACK_TEXT }),
+      complete: async () => ({
+        kind: 'llm_request_error' as const,
+        message: 'API key is not configured.',
+      }),
     };
     const service = createGuardInteractionService(llmClient);
     const worldState = createInitialWorldState();
@@ -147,12 +150,36 @@ describe('createGuardInteractionService', () => {
       playerMessage: 'Status?',
     });
 
-    expect(result.responseText).toBe(`Guard: ${MISSING_API_KEY_FALLBACK_TEXT}`);
+    expect(isLlmRequestError(result.llmError!)).toBe(true);
+    expect(result.responseText).toBe('');
   });
 
-  it('returns deterministic request-failure fallback when llm call throws', async () => {
+  it('does not append assistant message to history when llm returns structured error', async () => {
     const llmClient: LlmClient = {
-      complete: async () => {
+      complete: async () => ({
+        kind: 'llm_request_error' as const,
+        message: 'API key is not configured.',
+      }),
+    };
+    const service = createGuardInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    worldState.guards = [makeGuard('idle')];
+
+    const result = await service.handleGuardInteraction({
+      guard: worldState.guards[0],
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Status?',
+    });
+
+    const history =
+      result.updatedWorldState.actorConversationHistoryByActorId['guard-1'] ?? [];
+    expect(history.at(-1)?.role).toBe('player');
+  });
+
+  it('propagates structured error when llm call throws', async () => {
+    const llmClient: LlmClient = {
+      complete: async (): Promise<never> => {
         throw new Error('network down');
       },
     };
@@ -167,6 +194,10 @@ describe('createGuardInteractionService', () => {
       playerMessage: 'Any trouble?',
     });
 
-    expect(result.responseText).toBe(`Guard: ${REQUEST_FAILURE_FALLBACK_TEXT}`);
+    expect(isLlmRequestError(result.llmError!)).toBe(true);
+    expect(result.responseText).toBe('');
+    const history =
+      result.updatedWorldState.actorConversationHistoryByActorId['guard-1'] ?? [];
+    expect(history.at(-1)?.role).toBe('player');
   });
 });

--- a/src/interaction/guardInteraction.ts
+++ b/src/interaction/guardInteraction.ts
@@ -1,4 +1,4 @@
-import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
+import { isLlmRequestError, type LlmRequestError, type LlmClient } from '../llm/client';
 import type { ConversationMessage, Guard, Player, WorldState } from '../world/types';
 import { buildGuardPromptContext } from './guardPromptContext';
 
@@ -10,6 +10,7 @@ export interface GuardInteractionRequest {
 export interface GuardInteractionResult {
   guardId: string;
   responseText: string;
+  llmError?: LlmRequestError;
 }
 
 export interface GuardLlmInteractionResult extends GuardInteractionResult {
@@ -52,16 +53,36 @@ export const createGuardInteractionService = (llmClient: LlmClient): GuardIntera
     };
     const historyWithPlayerMessage = [...previousHistory, playerMessageRecord];
 
-    const assistantText = await llmClient
+    const llmResult = await llmClient
       .complete({
         actorId: request.guard.id,
         context: buildGuardPromptContext(request.guard, request.worldState),
         playerMessage: request.playerMessage,
         conversationHistory: historyWithPlayerMessage,
       })
-      .then((llmResponse) => llmResponse.text)
-      .catch(() => REQUEST_FAILURE_FALLBACK_TEXT);
+      .catch((err: unknown): LlmRequestError => ({
+        kind: 'llm_request_error',
+        message: err instanceof Error ? err.message : 'Unknown error',
+      }));
 
+    if (isLlmRequestError(llmResult)) {
+      const updatedWorldState: WorldState = {
+        ...request.worldState,
+        actorConversationHistoryByActorId: {
+          ...request.worldState.actorConversationHistoryByActorId,
+          [request.guard.id]: historyWithPlayerMessage,
+        },
+      };
+
+      return {
+        guardId: request.guard.id,
+        responseText: '',
+        llmError: llmResult,
+        updatedWorldState,
+      };
+    }
+
+    const assistantText = llmResult.text;
     const assistantMessageRecord: ConversationMessage = {
       role: 'assistant',
       text: assistantText,

--- a/src/interaction/interactionDispatcherTypes.ts
+++ b/src/interaction/interactionDispatcherTypes.ts
@@ -1,4 +1,4 @@
-import type { LlmClient } from '../llm/client';
+import type { LlmClient, LlmRequestError } from '../llm/client';
 import type { ConversationMessage, WorldState } from '../world/types';
 import type { AdjacentTarget } from './adjacencyResolver';
 
@@ -10,6 +10,7 @@ export interface InteractionHandlerResult {
   updatedWorldState?: WorldState;
   levelOutcome?: 'win' | 'lose' | null;
   isConversational: boolean;
+  llmError?: LlmRequestError;
 }
 
 export type InteractionDispatchResult = InteractionHandlerResult | Promise<InteractionHandlerResult>;

--- a/src/interaction/interactionHandlerRegistry.ts
+++ b/src/interaction/interactionHandlerRegistry.ts
@@ -101,6 +101,7 @@ export const createGuardHandler = (llmClient: LlmClient): ConditionalInteraction
         responseText: result.responseText,
         updatedWorldState: result.updatedWorldState,
         isConversational: true,
+        llmError: result.llmError,
       }));
   };
 };
@@ -137,6 +138,7 @@ export const createNpcHandler = (llmClient: LlmClient): ConditionalInteractionHa
         responseText: result.responseText,
         updatedWorldState: result.updatedWorldState,
         isConversational: true,
+        llmError: result.llmError,
       }));
   };
 };

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
+import { isLlmRequestError, type LlmClient } from '../llm/client';
 import { createNpcInteractionService } from './npcInteraction';
 import { renderActorConversationThread } from './actorConversationThread';
 import { createInitialWorldState } from '../world/state';
@@ -102,9 +102,9 @@ describe('createNpcInteractionService', () => {
     ]);
   });
 
-  it('stores deterministic fallback assistant text when llm request throws', async () => {
+  it('propagates structured error and does not append assistant message when llm request throws', async () => {
     const llmClient: LlmClient = {
-      complete: async () => {
+      complete: async (): Promise<never> => {
         throw new Error('timeout');
       },
     };
@@ -119,11 +119,10 @@ describe('createNpcInteractionService', () => {
       playerMessage: 'Can you hear me?',
     });
 
-    expect(result.responseText).toBe(`Archivist: ${REQUEST_FAILURE_FALLBACK_TEXT}`);
-    expect(result.updatedWorldState.actorConversationHistoryByActorId[npc.id]).toEqual([
-      { role: 'player', text: 'Can you hear me?' },
-      { role: 'assistant', text: REQUEST_FAILURE_FALLBACK_TEXT },
-    ]);
+    expect(isLlmRequestError(result.llmError!)).toBe(true);
+    expect(result.responseText).toBe('');
+    const history = result.updatedWorldState.actorConversationHistoryByActorId[npc.id] ?? [];
+    expect(history).toEqual([{ role: 'player', text: 'Can you hear me?' }]);
   });
 
   it('keeps conversation history JSON-serializable', async () => {

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -1,4 +1,4 @@
-import { REQUEST_FAILURE_FALLBACK_TEXT, type LlmClient } from '../llm/client';
+import { isLlmRequestError, type LlmRequestError, type LlmClient } from '../llm/client';
 import { Item } from '../world/entities/items/Item';
 import type { ConversationMessage, Npc, Player, WorldState } from '../world/types';
 import { buildNpcPromptContext } from './npcPromptContext';
@@ -117,6 +117,7 @@ export interface NpcInteractionResult {
   npcId: string;
   responseText: string;
   updatedWorldState: WorldState;
+  llmError?: LlmRequestError;
 }
 
 export interface NpcInteractionService {
@@ -133,16 +134,37 @@ export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractio
     };
     const historyWithPlayerMessage = [...previousHistory, playerMessageRecord];
 
-    const llmResponse = await llmClient
+    const llmResult = await llmClient
       .complete({
         actorId: request.npc.id,
         context: buildNpcPromptContext(request.npc, request.player, request.worldState),
         playerMessage: request.playerMessage,
         conversationHistory: historyWithPlayerMessage,
       })
-      .catch(() => ({ text: REQUEST_FAILURE_FALLBACK_TEXT }));
+      .catch((err: unknown): LlmRequestError => ({
+        kind: 'llm_request_error',
+        message: err instanceof Error ? err.message : 'Unknown error',
+      }));
 
-    const assistantText = llmResponse.text;
+    if (isLlmRequestError(llmResult)) {
+      const updatedHistoryByActorId = {
+        ...request.worldState.actorConversationHistoryByActorId,
+        [request.npc.id]: historyWithPlayerMessage,
+      };
+      const updatedWorldState: WorldState = {
+        ...request.worldState,
+        actorConversationHistoryByActorId: updatedHistoryByActorId,
+      };
+
+      return {
+        npcId: request.npc.id,
+        responseText: '',
+        llmError: llmResult,
+        updatedWorldState,
+      };
+    }
+
+    const assistantText = llmResult.text;
 
     const assistantMessageRecord: ConversationMessage = {
       role: 'assistant',
@@ -165,7 +187,7 @@ export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractio
     const inventoryResult = applyInventoryOutcome(
       npcAfterTalkTrigger,
       stateWithUpdatedHistory.player,
-      'outcome' in llmResponse ? llmResponse.outcome : undefined,
+      'outcome' in llmResult ? llmResult.outcome : undefined,
     );
 
     const updatedWorldState: WorldState = {

--- a/src/llm/client.test.ts
+++ b/src/llm/client.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   createGeminiLlmClient,
-  MISSING_API_KEY_FALLBACK_TEXT,
-  REQUEST_FAILURE_FALLBACK_TEXT,
+  isLlmRequestError,
 } from './client';
 
 const prompt = {
@@ -48,12 +47,18 @@ describe('createGeminiLlmClient', () => {
     const response = await client.complete(prompt);
 
     expect(fetchImpl).not.toHaveBeenCalled();
-    expect(response).toEqual({ text: MISSING_API_KEY_FALLBACK_TEXT });
+    expect(isLlmRequestError(response)).toBe(true);
+    if (isLlmRequestError(response)) {
+      expect(response.kind).toBe('llm_request_error');
+      expect(typeof response.message).toBe('string');
+      expect(response.statusCode).toBeUndefined();
+    }
   });
 
-  it('returns deterministic fallback when request fails', async () => {
+  it('returns structured error when request returns non-ok status', async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: false,
+      status: 503,
       json: async () => ({}),
     }));
 
@@ -64,10 +69,14 @@ describe('createGeminiLlmClient', () => {
 
     const response = await client.complete(prompt);
 
-    expect(response).toEqual({ text: REQUEST_FAILURE_FALLBACK_TEXT });
+    expect(isLlmRequestError(response)).toBe(true);
+    if (isLlmRequestError(response)) {
+      expect(response.kind).toBe('llm_request_error');
+      expect(response.statusCode).toBe(503);
+    }
   });
 
-  it('returns deterministic fallback when fetch throws', async () => {
+  it('returns structured error when fetch throws (network failure)', async () => {
     const fetchImpl = vi.fn(async () => {
       throw new Error('network down');
     });
@@ -79,6 +88,27 @@ describe('createGeminiLlmClient', () => {
 
     const response = await client.complete(prompt);
 
-    expect(response).toEqual({ text: REQUEST_FAILURE_FALLBACK_TEXT });
+    expect(isLlmRequestError(response)).toBe(true);
+    if (isLlmRequestError(response)) {
+      expect(response.kind).toBe('llm_request_error');
+      expect(response.statusCode).toBeUndefined();
+    }
+  });
+
+  it('does not append assistant fallback text on failure (no text property on error)', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    }));
+
+    const client = createGeminiLlmClient({
+      apiKey: 'test-key',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await client.complete(prompt);
+
+    expect('text' in response).toBe(false);
   });
 });

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -18,8 +18,18 @@ export interface LlmResponse {
   };
 }
 
+export interface LlmRequestError {
+  kind: 'llm_request_error';
+  message: string;
+  statusCode?: number;
+}
+
+export const isLlmRequestError = (
+  result: LlmResponse | LlmRequestError,
+): result is LlmRequestError => 'kind' in result && result.kind === 'llm_request_error';
+
 export interface LlmClient {
-  complete(prompt: LlmPrompt): Promise<LlmResponse>;
+  complete(prompt: LlmPrompt): Promise<LlmResponse | LlmRequestError>;
 }
 
 export interface GeminiLlmClientOptions {
@@ -72,9 +82,12 @@ export const createGeminiLlmClient = (options: GeminiLlmClientOptions = {}): Llm
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   return {
-    complete: async (prompt: LlmPrompt): Promise<LlmResponse> => {
+        complete: async (prompt: LlmPrompt): Promise<LlmResponse | LlmRequestError> => {
       if (!apiKey) {
-        return { text: MISSING_API_KEY_FALLBACK_TEXT };
+        return {
+          kind: 'llm_request_error' as const,
+          message: 'API key is not configured.',
+        };
       }
 
       const abortController = new AbortController();
@@ -107,18 +120,28 @@ export const createGeminiLlmClient = (options: GeminiLlmClientOptions = {}): Llm
         );
 
         if (!response.ok) {
-          return { text: REQUEST_FAILURE_FALLBACK_TEXT };
+          return {
+            kind: 'llm_request_error' as const,
+            message: 'LLM request failed.',
+            statusCode: response.status,
+          };
         }
 
         const payload = (await response.json()) as unknown;
         const text = extractGeminiText(payload);
         if (!text) {
-          return { text: REQUEST_FAILURE_FALLBACK_TEXT };
+          return {
+            kind: 'llm_request_error' as const,
+            message: 'Empty or unparseable response from LLM.',
+          };
         }
 
         return { text };
       } catch {
-        return { text: REQUEST_FAILURE_FALLBACK_TEXT };
+        return {
+          kind: 'llm_request_error' as const,
+          message: 'Network request failed.',
+        };
       } finally {
         clearTimeout(timeout);
       }

--- a/src/runtime/interactionResultBridge.test.ts
+++ b/src/runtime/interactionResultBridge.test.ts
@@ -3,6 +3,7 @@ import { createRuntimeInteractionResultBridge } from './interactionResultBridge'
 import type { InteractionDispatcher, InteractionHandlerResult } from '../interaction/interactionDispatcher';
 import type { WorldState } from '../world/types';
 import type { Guard } from '../world/types';
+import type { LlmRequestError } from '../llm/client';
 
 const createWorldState = (
   overrides?: Omit<Partial<WorldState>, 'player'> & { player?: Partial<WorldState['player']> },
@@ -222,5 +223,116 @@ describe('createRuntimeInteractionResultBridge', () => {
 
     expect(didStartConversation).toBe(false);
     expect(interactionDispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('calls onLlmError and not onAssistantMessage when result carries llmError', async () => {
+    const llmError: LlmRequestError = { kind: 'llm_request_error', message: 'Service unavailable.', statusCode: 503 };
+    const initialState = createWorldState();
+    const stateWithPlayerMessage: WorldState = {
+      ...initialState,
+      actorConversationHistoryByActorId: {
+        ...initialState.actorConversationHistoryByActorId,
+        'guard-1': [
+          { role: 'player', text: 'Hello?' },
+          { role: 'assistant', text: 'State your purpose.' },
+          { role: 'player', text: 'Can I pass?' },
+        ],
+      },
+    };
+
+    let worldState = initialState;
+    const resetToState = vi.fn((nextState: WorldState) => {
+      worldState = nextState;
+    });
+
+    const interactionDispatcher = createInteractionDispatcherMock((playerMessage) => {
+      if (!playerMessage) {
+        return {
+          kind: 'guard',
+          targetId: 'guard-1',
+          displayName: 'Guard One',
+          isConversational: false,
+        };
+      }
+
+      return Promise.resolve({
+        kind: 'guard',
+        targetId: 'guard-1',
+        displayName: 'Guard One',
+        updatedWorldState: stateWithPlayerMessage,
+        isConversational: true,
+        llmError,
+      });
+    });
+
+    const bridge = createRuntimeInteractionResultBridge({
+      world: { getState: () => worldState, resetToState },
+      interactionDispatcher,
+      onActionModalStarted: vi.fn(),
+      onConversationStarted: vi.fn(),
+    });
+
+    const onAssistantMessage = vi.fn();
+    const onLlmError = vi.fn();
+    await bridge.sendConversationMessage('guard-1', 'Can I pass?', onAssistantMessage, onLlmError);
+
+    expect(onAssistantMessage).not.toHaveBeenCalled();
+    expect(onLlmError).toHaveBeenCalledWith(llmError);
+    expect(resetToState).toHaveBeenCalledWith(stateWithPlayerMessage);
+  });
+
+  it('does not call onLlmError or reset state when result has no error', async () => {
+    const initialState = createWorldState();
+    const updatedWorldState: WorldState = {
+      ...initialState,
+      actorConversationHistoryByActorId: {
+        ...initialState.actorConversationHistoryByActorId,
+        'guard-1': [
+          { role: 'player', text: 'Hello?' },
+          { role: 'assistant', text: 'State your purpose.' },
+          { role: 'player', text: 'Can I pass?' },
+          { role: 'assistant', text: 'Not yet.' },
+        ],
+      },
+    };
+
+    let worldState = initialState;
+    const resetToState = vi.fn((nextState: WorldState) => {
+      worldState = nextState;
+    });
+
+    const interactionDispatcher = createInteractionDispatcherMock((playerMessage) => {
+      if (!playerMessage) {
+        return {
+          kind: 'guard',
+          targetId: 'guard-1',
+          displayName: 'Guard One',
+          isConversational: false,
+        };
+      }
+
+      return Promise.resolve({
+        kind: 'guard',
+        targetId: 'guard-1',
+        displayName: 'Guard One',
+        updatedWorldState,
+        isConversational: true,
+      });
+    });
+
+    const bridge = createRuntimeInteractionResultBridge({
+      world: { getState: () => worldState, resetToState },
+      interactionDispatcher,
+      onActionModalStarted: vi.fn(),
+      onConversationStarted: vi.fn(),
+    });
+
+    const onAssistantMessage = vi.fn();
+    const onLlmError = vi.fn();
+    await bridge.sendConversationMessage('guard-1', 'Can I pass?', onAssistantMessage, onLlmError);
+
+    expect(onLlmError).not.toHaveBeenCalled();
+    expect(onAssistantMessage).toHaveBeenCalledWith('Not yet.');
+    expect(resetToState).toHaveBeenCalledWith(updatedWorldState);
   });
 });

--- a/src/runtime/interactionResultBridge.ts
+++ b/src/runtime/interactionResultBridge.ts
@@ -1,4 +1,5 @@
 import type { WorldCommand, WorldState, ConversationMessage } from '../world/types';
+import type { LlmRequestError } from '../llm/client';
 import { resolveAdjacentTarget, type AdjacentTarget } from '../interaction/adjacencyResolver';
 import {
   createActionModalSession,
@@ -31,6 +32,7 @@ export interface RuntimeInteractionResultBridge {
     actorId: string,
     playerMessage: string,
     onAssistantMessage: (message: string) => void,
+    onLlmError?: (error: LlmRequestError) => void,
   ): Promise<void>;
 }
 
@@ -111,6 +113,7 @@ export const createRuntimeInteractionResultBridge = (
       actorId: string,
       playerMessage: string,
       onAssistantMessage: (message: string) => void,
+      onLlmError?: (error: LlmRequestError) => void,
     ): Promise<void> {
       const currentWorldState = dependencies.world.getState();
       const target = dependencies.interactionDispatcher.resolveConversationalTarget(
@@ -126,6 +129,14 @@ export const createRuntimeInteractionResultBridge = (
         currentWorldState,
         playerMessage,
       );
+
+      if (result.llmError) {
+        if (result.updatedWorldState) {
+          dependencies.world.resetToState(result.updatedWorldState);
+        }
+        onLlmError?.(result.llmError);
+        return;
+      }
 
       const history = getActorConversationHistory(
         result.updatedWorldState ?? currentWorldState,

--- a/src/runtime/modalCoordinator.ts
+++ b/src/runtime/modalCoordinator.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeConversationSession,
 } from './runtimeController';
 import type { ConversationMessage, WorldState } from '../world/types';
+import type { LlmRequestError } from '../llm/client';
 
 export interface RuntimeModalCoordinatorDependencies {
   runtimeController: Pick<
@@ -31,6 +32,7 @@ export interface RuntimeModalCoordinatorDependencies {
     actorId: string,
     playerMessage: string,
     onAssistantMessage: (message: string) => void,
+    onLlmError?: (error: LlmRequestError) => void,
   ) => Promise<void>;
 }
 
@@ -66,6 +68,10 @@ export const createRuntimeModalCoordinator = (
           playerMessage,
           (assistantMessage: string) => {
             chatModal.appendMessage('assistant', assistantMessage);
+          },
+          (_error: LlmRequestError) => {
+            // Error rendering is deferred to follow-up ticket #177.
+            // Loading state is cleared so the UI is not left in a stuck state.
           },
         );
 


### PR DESCRIPTION
## Summary

Closes #178

Introduces a typed `LlmRequestError` contract so that LLM transport failures (HTTP 503, network throw, missing API key) are propagated as structured errors through the interaction layer and runtime bridge — instead of being converted to fake assistant text bubbles in the conversation thread.

### What changed

- **`src/llm/client.ts`** — Added `LlmRequestError` interface (`kind`, `message`, `statusCode`) and `isLlmRequestError` type guard. `createGeminiLlmClient.complete()` now returns `LlmRequestError` for 503/unavailable and thrown fetch errors rather than fallback text strings. Missing API key path is a deterministic early return. Fallback text constants are preserved for reference but are no longer emitted on the error path.
- **`src/interaction/interactionDispatcherTypes.ts`** — Interaction result type extended to carry `llmError` alongside the existing fields.
- **`src/interaction/interactionHandlerRegistry.ts`** — Handler results now thread `llmError` through to callers.
- **`src/interaction/guardInteraction.ts`** / **`src/interaction/npcInteraction.ts`** — On `LlmRequestError`, no assistant text is appended; the error is forwarded as `llmError` in the result.
- **`src/runtime/interactionResultBridge.ts`** — The result bridge accepts an optional `onLlmError` callback that fires when `llmError` is present; no fallback message is injected.
- **`src/runtime/modalCoordinator.ts`** — Passes `onLlmError` callback; keeps a stub comment referencing ticket #177 where UI rendering will be wired.

### Tests added

- `src/llm/client.test.ts`: 503 response returns `LlmRequestError`; network throw returns `LlmRequestError`; no assistant fallback text on failure.
- `src/interaction/guardInteraction.test.ts` / `src/interaction/npcInteraction.test.ts`: error path propagates `llmError`, no assistant message in result.
- `src/runtime/interactionResultBridge.test.ts`: `onLlmError` callback fires on error result; no fallback message appended.

### Validation

- `npm run lint` — ✅ clean
- `npm run build` — ✅ clean
- `npm run test` — ✅ 52 test files, 465 tests passed

### Notes

Implementation was completed as an incremental step on the existing main branch. The UI rendering side (showing error in the loading/status slot) is handled by ticket #177.
