### PR TITLE
#187 Integrate NPC Function Calls into Interaction Pipeline

### DIFF
--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -66,6 +66,141 @@ describe('createNpcInteractionService', () => {
       { role: 'player', text: 'Where are the archives?' },
       { role: 'assistant', text: 'The archives are west of here.' },
     ]);
+    expect(
+      (complete.mock.calls.at(0)?.at(0) as { availableFunctions?: Array<{ name: string }> } | undefined)
+        ?.availableFunctions?.map((fn) => fn.name),
+    ).toEqual(['end_chat', 'move', 'interact', 'use_item']);
+  });
+
+  it('executes actions-only npc responses without appending an empty assistant message', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({
+        actions: [{ name: 'move', arguments: { x: 9, y: 3 } }],
+      }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Move aside.',
+    });
+
+    expect(result.responseText).toBe('');
+    expect(result.updatedWorldState.npcs[0].position).toEqual({ x: 9, y: 3 });
+    expect(result.updatedWorldState.actorConversationHistoryByActorId[npc.id]).toEqual([
+      { role: 'player', text: 'Move aside.' },
+    ]);
+    expect(result.actionExecutionTrace?.steps).toHaveLength(1);
+    expect(result.actionExecutionTrace?.steps[0]).toMatchObject({
+      status: 'success',
+      code: 'executed',
+    });
+  });
+
+  it('supports mixed text and actions in a single npc turn', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({
+        text: 'I will open the seal.',
+        actions: [{ name: 'use_item', arguments: { itemId: 'seal-key', targetId: 'seal-door' } }],
+      }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      inventory: [
+        {
+          itemId: 'seal-key',
+          displayName: 'Seal Key',
+          sourceObjectId: 'npc-1',
+          pickedUpAtTick: 0,
+        },
+      ],
+      position: { x: 8, y: 3 },
+    };
+    const stateWithDoor = {
+      ...worldState,
+      npcs: [npc],
+      doors: [
+        {
+          id: 'seal-door',
+          displayName: 'Seal Door',
+          position: { x: 8, y: 4 },
+          isOpen: false,
+          isLocked: true,
+          requiredItemId: 'seal-key',
+        },
+      ],
+    };
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: stateWithDoor.player,
+      worldState: stateWithDoor,
+      playerMessage: 'Can you open this?',
+    });
+
+    expect(result.responseText).toBe('Archivist: I will open the seal.');
+    expect(result.updatedWorldState.actorConversationHistoryByActorId[npc.id]).toEqual([
+      { role: 'player', text: 'Can you open this?' },
+      { role: 'assistant', text: 'I will open the seal.' },
+    ]);
+    expect(result.updatedWorldState.doors[0]).toMatchObject({
+      isOpen: true,
+      isLocked: false,
+    });
+    expect(result.actionExecutionTrace?.steps[0]).toMatchObject({
+      status: 'success',
+      code: 'executed',
+      targetId: 'seal-door',
+    });
+  });
+
+  it('records failed action traces without crashing npc interaction flow', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({
+        text: 'I cannot reach that from here.',
+        actions: [{ name: 'interact', arguments: { targetId: 'far-door' } }],
+      }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+    const stateWithFarDoor = {
+      ...worldState,
+      doors: [
+        {
+          id: 'far-door',
+          displayName: 'Far Door',
+          position: { x: 11, y: 7 },
+          isOpen: false,
+          isLocked: false,
+        },
+      ],
+    };
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: stateWithFarDoor.player,
+      worldState: stateWithFarDoor,
+      playerMessage: 'Try the door.',
+    });
+
+    expect(result.responseText).toBe('Archivist: I cannot reach that from here.');
+    expect(result.updatedWorldState.actorConversationHistoryByActorId[npc.id]).toEqual([
+      { role: 'player', text: 'Try the door.' },
+      { role: 'assistant', text: 'I cannot reach that from here.' },
+    ]);
+    expect(result.updatedWorldState.levelOutcome).toBeNull();
+    expect(result.actionExecutionTrace?.steps[0]).toMatchObject({
+      status: 'failed',
+      code: 'not_adjacent',
+      targetId: 'far-door',
+    });
   });
 
   it('preserves prior per-npc history when appending a new turn', async () => {

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -1,6 +1,15 @@
 import { isLlmRequestError, type LlmRequestError, type LlmClient } from '../llm/client';
 import { Item } from '../world/entities/items/Item';
 import type { ConversationMessage, Npc, Player, WorldState } from '../world/types';
+import {
+  createDefaultNpcFunctionRegistry,
+  type NpcFunctionRegistry,
+} from './npcActionFunctions';
+import {
+  createNpcActionExecutor,
+  type NpcActionExecutionResult,
+  type NpcActionExecutor,
+} from './npcActionExecutor';
 import { buildNpcPromptContext } from './npcPromptContext';
 
 interface NpcInteractionOutcome {
@@ -118,13 +127,26 @@ export interface NpcInteractionResult {
   responseText: string;
   updatedWorldState: WorldState;
   llmError?: LlmRequestError;
+  actionExecutionTrace?: NpcActionExecutionResult;
 }
 
 export interface NpcInteractionService {
   handleNpcInteraction(request: NpcInteractionRequest): Promise<NpcInteractionResult>;
 }
 
-export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractionService => ({
+export interface NpcInteractionServiceOptions {
+  actionExecutor?: NpcActionExecutor;
+  functionRegistry?: NpcFunctionRegistry;
+}
+
+export const createNpcInteractionService = (
+  llmClient: LlmClient,
+  options: NpcInteractionServiceOptions = {},
+): NpcInteractionService => {
+  const actionExecutor = options.actionExecutor ?? createNpcActionExecutor();
+  const functionRegistry = options.functionRegistry ?? createDefaultNpcFunctionRegistry();
+
+  return {
   handleNpcInteraction: async (request: NpcInteractionRequest): Promise<NpcInteractionResult> => {
     const previousHistory =
       request.worldState.actorConversationHistoryByActorId[request.npc.id] ?? [];
@@ -140,6 +162,7 @@ export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractio
         context: buildNpcPromptContext(request.npc, request.player, request.worldState),
         playerMessage: request.playerMessage,
         conversationHistory: historyWithPlayerMessage,
+        availableFunctions: functionRegistry.resolveFunctions(request.npc),
       })
       .catch((err: unknown): LlmRequestError => ({
         kind: 'llm_request_error',
@@ -200,13 +223,23 @@ export const createNpcInteractionService = (llmClient: LlmClient): NpcInteractio
       ),
     };
 
+    const actionExecutionTrace = llmResult.actions?.length
+      ? actionExecutor.execute({
+          npcId: request.npc.id,
+          worldState: updatedWorldState,
+          actions: llmResult.actions,
+        })
+      : undefined;
+
     return {
       npcId: request.npc.id,
       responseText: assistantText ? `${request.npc.displayName}: ${assistantText}` : '',
-      updatedWorldState,
+      updatedWorldState: actionExecutionTrace?.updatedWorldState ?? updatedWorldState,
+      actionExecutionTrace,
     };
   },
-});
+  };
+};
 
 export const handleNpcInteraction = async (
   request: NpcInteractionRequest,


### PR DESCRIPTION
## Closes #187

- Integrates NPC function-calling into the interaction pipeline flow.
- Connects interaction routing with executor inputs and outputs.
- Adds tests for end-to-end interaction pipeline behavior.