### PR TITLE
#188 Runtime/UI Handling for NPC Action Side-Effects

### DIFF
--- a/src/interaction/interactionDispatcherTypes.ts
+++ b/src/interaction/interactionDispatcherTypes.ts
@@ -1,6 +1,7 @@
 import type { LlmClient, LlmRequestError } from '../llm/client';
 import type { ConversationMessage, WorldState } from '../world/types';
 import type { AdjacentTarget } from './adjacencyResolver';
+import type { NpcActionExecutionResult } from './npcActionExecutor';
 
 export interface InteractionHandlerResult {
   kind: AdjacentTarget['kind'];
@@ -11,6 +12,7 @@ export interface InteractionHandlerResult {
   levelOutcome?: 'win' | 'lose' | null;
   isConversational: boolean;
   llmError?: LlmRequestError;
+  actionExecutionTrace?: NpcActionExecutionResult;
 }
 
 export type InteractionDispatchResult = InteractionHandlerResult | Promise<InteractionHandlerResult>;

--- a/src/interaction/interactionHandlerRegistry.ts
+++ b/src/interaction/interactionHandlerRegistry.ts
@@ -139,6 +139,7 @@ export const createNpcHandler = (llmClient: LlmClient): ConditionalInteractionHa
         updatedWorldState: result.updatedWorldState,
         isConversational: true,
         llmError: result.llmError,
+        actionExecutionTrace: result.actionExecutionTrace,
       }));
   };
 };

--- a/src/runtime/interactionResultBridge.test.ts
+++ b/src/runtime/interactionResultBridge.test.ts
@@ -416,7 +416,7 @@ describe('createRuntimeInteractionResultBridge', () => {
       dispatch: vi.fn((_target, _worldState, playerMessage) => {
         if (!playerMessage) {
           return {
-            kind: 'npc',
+            kind: 'npc' as const,
             targetId: 'npc-1',
             displayName: 'Archivist',
             isConversational: false,
@@ -424,7 +424,7 @@ describe('createRuntimeInteractionResultBridge', () => {
         }
 
         return Promise.resolve({
-          kind: 'npc',
+          kind: 'npc' as const,
           targetId: 'npc-1',
           displayName: 'Archivist',
           updatedWorldState,
@@ -435,7 +435,7 @@ describe('createRuntimeInteractionResultBridge', () => {
       }),
       resolveConversationalTarget: vi.fn((worldStateCandidate: WorldState, targetId: string) => {
         const npc = worldStateCandidate.npcs.find((candidate) => candidate.id === targetId);
-        return npc ? { kind: 'npc', target: npc } : null;
+        return npc ? { kind: 'npc' as const, target: npc } : null;
       }),
     };
 

--- a/src/runtime/interactionResultBridge.test.ts
+++ b/src/runtime/interactionResultBridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createRuntimeInteractionResultBridge } from './interactionResultBridge';
 import type { InteractionDispatcher, InteractionHandlerResult } from '../interaction/interactionDispatcher';
+import type { NpcActionExecutionResult } from '../interaction/npcActionExecutor';
 import type { WorldState } from '../world/types';
 import type { Guard } from '../world/types';
 import type { LlmRequestError } from '../llm/client';
@@ -190,10 +191,11 @@ describe('createRuntimeInteractionResultBridge', () => {
     });
 
     const onAssistantMessage = vi.fn();
-    await bridge.sendConversationMessage('guard-1', 'Can I pass?', onAssistantMessage);
+    const sendResult = await bridge.sendConversationMessage('guard-1', 'Can I pass?', onAssistantMessage);
 
     expect(onAssistantMessage).toHaveBeenCalledWith('Not yet.');
     expect(resetToState).toHaveBeenCalledWith(updatedWorldState);
+    expect(sendResult).toEqual({ endedConversation: false });
   });
 
   it('returns false when action-modal chat target can no longer be resolved', () => {
@@ -274,11 +276,17 @@ describe('createRuntimeInteractionResultBridge', () => {
 
     const onAssistantMessage = vi.fn();
     const onLlmError = vi.fn();
-    await bridge.sendConversationMessage('guard-1', 'Can I pass?', onAssistantMessage, onLlmError);
+    const sendResult = await bridge.sendConversationMessage(
+      'guard-1',
+      'Can I pass?',
+      onAssistantMessage,
+      onLlmError,
+    );
 
     expect(onAssistantMessage).not.toHaveBeenCalled();
     expect(onLlmError).toHaveBeenCalledWith(llmError);
     expect(resetToState).toHaveBeenCalledWith(stateWithPlayerMessage);
+    expect(sendResult).toEqual({ endedConversation: false });
   });
 
   it('does not call onLlmError or reset state when result has no error', async () => {
@@ -329,10 +337,124 @@ describe('createRuntimeInteractionResultBridge', () => {
 
     const onAssistantMessage = vi.fn();
     const onLlmError = vi.fn();
-    await bridge.sendConversationMessage('guard-1', 'Can I pass?', onAssistantMessage, onLlmError);
+    const sendResult = await bridge.sendConversationMessage(
+      'guard-1',
+      'Can I pass?',
+      onAssistantMessage,
+      onLlmError,
+    );
 
     expect(onLlmError).not.toHaveBeenCalled();
     expect(onAssistantMessage).toHaveBeenCalledWith('Not yet.');
     expect(resetToState).toHaveBeenCalledWith(updatedWorldState);
+    expect(sendResult).toEqual({ endedConversation: false });
+  });
+
+  it('returns endedConversation=true after npc action execution ends the chat and commits world updates', async () => {
+    const initialState = createWorldState({
+      guards: [],
+      npcs: [
+        {
+          id: 'npc-1',
+          displayName: 'Archivist',
+          position: { x: 4, y: 4 },
+          npcType: 'archive_keeper',
+          dialogueContextKey: 'archive_keeper_intro',
+        },
+      ],
+      actorConversationHistoryByActorId: {
+        'npc-1': [
+          { role: 'player', text: 'Hello?' },
+          { role: 'assistant', text: 'Proceed.' },
+        ],
+      },
+    });
+    const updatedWorldState: WorldState = {
+      ...initialState,
+      npcs: [
+        {
+          ...initialState.npcs[0],
+          position: { x: 5, y: 4 },
+        },
+      ],
+      actorConversationHistoryByActorId: {
+        'npc-1': [
+          { role: 'player', text: 'Hello?' },
+          { role: 'assistant', text: 'Proceed.' },
+          { role: 'player', text: 'Move and end this.' },
+          { role: 'assistant', text: 'Understood.' },
+        ],
+      },
+    };
+    const actionExecutionTrace: NpcActionExecutionResult = {
+      updatedWorldState,
+      endedChat: true,
+      steps: [
+        {
+          index: 0,
+          action: { name: 'move', arguments: { x: 5, y: 4 } },
+          status: 'success',
+          code: 'executed',
+          message: 'Moved to (5, 4).',
+        },
+        {
+          index: 1,
+          action: { name: 'end_chat', arguments: {} },
+          status: 'success',
+          code: 'executed',
+          message: 'Conversation ended.',
+        },
+      ],
+    };
+
+    let worldState = initialState;
+    const resetToState = vi.fn((nextState: WorldState) => {
+      worldState = nextState;
+    });
+
+    const interactionDispatcher: InteractionDispatcher = {
+      dispatch: vi.fn((_target, _worldState, playerMessage) => {
+        if (!playerMessage) {
+          return {
+            kind: 'npc',
+            targetId: 'npc-1',
+            displayName: 'Archivist',
+            isConversational: false,
+          };
+        }
+
+        return Promise.resolve({
+          kind: 'npc',
+          targetId: 'npc-1',
+          displayName: 'Archivist',
+          updatedWorldState,
+          responseText: 'Archivist: Understood.',
+          isConversational: true,
+          actionExecutionTrace,
+        });
+      }),
+      resolveConversationalTarget: vi.fn((worldStateCandidate: WorldState, targetId: string) => {
+        const npc = worldStateCandidate.npcs.find((candidate) => candidate.id === targetId);
+        return npc ? { kind: 'npc', target: npc } : null;
+      }),
+    };
+
+    const bridge = createRuntimeInteractionResultBridge({
+      world: { getState: () => worldState, resetToState },
+      interactionDispatcher,
+      onActionModalStarted: vi.fn(),
+      onConversationStarted: vi.fn(),
+    });
+
+    const onAssistantMessage = vi.fn();
+    const sendResult = await bridge.sendConversationMessage(
+      'npc-1',
+      'Move and end this.',
+      onAssistantMessage,
+    );
+
+    expect(onAssistantMessage).toHaveBeenCalledWith('Understood.');
+    expect(resetToState).toHaveBeenCalledWith(updatedWorldState);
+    expect(sendResult).toEqual({ endedConversation: true });
   });
 });

--- a/src/runtime/interactionResultBridge.ts
+++ b/src/runtime/interactionResultBridge.ts
@@ -33,7 +33,7 @@ export interface RuntimeInteractionResultBridge {
     playerMessage: string,
     onAssistantMessage: (message: string) => void,
     onLlmError?: (error: LlmRequestError) => void,
-  ): Promise<void>;
+  ): Promise<{ endedConversation: boolean }>;
 }
 
 export const createRuntimeInteractionResultBridge = (
@@ -114,14 +114,14 @@ export const createRuntimeInteractionResultBridge = (
       playerMessage: string,
       onAssistantMessage: (message: string) => void,
       onLlmError?: (error: LlmRequestError) => void,
-    ): Promise<void> {
+    ): Promise<{ endedConversation: boolean }> {
       const currentWorldState = dependencies.world.getState();
       const target = dependencies.interactionDispatcher.resolveConversationalTarget(
         currentWorldState,
         actorId,
       );
       if (!target) {
-        return;
+        return { endedConversation: false };
       }
 
       const result = await dependencies.interactionDispatcher.dispatch(
@@ -135,7 +135,7 @@ export const createRuntimeInteractionResultBridge = (
           dependencies.world.resetToState(result.updatedWorldState);
         }
         onLlmError?.(result.llmError);
-        return;
+        return { endedConversation: false };
       }
 
       const history = getActorConversationHistory(
@@ -150,6 +150,10 @@ export const createRuntimeInteractionResultBridge = (
       if (result.updatedWorldState) {
         dependencies.world.resetToState(result.updatedWorldState);
       }
+
+      return {
+        endedConversation: result.actionExecutionTrace?.endedChat ?? false,
+      };
     },
   };
 };

--- a/src/runtime/modalCoordinator.test.ts
+++ b/src/runtime/modalCoordinator.test.ts
@@ -116,7 +116,7 @@ describe('createRuntimeModalCoordinator', () => {
       actionModalHostElement: document.querySelector<HTMLElement>('#action-host')!,
       inventoryOverlayHostElement: document.querySelector<HTMLElement>('#inventory-host')!,
       onOpenConversationForActionSession: vi.fn(() => false),
-      onSendConversationMessage: vi.fn(async () => {}),
+      onSendConversationMessage: vi.fn(async () => ({ endedConversation: false })),
     });
 
     coordinator.openActionModal(session);
@@ -156,6 +156,7 @@ describe('createRuntimeModalCoordinator', () => {
         onLlmError?: (error: { kind: 'llm_request_error'; message: string; statusCode?: number }) => void,
       ) => {
         onLlmError?.({ kind: 'llm_request_error', message: 'LLM request failed.', statusCode: 503 });
+        return { endedConversation: false };
       },
     );
 
@@ -213,10 +214,11 @@ describe('createRuntimeModalCoordinator', () => {
         callCount += 1;
         if (callCount === 1) {
           onLlmError?.({ kind: 'llm_request_error', message: 'Network request failed.' });
-          return;
+          return { endedConversation: false };
         }
 
         onAssistantMessage('Permission granted.');
+        return { endedConversation: false };
       },
     );
 
@@ -303,7 +305,7 @@ describe('createRuntimeModalCoordinator', () => {
       actionModalHostElement: document.querySelector<HTMLElement>('#action-host')!,
       inventoryOverlayHostElement: document.querySelector<HTMLElement>('#inventory-host')!,
       onOpenConversationForActionSession: vi.fn(() => true),
-      onSendConversationMessage: vi.fn(async () => {}),
+      onSendConversationMessage: vi.fn(async () => ({ endedConversation: false })),
     });
 
     coordinator.openActionModal(session);
@@ -322,6 +324,49 @@ describe('createRuntimeModalCoordinator', () => {
     });
     expect(runtimeController.openInventoryOverlay).toHaveBeenCalledWith(session);
     expect(runtimeController.closeInventoryOverlay).toHaveBeenCalledTimes(1);
+    expect(pauseOverlay.hide).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the chat modal cleanly when the conversation send reports endedChat', async () => {
+    document.body.innerHTML = `
+      <div id="chat-host"></div>
+      <div id="action-host"></div>
+      <div id="inventory-host"></div>
+    `;
+
+    const runtimeController = createRuntimeControllerMock(null);
+    const pauseOverlay = {
+      show: vi.fn(),
+      hide: vi.fn(),
+    };
+
+    const coordinator = createRuntimeModalCoordinator({
+      runtimeController,
+      world: {
+        getState: () => createWorldState(),
+      },
+      viewportPauseOverlay: pauseOverlay,
+      chatModalHostElement: document.querySelector<HTMLElement>('#chat-host')!,
+      actionModalHostElement: document.querySelector<HTMLElement>('#action-host')!,
+      inventoryOverlayHostElement: document.querySelector<HTMLElement>('#inventory-host')!,
+      onOpenConversationForActionSession: vi.fn(() => true),
+      onSendConversationMessage: vi.fn(async (_actorId, _playerMessage, onAssistantMessage) => {
+        onAssistantMessage('We are done here.');
+        return { endedConversation: true };
+      }),
+    });
+
+    coordinator.openConversation('guard-1', 'Guard One', [], 'guard');
+
+    const input = document.querySelector<HTMLInputElement>('.chat-modal-input');
+    const sendButton = document.querySelector<HTMLButtonElement>('.chat-modal-send-btn');
+    input!.value = 'Understood.';
+    sendButton?.click();
+    await Promise.resolve();
+
+    const overlay = document.querySelector<HTMLElement>('.chat-modal-overlay');
+    expect(overlay?.hidden).toBe(true);
+    expect(runtimeController.closeConversation).toHaveBeenCalledTimes(1);
     expect(pauseOverlay.hide).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/runtime/modalCoordinator.test.ts
+++ b/src/runtime/modalCoordinator.test.ts
@@ -110,6 +110,7 @@ describe('createRuntimeModalCoordinator', () => {
       runtimeController,
       world: {
         getState: () => createWorldState(),
+        resetToState: vi.fn(),
       },
       viewportPauseOverlay: pauseOverlay,
       chatModalHostElement: document.querySelector<HTMLElement>('#chat-host')!,
@@ -164,6 +165,7 @@ describe('createRuntimeModalCoordinator', () => {
       runtimeController,
       world: {
         getState: () => createWorldState(),
+        resetToState: vi.fn(),
       },
       viewportPauseOverlay: pauseOverlay,
       chatModalHostElement: document.querySelector<HTMLElement>('#chat-host')!,
@@ -226,6 +228,7 @@ describe('createRuntimeModalCoordinator', () => {
       runtimeController,
       world: {
         getState: () => createWorldState(),
+        resetToState: vi.fn(),
       },
       viewportPauseOverlay: pauseOverlay,
       chatModalHostElement: document.querySelector<HTMLElement>('#chat-host')!,
@@ -279,7 +282,7 @@ describe('createRuntimeModalCoordinator', () => {
       hide: vi.fn(),
     };
 
-    let worldState = {
+    let worldState: WorldState = {
       ...createWorldState(),
       player: {
         ...createWorldState().player,
@@ -344,6 +347,7 @@ describe('createRuntimeModalCoordinator', () => {
       runtimeController,
       world: {
         getState: () => createWorldState(),
+        resetToState: vi.fn(),
       },
       viewportPauseOverlay: pauseOverlay,
       chatModalHostElement: document.querySelector<HTMLElement>('#chat-host')!,

--- a/src/runtime/modalCoordinator.ts
+++ b/src/runtime/modalCoordinator.ts
@@ -33,7 +33,7 @@ export interface RuntimeModalCoordinatorDependencies {
     playerMessage: string,
     onAssistantMessage: (message: string) => void,
     onLlmError?: (error: LlmRequestError) => void,
-  ) => Promise<void>;
+  ) => Promise<{ endedConversation: boolean }>;
 }
 
 export interface RuntimeModalCoordinator {
@@ -64,7 +64,7 @@ export const createRuntimeModalCoordinator = (
       chatModal.appendMessage('player', playerMessage);
 
       void (async () => {
-        await dependencies.onSendConversationMessage(
+        const result = await dependencies.onSendConversationMessage(
           interaction.actorId,
           playerMessage,
           (assistantMessage: string) => {
@@ -74,6 +74,11 @@ export const createRuntimeModalCoordinator = (
             chatModal.setError('Request failed. Please try again.');
           },
         );
+
+        if (result.endedConversation) {
+          chatModal.close();
+          return;
+        }
 
         chatModal.setLoading(false);
       })();


### PR DESCRIPTION
## Closes #188

- Applies runtime and UI handling for NPC action side-effects.
- Updates side-effect presentation paths while preserving determinism.
- Adds tests for side-effect propagation and UI state updates.