### PR TITLE
#184 NPC Function Calling: Base Action Contract and Registry

### DIFF
--- a/src/interaction/npcActionFunctions.test.ts
+++ b/src/interaction/npcActionFunctions.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultNpcFunctionRegistry,
+  createNpcFunctionRegistry,
+  type NpcActionCall,
+} from './npcActionFunctions';
+import type { Npc } from '../world/types';
+
+const createNpc = (overrides: Partial<Npc> = {}): Npc => ({
+  id: 'npc-1',
+  displayName: 'Archivist',
+  position: { x: 5, y: 5 },
+  npcType: 'archive_keeper',
+  dialogueContextKey: 'archive_keeper_intro',
+  ...overrides,
+});
+
+describe('npcActionFunctions', () => {
+  it('provides deterministic base function order for default registry', () => {
+    const registry = createDefaultNpcFunctionRegistry();
+    const functions = registry.resolveFunctions(createNpc());
+
+    expect(functions.map((fn) => fn.name)).toEqual(['end_chat', 'move', 'interact', 'use_item']);
+  });
+
+  it('returns serializable function schemas', () => {
+    const registry = createDefaultNpcFunctionRegistry();
+    const functions = registry.resolveFunctions(createNpc());
+
+    const serialized = JSON.stringify(functions);
+    const roundTrip = JSON.parse(serialized) as Array<{ name: string }>;
+
+    expect(roundTrip.map((fn) => fn.name)).toEqual(['end_chat', 'move', 'interact', 'use_item']);
+  });
+
+  it('supports serializable action call payloads', () => {
+    const calls: NpcActionCall[] = [
+      { name: 'move', arguments: { x: 7, y: 8 } },
+      { name: 'interact', arguments: { targetId: 'door-safe' } },
+      { name: 'use_item', arguments: { itemId: 'armory-key', targetId: 'door-safe' } },
+      { name: 'end_chat', arguments: { reason: 'Conversation complete.' } },
+    ];
+
+    const roundTrip = JSON.parse(JSON.stringify(calls)) as Array<{ name: string }>;
+    expect(roundTrip.map((call) => call.name)).toEqual(['move', 'interact', 'use_item', 'end_chat']);
+  });
+
+  it('filters function exposure using npc facts capabilities', () => {
+    const registry = createDefaultNpcFunctionRegistry();
+    const npc = createNpc({
+      facts: {
+        canMove: false,
+        canUseItem: false,
+      },
+    });
+
+    const functions = registry.resolveFunctions(npc);
+    expect(functions.map((fn) => fn.name)).toEqual(['end_chat', 'interact']);
+  });
+
+  it('merges npc-type specific additional functions and dedupes by name', () => {
+    const registry = createNpcFunctionRegistry({
+      additionalByNpcType: {
+        archive_keeper: [
+          {
+            name: 'interact',
+            description: 'Interact with archive-only target.',
+            parameters: {
+              type: 'object',
+              properties: {
+                targetId: { type: 'string' },
+              },
+              required: ['targetId'],
+              additionalProperties: false,
+            },
+          },
+        ],
+      },
+    });
+
+    const functions = registry.resolveFunctions(createNpc());
+    expect(functions.map((fn) => fn.name)).toEqual(['end_chat', 'move', 'interact', 'use_item']);
+    expect(functions.find((fn) => fn.name === 'interact')?.description).toContain('archive-only');
+  });
+});

--- a/src/interaction/npcActionFunctions.ts
+++ b/src/interaction/npcActionFunctions.ts
@@ -1,0 +1,148 @@
+import type { Npc } from '../world/types';
+
+export type NpcActionName = 'end_chat' | 'move' | 'interact' | 'use_item';
+
+export interface EndChatActionArguments {
+  reason?: string;
+}
+
+export interface MoveActionArguments {
+  x: number;
+  y: number;
+}
+
+export interface InteractActionArguments {
+  targetId: string;
+}
+
+export interface UseItemActionArguments {
+  itemId: string;
+  targetId?: string;
+}
+
+export type NpcActionCall =
+  | { name: 'end_chat'; arguments: EndChatActionArguments }
+  | { name: 'move'; arguments: MoveActionArguments }
+  | { name: 'interact'; arguments: InteractActionArguments }
+  | { name: 'use_item'; arguments: UseItemActionArguments };
+
+export interface JsonSchema {
+  type: 'object';
+  properties: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export interface NpcFunctionDefinition {
+  name: NpcActionName;
+  description: string;
+  parameters: JsonSchema;
+}
+
+const BASE_NPC_FUNCTION_DEFINITIONS: ReadonlyArray<NpcFunctionDefinition> = [
+  {
+    name: 'end_chat',
+    description: 'End the current conversation with the player.',
+    parameters: {
+      type: 'object',
+      properties: {
+        reason: {
+          type: 'string',
+          description: 'Optional short reason for ending the conversation.',
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'move',
+    description: 'Move the NPC to a target grid tile.',
+    parameters: {
+      type: 'object',
+      properties: {
+        x: { type: 'number', description: 'Target x grid coordinate.' },
+        y: { type: 'number', description: 'Target y grid coordinate.' },
+      },
+      required: ['x', 'y'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'interact',
+    description: 'Interact with a target entity by id.',
+    parameters: {
+      type: 'object',
+      properties: {
+        targetId: { type: 'string', description: 'ID of the target entity to interact with.' },
+      },
+      required: ['targetId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'use_item',
+    description: 'Use an inventory item, optionally on a specific target.',
+    parameters: {
+      type: 'object',
+      properties: {
+        itemId: { type: 'string', description: 'ID of the item to use.' },
+        targetId: { type: 'string', description: 'Optional target entity id.' },
+      },
+      required: ['itemId'],
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+const NpcFunctionCapabilityFacts: Readonly<Record<NpcActionName, string>> = {
+  end_chat: 'canEndChat',
+  move: 'canMove',
+  interact: 'canInteract',
+  use_item: 'canUseItem',
+};
+
+const isFunctionEnabledForNpc = (npc: Npc, functionName: NpcActionName): boolean => {
+  const factKey = NpcFunctionCapabilityFacts[functionName];
+  const factValue = npc.facts?.[factKey];
+  if (typeof factValue === 'boolean') {
+    return factValue;
+  }
+
+  return true;
+};
+
+const dedupeByFunctionName = (
+  definitions: ReadonlyArray<NpcFunctionDefinition>,
+): NpcFunctionDefinition[] => {
+  const byName = new Map<NpcActionName, NpcFunctionDefinition>();
+  for (const definition of definitions) {
+    byName.set(definition.name, definition);
+  }
+
+  return [...byName.values()];
+};
+
+export interface NpcFunctionRegistry {
+  resolveFunctions(npc: Npc): NpcFunctionDefinition[];
+}
+
+export interface NpcFunctionRegistryOptions {
+  additionalByNpcType?: Readonly<Record<string, ReadonlyArray<NpcFunctionDefinition>>>;
+}
+
+export const createNpcFunctionRegistry = (
+  options: NpcFunctionRegistryOptions = {},
+): NpcFunctionRegistry => {
+  return {
+    resolveFunctions(npc: Npc): NpcFunctionDefinition[] {
+      const additional = options.additionalByNpcType?.[npc.npcType] ?? [];
+      const merged = dedupeByFunctionName([...BASE_NPC_FUNCTION_DEFINITIONS, ...additional]);
+
+      return merged.filter((definition) => isFunctionEnabledForNpc(npc, definition.name));
+    },
+  };
+};
+
+export const createDefaultNpcFunctionRegistry = (): NpcFunctionRegistry => {
+  return createNpcFunctionRegistry();
+};


### PR DESCRIPTION
## Closes #184

- Defines the base NPC action contract for deterministic execution.
- Adds registry wiring for action lookup and dispatch boundaries.
- Includes focused tests to validate contract and registry behavior.