### PR TITLE
Render chat request errors in loading/status slot (#177)

### DIFF
--- a/src/render/chatModal.test.ts
+++ b/src/render/chatModal.test.ts
@@ -124,4 +124,66 @@ describe('createChatModal', () => {
       expect(handle.isOpen()).toBe(false);
     });
   });
+
+  describe('status slot states', () => {
+    it('shows error text in the loading/status slot when setError is called', () => {
+      const { handle } = openModal(container);
+
+      handle.setError('Request failed. Please try again.');
+
+      const status = container.querySelector<HTMLDivElement>('.chat-modal-loading');
+      expect(status?.hidden).toBe(false);
+      expect(status?.textContent).toBe('Request failed. Please try again.');
+      expect(status?.getAttribute('aria-label')).toBe('Error');
+    });
+
+    it('hides the loading/status slot when setError is called with null', () => {
+      const { handle } = openModal(container);
+      handle.setError('Request failed. Please try again.');
+
+      handle.setError(null);
+
+      const status = container.querySelector<HTMLDivElement>('.chat-modal-loading');
+      expect(status?.hidden).toBe(true);
+    });
+
+    it('clears visible error state when loading starts', () => {
+      const { handle } = openModal(container);
+      handle.setError('Request failed. Please try again.');
+
+      handle.setLoading(true);
+
+      const status = container.querySelector<HTMLDivElement>('.chat-modal-loading');
+      expect(status?.hidden).toBe(false);
+      expect(status?.textContent).toBe('…');
+      expect(status?.getAttribute('aria-label')).toBe('Waiting for response');
+    });
+
+    it('replaces loading indicator with error text when setError is called', () => {
+      const { handle } = openModal(container);
+      handle.setLoading(true);
+
+      handle.setError('Request failed. Please try again.');
+
+      const status = container.querySelector<HTMLDivElement>('.chat-modal-loading');
+      expect(status?.hidden).toBe(false);
+      expect(status?.textContent).toBe('Request failed. Please try again.');
+      expect(status?.getAttribute('aria-label')).toBe('Error');
+    });
+
+    it('clears prior error state when the modal is reopened', () => {
+      const callbacks = makeCallbacks();
+      const handle = createChatModal(container, callbacks);
+      handle.open('actor-1', 'Guard', []);
+      handle.setError('Request failed. Please try again.');
+      handle.close();
+
+      handle.open('actor-1', 'Guard', []);
+
+      const status = container.querySelector<HTMLDivElement>('.chat-modal-loading');
+      expect(status?.hidden).toBe(true);
+      expect(status?.textContent).toBe('…');
+      expect(status?.getAttribute('aria-label')).toBe('Waiting for response');
+    });
+  });
 });

--- a/src/render/chatModal.ts
+++ b/src/render/chatModal.ts
@@ -14,6 +14,12 @@ export interface ChatModalHandle {
   appendMessage(role: 'player' | 'assistant', text: string): void;
   /** Show or hide the loading indicator; disables/enables input while loading. */
   setLoading(loading: boolean): void;
+  /**
+   * Show an error message in the loading/status slot, or clear it when null.
+   * Mutually exclusive with the loading state: setting error enables input;
+   * calling setLoading(true) clears any visible error.
+   */
+  setError(message: string | null): void;
   /** Returns true when the panel is visible. */
   isOpen(): boolean;
 }
@@ -27,6 +33,7 @@ export function createChatModal(
   callbacks: ChatModalCallbacks,
 ): ChatModalHandle {
   let open = false;
+  let errorText: string | null = null;
 
   // --- Build DOM skeleton ---
   const overlay = document.createElement('div');
@@ -182,7 +189,10 @@ export function createChatModal(
       document.addEventListener('keydown', escapeListener);
       input.disabled = false;
       sendBtn.disabled = false;
+      errorText = null;
       loadingEl.hidden = true;
+      loadingEl.textContent = '\u2026';
+      loadingEl.setAttribute('aria-label', 'Waiting for response');
       input.value = '';
       input.focus();
     },
@@ -196,10 +206,33 @@ export function createChatModal(
     },
 
     setLoading(loading: boolean): void {
-      loadingEl.hidden = !loading;
-      input.disabled = loading;
-      sendBtn.disabled = loading;
-      if (!loading) {
+      if (loading) {
+        errorText = null;
+        loadingEl.textContent = '\u2026';
+        loadingEl.setAttribute('aria-label', 'Waiting for response');
+        loadingEl.hidden = false;
+        input.disabled = true;
+        sendBtn.disabled = true;
+      } else {
+        if (errorText === null) {
+          loadingEl.hidden = true;
+        }
+        input.disabled = false;
+        sendBtn.disabled = false;
+        input.focus();
+      }
+    },
+
+    setError(message: string | null): void {
+      errorText = message;
+      if (message === null) {
+        loadingEl.hidden = true;
+      } else {
+        loadingEl.textContent = message;
+        loadingEl.setAttribute('aria-label', 'Error');
+        loadingEl.hidden = false;
+        input.disabled = false;
+        sendBtn.disabled = false;
         input.focus();
       }
     },

--- a/src/runtime/modalCoordinator.test.ts
+++ b/src/runtime/modalCoordinator.test.ts
@@ -134,4 +134,127 @@ describe('createRuntimeModalCoordinator', () => {
     expect(pauseOverlay.show).toHaveBeenCalledTimes(2);
     expect(pauseOverlay.hide).not.toHaveBeenCalled();
   });
+
+  it('shows request error in status slot and does not append assistant bubble on failure', async () => {
+    document.body.innerHTML = `
+      <div id="chat-host"></div>
+      <div id="action-host"></div>
+      <div id="inventory-host"></div>
+    `;
+
+    const runtimeController = createRuntimeControllerMock(null);
+    const pauseOverlay = {
+      show: vi.fn(),
+      hide: vi.fn(),
+    };
+
+    const onSendConversationMessage = vi.fn(
+      async (
+        _actorId: string,
+        _playerMessage: string,
+        _onAssistantMessage: (message: string) => void,
+        onLlmError?: (error: { kind: 'llm_request_error'; message: string; statusCode?: number }) => void,
+      ) => {
+        onLlmError?.({ kind: 'llm_request_error', message: 'LLM request failed.', statusCode: 503 });
+      },
+    );
+
+    const coordinator = createRuntimeModalCoordinator({
+      runtimeController,
+      world: {
+        getState: () => createWorldState(),
+      },
+      viewportPauseOverlay: pauseOverlay,
+      chatModalHostElement: document.querySelector<HTMLElement>('#chat-host')!,
+      actionModalHostElement: document.querySelector<HTMLElement>('#action-host')!,
+      inventoryOverlayHostElement: document.querySelector<HTMLElement>('#inventory-host')!,
+      onOpenConversationForActionSession: vi.fn(() => true),
+      onSendConversationMessage,
+    });
+
+    coordinator.openConversation('guard-1', 'Guard One', [], 'guard');
+
+    const input = document.querySelector<HTMLInputElement>('.chat-modal-input');
+    const sendButton = document.querySelector<HTMLButtonElement>('.chat-modal-send-btn');
+    input!.value = 'State your orders.';
+    sendButton?.click();
+    await Promise.resolve();
+
+    const status = document.querySelector<HTMLDivElement>('.chat-modal-loading');
+    expect(status?.hidden).toBe(false);
+    expect(status?.textContent).toBe('Request failed. Please try again.');
+    expect(status?.getAttribute('aria-label')).toBe('Error');
+
+    const assistantBubbles = document.querySelectorAll('.chat-bubble-assistant');
+    expect(assistantBubbles).toHaveLength(0);
+  });
+
+  it('clears error state on next successful send and appends assistant bubble', async () => {
+    document.body.innerHTML = `
+      <div id="chat-host"></div>
+      <div id="action-host"></div>
+      <div id="inventory-host"></div>
+    `;
+
+    const runtimeController = createRuntimeControllerMock(null);
+    const pauseOverlay = {
+      show: vi.fn(),
+      hide: vi.fn(),
+    };
+
+    let callCount = 0;
+    const onSendConversationMessage = vi.fn(
+      async (
+        _actorId: string,
+        _playerMessage: string,
+        onAssistantMessage: (message: string) => void,
+        onLlmError?: (error: { kind: 'llm_request_error'; message: string; statusCode?: number }) => void,
+      ) => {
+        callCount += 1;
+        if (callCount === 1) {
+          onLlmError?.({ kind: 'llm_request_error', message: 'Network request failed.' });
+          return;
+        }
+
+        onAssistantMessage('Permission granted.');
+      },
+    );
+
+    const coordinator = createRuntimeModalCoordinator({
+      runtimeController,
+      world: {
+        getState: () => createWorldState(),
+      },
+      viewportPauseOverlay: pauseOverlay,
+      chatModalHostElement: document.querySelector<HTMLElement>('#chat-host')!,
+      actionModalHostElement: document.querySelector<HTMLElement>('#action-host')!,
+      inventoryOverlayHostElement: document.querySelector<HTMLElement>('#inventory-host')!,
+      onOpenConversationForActionSession: vi.fn(() => true),
+      onSendConversationMessage,
+    });
+
+    coordinator.openConversation('guard-1', 'Guard One', [], 'guard');
+
+    const input = document.querySelector<HTMLInputElement>('.chat-modal-input');
+    const sendButton = document.querySelector<HTMLButtonElement>('.chat-modal-send-btn');
+
+    input!.value = 'First attempt';
+    sendButton?.click();
+    await Promise.resolve();
+
+    let status = document.querySelector<HTMLDivElement>('.chat-modal-loading');
+    expect(status?.hidden).toBe(false);
+    expect(status?.textContent).toBe('Request failed. Please try again.');
+
+    input!.value = 'Second attempt';
+    sendButton?.click();
+    await Promise.resolve();
+
+    status = document.querySelector<HTMLDivElement>('.chat-modal-loading');
+    expect(status?.hidden).toBe(true);
+
+    const assistantBubbles = document.querySelectorAll('.chat-bubble-assistant');
+    expect(assistantBubbles).toHaveLength(1);
+    expect(assistantBubbles[0].textContent).toContain('Permission granted.');
+  });
 });

--- a/src/runtime/modalCoordinator.ts
+++ b/src/runtime/modalCoordinator.ts
@@ -59,6 +59,7 @@ export const createRuntimeModalCoordinator = (
       }
 
       const interaction: RuntimeConversationSession = currentInteraction;
+      chatModal.setError(null);
       chatModal.setLoading(true);
       chatModal.appendMessage('player', playerMessage);
 
@@ -70,8 +71,7 @@ export const createRuntimeModalCoordinator = (
             chatModal.appendMessage('assistant', assistantMessage);
           },
           (_error: LlmRequestError) => {
-            // Error rendering is deferred to follow-up ticket #177.
-            // Loading state is cleared so the UI is not left in a stuck state.
+            chatModal.setError('Request failed. Please try again.');
           },
         );
 


### PR DESCRIPTION
## Summary

Closes #177

Renders request failures in the chat modal status slot (where loading `…` appears) instead of adding assistant dialogue on failed turns.

## Changes

- Wire runtime chat send flow to clear prior error, show loading, and render request failure into the status slot.
- Add/extend tests for status-slot behavior and error-to-success transitions.

Files:
- src/runtime/modalCoordinator.ts
- src/render/chatModal.test.ts
- src/runtime/modalCoordinator.test.ts

## Validation

- Local validation has been run for:
  - npm run lint
  - npm run build
  - npm run test
