### PR TITLE
Tighten agent and skill workflow definitions

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -90,6 +90,15 @@ Categorize each work package into exactly one type:
   - include documentation fixes when behavior or architecture explanations become outdated
   - re-validate impacted behavior
 
+## Phase Gates
+The implementation flow is complete only when all gates pass in order:
+1. Plan gate: issue scope and AC are documented in a concrete step-by-step plan.
+2. Implement gate: all planned steps are implemented with focused commits and per-step validation.
+3. PR gate: PR is opened with `Closes #<issue-number>`, validation evidence, and exactly one category label.
+4. Check gate: self-review confirms scope, correctness, labels, and issue linkage are consistent.
+5. Feedback gate: all blocking review feedback is resolved or explicitly escalated to the user.
+6. Finish gate: PR is merged, branches are cleaned up, and ticket state is verified as `Done`/`Completed`.
+
 ## Finish PR Workflow
 If the user asks you to finish a PR, follow this exact sequence:
 1. Check the PR status, comments, review threads, and checks.

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -41,6 +41,7 @@ Your job is to review pull requests against GitHub issue scope with two modes:
 - Enforce 1 ticket = 1 PR for implementation work. Reject slice-based delivery plans.
 - PR is expected to satisfy the ticket's scope and acceptance criteria.
 - Allow minor adjacent improvements (for example docs clarifications) when coherent and low risk.
+- If the PR or review request is explicitly marked as an incremental/non-final checkpoint, return a blocking verdict and request a ticket split or scope adjustment before merge.
 - Check that the PR label matches the actual diff content:
   - `AI_BEHAVIOR`: only agent/skill/instruction workflow files
   - `ENHANCEMENT`: feature logic/content changes

--- a/.github/ai-behavior-ambiguity-log.md
+++ b/.github/ai-behavior-ambiguity-log.md
@@ -1,0 +1,39 @@
+# AI Behavior Ambiguity Log
+
+## Resolved in this update
+
+1. Reviewer label taxonomy mismatch
+- Ambiguity: `reviewer-change` and `reviewer-partial-pr` used legacy `CHANGE` labels while agents and PR policy use `ENHANCEMENT`, `BUGS`, `LEVEL`, `DOCUMENTATION`, `REFACTORING`, and `AI_BEHAVIOR`.
+- Resolution: Updated reviewer skills to use the active category taxonomy.
+
+2. Partial PR guidance contradicted one-ticket-one-PR policy
+- Ambiguity: `reviewer-partial-pr` described partial delivery as normal while coordinator/developer/reviewer enforce full-ticket implementation delivery.
+- Resolution: Restricted `reviewer-partial-pr` to explicit non-merge checkpoint reviews and added a policy-blocking outcome for non-merge-ready implementation slices.
+
+3. Missing LEVEL category in self-check workflow
+- Ambiguity: `check` skill label policy omitted `LEVEL` even though agents treat `LEVEL` as first-class.
+- Resolution: Added `LEVEL` to label policy and explicit readiness expectations.
+
+4. Duplicated clarity section in AI behavior review skill
+- Ambiguity: `reviewer-ai-behavior` had two `Clarity` sections with overlapping guidance.
+- Resolution: Consolidated into one clarity section with explicit flow completeness checks.
+
+5. PR labeling requirements were underspecified
+- Ambiguity: `pr` skill said to add labels but did not define exactly-one primary category rule.
+- Resolution: Added exact-one category label rule and explicit `Closes #<issue>` requirement for implementation PRs.
+
+6. Feedback handling end condition was unclear
+- Ambiguity: `address-comments` did not define when comment processing is complete.
+- Resolution: Added completion rule requiring all must-fix comments resolved or escalated.
+
+7. Developer workflow lacked explicit pass/fail gates
+- Ambiguity: sequence existed but no explicit gate criteria for flow completion.
+- Resolution: Added ordered phase gates from planning through merge/ticket closure.
+
+## Still intentionally flexible
+
+1. Pragmatic reviewer judgment on minor adjacent improvements
+- Reason: Allows low-risk quality improvements without forcing unnecessary follow-up tickets.
+
+2. Manual validation allowance when automated coverage is not practical
+- Reason: Some workflow and documentation changes are best validated by consistency and process checks.

--- a/.github/skills/address-comments/SKILL.md
+++ b/.github/skills/address-comments/SKILL.md
@@ -18,6 +18,10 @@ Handle review feedback methodically and transparently.
 4. Respond to each comment with clear resolution.
 5. Push updates and summarize what changed.
 
+## Completion Rule
+- Do not mark feedback handling complete while unresolved must-fix comments remain.
+- If a must-fix request cannot be addressed within scope, escalate to the user with explicit options.
+
 ## Output
 - Comment-by-comment resolution log
 - Code/validation updates made

--- a/.github/skills/check/SKILL.md
+++ b/.github/skills/check/SKILL.md
@@ -24,8 +24,12 @@ Perform a structured self-review of an opened PR.
 - No slice-PR `Refs` usage for implementation delivery.
 - If ticket is a sub ticket, parent linkage is present and post-merge parent comment plan is clear.
 6. Label policy:
-- Exactly one category label is present: `DOCUMENTATION`, `BUGS`, `ENHANCEMENT`, `AI_BEHAVIOR`, or `REFACTORING`.
+- Exactly one category label is present: `DOCUMENTATION`, `BUGS`, `ENHANCEMENT`, `LEVEL`, `AI_BEHAVIOR`, or `REFACTORING`.
 - `AI_BEHAVIOR` is used only for AI workflow customization changes.
+- `LEVEL` is required for level-definition delivery from game designer specifications.
+
+## Readiness Rule
+- If any checklist item fails, the PR is not ready and must be updated before handoff or merge.
 
 ## Cleanup Actions
 - Make any necessary cleanup commits.

--- a/.github/skills/pr/SKILL.md
+++ b/.github/skills/pr/SKILL.md
@@ -18,6 +18,10 @@ Open a high-quality PR that is easy to review.
 - If this is a sub ticket, include one parent link line (for example: `Parent: #<parent-issue>`).
 5. Add required labels.
 
+## Label Rule
+- Apply exactly one primary category label per PR: `DOCUMENTATION`, `BUGS`, `ENHANCEMENT`, `LEVEL`, `AI_BEHAVIOR`, or `REFACTORING`.
+- For implementation tickets, do not open PRs without `Closes #<issue>` in the body.
+
 ## Output
 - PR title and body
 - Labels applied

--- a/.github/skills/reviewer-ai-behavior/SKILL.md
+++ b/.github/skills/reviewer-ai-behavior/SKILL.md
@@ -28,11 +28,7 @@ Review PRs labeled `AI_BEHAVIOR` that change agent, skill, instruction, prompt, 
 - **Complete examples**: Do code examples or workflow steps show full, concrete scenarios?
 - **Testability**: Can another person follow the instructions without guessing about intent?
 - **Consistency in terminology**: Are the same concepts referred to with consistent names throughout?
-
-### Clarity
-- Check for ambiguous wording or incomplete workflow steps.
-- Ensure branch and PR guidance are explicit and testable.
-- Confirm the intended behavior can be followed without guessing.
+- **Flow completeness**: Ensure any required sequence (plan -> edit -> validate -> PR -> label) is explicit with no skipped gate.
 
 ## Decision Labels
 - `VALID_PARTIAL_SLICE` — Focused AI customization change, consistent and clear

--- a/.github/skills/reviewer-change/SKILL.md
+++ b/.github/skills/reviewer-change/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: reviewer-change
-description: "Use when reviewing a PR labeled CHANGE for AC alignment, correctness, and completeness."
+description: "Use when reviewing a PR labeled ENHANCEMENT, BUGS, LEVEL, or implementation-scoped DOCUMENTATION for AC alignment, correctness, and completeness."
 ---
 
 # Reviewer Change
 
 ## Purpose
-Review PRs labeled `CHANGE` that implement feature, logic, or content changes to the game. Verify that changes align with ticket acceptance criteria, are functionally correct, and are complete within their scope.
+Review PRs labeled `ENHANCEMENT`, `BUGS`, `LEVEL`, or implementation-scoped `DOCUMENTATION` that implement feature, logic, content, or delivery documentation changes. Verify that changes align with ticket acceptance criteria, are functionally correct, and are complete within their scope.
 
 ## Review Checklist
 
@@ -41,7 +41,7 @@ Review PRs labeled `CHANGE` that implement feature, logic, or content changes to
 
 ## Output Template
 - PR:
-- Label: CHANGE
+- Label: ENHANCEMENT / BUGS / LEVEL / DOCUMENTATION
 - Related ACs: (which ticket ACs does this advance?)
 - AC alignment: (which ACs met, which deferred and why?)
 - Correctness check: (any logic errors or regressions?)

--- a/.github/skills/reviewer-partial-pr/SKILL.md
+++ b/.github/skills/reviewer-partial-pr/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: reviewer-partial-pr
-description: "Use when reviewing a partial PR for a Jira ticket; verify the PR is a focused incremental slice that contributes to the ticket goal without requiring full feature completion."
+description: "Use only when a user explicitly requests a non-merge checkpoint review; verify focus and risk while preserving one-ticket-one-PR merge policy for implementation delivery."
 ---
 
 # Reviewer Partial PR
 
 ## Purpose
-Use this skill to review a single PR as a partial delivery for a ticket.
+Use this skill only for explicit checkpoint feedback requests. It must not approve implementation PRs that are intentionally partial for merge.
 
 ## Workflow
 1. Read the Jira ticket and identify outcome, scope boundaries, and acceptance criteria.
 2. Read the PR diff and summarize its single dominant concern.
 3. Determine review basis:
-	- `ticket-delivery` for product/runtime/test/refactor slices
-	- `workflow-reasonableness` for PRs that change only agents, skills, prompts, or review workflow files
-4. Verify contribution to the ticket goal even if ACs are not fully met yet.
+   - `implementation-checkpoint` for non-final implementation progress requested by the user
+   - `workflow-reasonableness` for PRs that change only agents, skills, prompts, or review workflow files
+4. Verify contribution to the ticket goal, and explicitly state that implementation merge readiness is blocked until full AC completion.
 5. For workflow-only PRs, judge the changes on coherence, usefulness, and broader reasonableness instead of runtime AC progress.
 6. Check that the PR remains focused (one concern) and reviewable.
 7. Flag scope creep and cross-layer coupling.
@@ -33,13 +33,14 @@ Use this skill to review a single PR as a partial delivery for a ticket.
 - `NEEDS_SPLIT`
 - `OUT_OF_SCOPE`
 - `BLOCKED_BY_MISSING_CONTEXT`
+- `NOT_MERGE_READY_BY_POLICY`
 
 ## Integration with Category-Specific Skills
 For partial PR reviews, use the appropriate category skill based on the PR label:
-1. Verify PR has exactly one primary review label: `CHANGE`, `REFACTORING`, or `AI_BEHAVIOR`
+1. Verify PR has exactly one primary review label: `ENHANCEMENT`, `BUGS`, `LEVEL`, `DOCUMENTATION`, `REFACTORING`, or `AI_BEHAVIOR`
 2. Use the category-specific skill:
    - `reviewer-ai-behavior` for `AI_BEHAVIOR` PRs
-   - `reviewer-change` for `CHANGE` PRs
+   - `reviewer-change` for `ENHANCEMENT`, `BUGS`, `LEVEL`, or implementation-scoped `DOCUMENTATION` PRs
    - `reviewer-refactoring` for `REFACTORING` PRs
 3. Follow that skill's review checklist and decision process
 


### PR DESCRIPTION
## Summary
- tighten developer and reviewer agent workflow definitions to remove ambiguous execution paths
- align reviewer skills with the active category label taxonomy
- clarify PR/check/address-comments skill completion and label rules
- add a dedicated ambiguity log with resolved and intentionally flexible definitions

## Files Updated
- .github/agents/developer.agent.md
- .github/agents/reviewer.agent.md
- .github/skills/check/SKILL.md
- .github/skills/pr/SKILL.md
- .github/skills/address-comments/SKILL.md
- .github/skills/reviewer-change/SKILL.md
- .github/skills/reviewer-partial-pr/SKILL.md
- .github/skills/reviewer-ai-behavior/SKILL.md
- .github/ai-behavior-ambiguity-log.md

## Validation
- diagnostics check on all changed files (`get_errors`): no errors

## Notes
- this PR intentionally contains only AI behavior/workflow customization changes