### PR TITLE
#200 add deterministic quest-state progression foundation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,18 +68,20 @@ Types and interfaces use clear, semantic names. This supports LLM prompt generat
 
 3. **Deterministic Use-Attempt Routing:** When `useSelectedItem` commands are present, `RuntimeController` calls the injected item-use resolver with the post-command `WorldState` and each original command index. `src/runtime/createRuntimeApp.ts` wires the `onItemUseAttemptResolved(...)` callback that commits the latest emitted `ItemUseAttemptResultEvent` back into serialized world state through `world.resetToState(...)`. When a door is unlocked (`event.doorUnlockedId` is present), that same callback sets the corresponding door's `isUnlocked` flag to true, allowing future movement through that door via spatial rules checks.
 
-4. **Interaction Routing:** If an `interact` command was issued and the runtime is not paused, `src/runtime/interactionResultBridge.ts` resolves one adjacent target.
+4. **Quest Progression Reducer:** The same deterministic item-use callback converts validated `ItemUseAttemptResultEvent` values into quest progress events and applies them through the pure quest reducer in `src/world/questState.ts`. No LLM text is used as a quest transition input.
+
+5. **Interaction Routing:** If an `interact` command was issued and the runtime is not paused, `src/runtime/interactionResultBridge.ts` resolves one adjacent target.
        - **Action Modal Routing:** If the target is action-modal-eligible (`guard` or `npc`), the bridge opens an action-modal session immediately through `src/runtime/modalCoordinator.ts`. If the player chooses Chat, the bridge resolves the conversational target by id and then calls `interactionDispatcher.dispatch(...)` to start the chat flow.
        - **Deterministic Routing:** If the target is non-modal (`door` or `interactiveObject`), the bridge dispatches immediately. Result handlers commit world-state mutations without opening modals.
 
-5. **Result Routing:** Returned `InteractionHandlerResult` (sync or async) is routed through `resultDispatcher.dispatch(...)` into runtime bridge side effects.
+6. **Result Routing:** Returned `InteractionHandlerResult` (sync or async) is routed through `resultDispatcher.dispatch(...)` into runtime bridge side effects.
        - Conversational results (`guard`/`npc`) are routed through `interactionResultBridge` into `modalCoordinator`, which calls `runtimeController.openConversation(actorId)`, `viewportPauseOverlay.show()`, and `chatModal.open(...)`.
    - Deterministic results (door/object) stay local to world-state reset and level-outcome callbacks.
    - Door and object interactions do not open modals and do not pause gameplay.
 
-6. **Render Phase:** Every animation frame renders the latest world state through the PixiJS render port. Character sprite assets are loaded and resolved to sprite/marker mode inside the render layer only. Separate DOM render utilities manage the chat modal, inventory overlay, paused-viewport overlay, and level-outcome overlay.
+7. **Render Phase:** Every animation frame renders the latest world state through the PixiJS render port. Character sprite assets are loaded and resolved to sprite/marker mode inside the render layer only. Separate DOM render utilities manage the chat modal, inventory overlay, paused-viewport overlay, and level-outcome overlay.
 
-7. **Debug Phase:** Current JSON world state is serialized and printed to the debug panel.
+8. **Debug Phase:** Current JSON world state is serialized and printed to the debug panel.
 
 Runtime composition entry points:
 - `src/main.ts`: validates `#app` and starts the runtime app.

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -14,6 +14,7 @@ Source of truth:
   - `src/world/types/object.ts` - InteractiveObject, ObjectCapabilities
   - `src/world/types/environment.ts` - Environment
   - `src/world/types/conversation.ts` - ConversationMessage, ActorConversationHistoryByActorId
+  - `src/world/types/quest.ts` - QuestState, QuestChainDefinition, QuestProgressEvent
   - `src/world/types/world-state.ts` - WorldState, WorldGrid, LevelMetadata
   - `src/world/types/level.ts` - LevelData, Level*Dto types
   - `src/world/types/command.ts` - WorldCommand, Intent, World interface
@@ -394,9 +395,38 @@ Stores conversation history by actor id. The current conversational actors are g
 - `doors: Door[]`
 - `interactiveObjects: InteractiveObject[]`
 - `environments?: Environment[]`
+- `questState?: QuestState` - deterministic quest-chain definitions and progression snapshot
 - `actorConversationHistoryByActorId: ActorConversationHistoryByActorId`
 - `lastItemUseAttemptEvent?: ItemUseAttemptResultEvent | null` - latest resolved selected-item use attempt
 - `levelOutcome: 'win' | 'lose' | null`
+
+### QuestChainDefinition
+- `chainId: string`
+- `displayName: string`
+- `npcId?: string`
+- `stages: QuestStageDefinition[]`
+
+### QuestStageDefinition
+- `stageId: string`
+- `description?: string`
+- `completeWhen: QuestProgressCriteria`
+
+### QuestProgressCriteria
+Current deterministic event matcher shape:
+- `eventType: 'item_use_resolved'`
+- optional filters: `result`, `targetKind`, `targetId`, `selectedItemId`, `doorUnlockedId`, `affectedEntityType`, `affectedEntityId`
+
+### QuestState
+- `version: 1`
+- `chains: QuestChainDefinition[]`
+- `progressByChainId: Record<string, QuestChainProgress>`
+
+### QuestChainProgress
+- `chainId: string`
+- `status: 'not_started' | 'in_progress' | 'completed'`
+- `currentStageIndex: number`
+- `completedStageIds: string[]`
+- `lastAdvancedTick?: number`
 
 ## Actor and NPC Prompt Context Types
 

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -65,6 +65,7 @@ Legacy `WorldCommand` objects (`move`, `selectInventorySlot`, `useSelectedItem`,
 - `doors`
 - `interactiveObjects`
 - `environments`
+- `questState`
 - `actorConversationHistoryByActorId`
 - `lastItemUseAttemptEvent`
 - `levelOutcome`
@@ -134,6 +135,16 @@ Deterministic rules:
 - `src/runtime/runtimeController.ts` emits one event per `useSelectedItem` command using command index ordering within the tick.
 - The callback wiring in `src/runtime/createRuntimeApp.ts` commits each emitted event immutably, so the last one in a tick becomes the stored event.
 
+### Quest State
+
+`questState` is a serializable world field storing deterministic quest-chain definitions and progression state.
+
+Deterministic rules:
+- New runtime state initializes `questState` to an empty schema (`version: 1`, no chains, empty progress map).
+- Level deserialization initializes `questState` from optional `levelData.questChains` with safe defaults when omitted.
+- Quest progression is advanced only from validated item-use events emitted by the deterministic item-use resolver (`ItemUseAttemptResultEvent`) and never from LLM response text.
+- Quest transitions are pure world-layer reducer logic (`src/world/questState.ts`), so identical event sequences produce identical progression state.
+
 ### Door Unlock State
 
 `door.isUnlocked` is a serializable boolean flag that tracks whether a door has been unlocked via item-use interaction.
@@ -159,6 +170,7 @@ Deterministic rules:
 | `validateNpcs.ts` | npcs array: identity, position, npcType, patrol path bounds, triggers, inventory, riddleClue |
 | `validateObjects.ts` | interactiveObjects array: identity, position, objectType, interactionType, state, pickupItem, sprites, capabilities, itemUseRules |
 | `validateEnvironments.ts` | environments array: identity, position, isBlocking |
+| `validateQuestChains.ts` | optional questChains array: chain identity, stage identity, and deterministic item-use event criteria |
 | `shared.ts` | shared helper functions used across domain validators |
 
 `src/world/levelValidation/shared.ts` contains reusable cross-domain helpers:

--- a/src/runtime/createRuntimeApp.ts
+++ b/src/runtime/createRuntimeApp.ts
@@ -17,6 +17,11 @@ import { createDefaultItemUseResolver } from '../interaction/itemUse';
 import { createInteractionDispatcher } from '../interaction/interactionDispatcher';
 import { createWorld } from '../world/world';
 import type { ConversationMessage } from '../world/types';
+import {
+  applyQuestProgressEvent,
+  ensureQuestState,
+  toQuestProgressEventFromItemUseAttempt,
+} from '../world/questState';
 import { createFixedTickLoop } from './fixedTickLoop';
 import { createLevelLoadOrchestration } from './levelLoadOrchestration';
 import { createRuntimeInteractionResultBridge } from './interactionResultBridge';
@@ -110,9 +115,14 @@ export const createRuntimeApp = (appElement: HTMLDivElement): RuntimeApp => {
     itemUseResolver,
     onItemUseAttemptResolved: (event) => {
       const currentState = world.getState();
+      const questState = applyQuestProgressEvent(
+        ensureQuestState(currentState.questState),
+        toQuestProgressEventFromItemUseAttempt(event),
+      );
       let updatedState = {
         ...currentState,
         lastItemUseAttemptEvent: event,
+        questState,
       };
 
       if (event.doorUnlockedId) {

--- a/src/test-support/worldState.ts
+++ b/src/test-support/worldState.ts
@@ -1,4 +1,5 @@
 import type { Door, Guard, InteractiveObject, InventoryItem, Npc, WorldState } from '../world/types';
+import { createQuestState } from '../world/questState';
 
 export type TestWorldStateOverrides = Omit<Partial<WorldState>, 'player'> & {
   player?: Partial<WorldState['player']>;
@@ -26,6 +27,7 @@ export const createTestWorldState = (overrides?: TestWorldStateOverrides): World
     doors: [],
     npcs: [],
     interactiveObjects: [],
+    questState: createQuestState(),
     actorConversationHistoryByActorId: {},
     levelOutcome: null,
   };

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -897,6 +897,73 @@ describe('levelOutcome field', () => {
   });
 });
 
+describe('questState field', () => {
+  it('initializes to an empty quest state when questChains is omitted', () => {
+    const state = deserializeLevelWithDefaultLayout(validateLevelData(minimalLevel));
+
+    expect(state.questState).toEqual({
+      version: 1,
+      chains: [],
+      progressByChainId: {},
+    });
+  });
+
+  it('deserializes deterministic quest chain progress defaults when questChains are provided', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      questChains: [
+        {
+          chainId: 'seal-1',
+          displayName: 'First Seal',
+          stages: [
+            {
+              stageId: 'bribe-guard',
+              completeWhen: {
+                eventType: 'item_use_resolved',
+                result: 'success',
+                targetKind: 'guard',
+                targetId: 'guard-1',
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const state = deserializeLevelWithDefaultLayout(validateLevelData(level));
+
+    expect(state.questState?.chains).toHaveLength(1);
+    expect(state.questState?.progressByChainId['seal-1']).toEqual({
+      chainId: 'seal-1',
+      status: 'not_started',
+      currentStageIndex: 0,
+      completedStageIds: [],
+    });
+  });
+
+  it('rejects quest chains with unsupported completeWhen event types', () => {
+    const badLevel = {
+      ...minimalLevel,
+      questChains: [
+        {
+          chainId: 'seal-1',
+          displayName: 'First Seal',
+          stages: [
+            {
+              stageId: 'stage-1',
+              completeWhen: {
+                eventType: 'dialogue_generated',
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(() => validateLevelData(badLevel)).toThrowError('completeWhen.eventType must be "item_use_resolved"');
+  });
+});
+
 describe('npcs field', () => {
   it('accepts level data without npcs field (backward compatibility)', () => {
     const level: LevelData = {

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -13,9 +13,11 @@ import { validateDoors } from './levelValidation/validateDoors';
 import { validateNpcs } from './levelValidation/validateNpcs';
 import { validateObjects } from './levelValidation/validateObjects';
 import { validateEnvironments } from './levelValidation/validateEnvironments';
+import { validateQuestChains } from './levelValidation/validateQuestChains';
 import { mapPlayerDtoToRuntime } from './levelMapping/mapPlayer';
 import { mapDoorDtoToRuntime } from './levelMapping/mapDoor';
 import { mapNpcWithRiddleClue } from './levelMapping/mapNpcWithRiddleClue';
+import { createQuestState } from './questState';
 
 interface LayoutBounds {
   width: number;
@@ -104,6 +106,7 @@ export function validateLevelData(input: unknown, layoutBounds?: LayoutBounds): 
   }
   validateObjects(raw);
   validateEnvironments(raw);
+  validateQuestChains(raw);
 
   return raw as unknown as LevelData;
 }
@@ -139,6 +142,7 @@ export function deserializeLevel(levelData: LevelData, parsedLayout: ParsedLayou
     environments: [...layoutWallEnvironments, ...(levelData.environments ?? [])].map((environment) =>
       mapEnvironmentDtoToRuntime(environment),
     ),
+    questState: createQuestState(levelData.questChains ?? []),
     actorConversationHistoryByActorId: {},
     lastItemUseAttemptEvent: null,
     levelOutcome: null,

--- a/src/world/levelLoader.test.ts
+++ b/src/world/levelLoader.test.ts
@@ -124,6 +124,11 @@ describe('fetchAndLoadLevel', () => {
       premise: 'A deterministic test premise.',
       goal: 'Verify level loading behavior.',
     });
+    expect(state.questState).toEqual({
+      version: 1,
+      chains: [],
+      progressByChainId: {},
+    });
     expect(state.npcs[0]).toBeInstanceOf(Npc);
     expect(state.npcs[0].inventory?.[0]).toBeInstanceOf(Item);
     expect(state.interactiveObjects[0]).toBeInstanceOf(InertObject);

--- a/src/world/levelValidation/validateQuestChains.ts
+++ b/src/world/levelValidation/validateQuestChains.ts
@@ -1,0 +1,150 @@
+import type { QuestAffectedEntityType, QuestItemUseTargetKind } from '../types';
+
+const VALID_ITEM_USE_RESULTS = new Set(['no-selection', 'no-target', 'blocked', 'success', 'no-rule']);
+const VALID_TARGET_KINDS: ReadonlySet<QuestItemUseTargetKind> = new Set([
+  'door',
+  'guard',
+  'npc',
+  'interactiveObject',
+]);
+const VALID_AFFECTED_ENTITY_TYPES: ReadonlySet<QuestAffectedEntityType> = new Set(['guard', 'object']);
+
+export const validateQuestChains = (raw: Record<string, unknown>): void => {
+  if (raw['questChains'] === undefined) {
+    return;
+  }
+
+  if (!Array.isArray(raw['questChains'])) {
+    throw new Error('Invalid level data: questChains must be an array when provided');
+  }
+
+  const chainIds = new Set<string>();
+
+  for (let chainIndex = 0; chainIndex < raw['questChains'].length; chainIndex++) {
+    const chain = raw['questChains'][chainIndex] as Record<string, unknown>;
+    if (
+      typeof chain !== 'object' ||
+      chain === null ||
+      typeof chain['chainId'] !== 'string' ||
+      chain['chainId'].trim() === '' ||
+      typeof chain['displayName'] !== 'string' ||
+      chain['displayName'].trim() === '' ||
+      !Array.isArray(chain['stages']) ||
+      chain['stages'].length === 0
+    ) {
+      throw new Error(
+        `Invalid level data: questChain at index ${chainIndex} must include chainId, displayName, and non-empty stages array`,
+      );
+    }
+
+    if (chainIds.has(chain['chainId'])) {
+      throw new Error(`Invalid level data: duplicate questChain chainId "${chain['chainId']}"`);
+    }
+
+    chainIds.add(chain['chainId']);
+
+    if (chain['npcId'] !== undefined && (typeof chain['npcId'] !== 'string' || chain['npcId'].trim() === '')) {
+      throw new Error(
+        `Invalid level data: questChain at index ${chainIndex} has invalid npcId (must be a non-empty string when provided)`,
+      );
+    }
+
+    const stageIds = new Set<string>();
+    const stages = chain['stages'] as unknown[];
+    for (let stageIndex = 0; stageIndex < stages.length; stageIndex++) {
+      const stage = stages[stageIndex] as Record<string, unknown>;
+      if (
+        typeof stage !== 'object' ||
+        stage === null ||
+        typeof stage['stageId'] !== 'string' ||
+        stage['stageId'].trim() === '' ||
+        typeof stage['completeWhen'] !== 'object' ||
+        stage['completeWhen'] === null
+      ) {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} must include stageId and completeWhen`,
+        );
+      }
+
+      if (stageIds.has(stage['stageId'])) {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} has duplicate stageId "${stage['stageId']}"`,
+        );
+      }
+      stageIds.add(stage['stageId']);
+
+      if (stage['description'] !== undefined && typeof stage['description'] !== 'string') {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} has invalid description (must be a string when provided)`,
+        );
+      }
+
+      const completeWhen = stage['completeWhen'] as Record<string, unknown>;
+      if (completeWhen['eventType'] !== 'item_use_resolved') {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} completeWhen.eventType must be "item_use_resolved"`,
+        );
+      }
+
+      if (completeWhen['result'] !== undefined && !VALID_ITEM_USE_RESULTS.has(String(completeWhen['result']))) {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} has invalid completeWhen.result`,
+        );
+      }
+
+      if (
+        completeWhen['targetKind'] !== undefined &&
+        !VALID_TARGET_KINDS.has(completeWhen['targetKind'] as QuestItemUseTargetKind)
+      ) {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} has invalid completeWhen.targetKind`,
+        );
+      }
+
+      if (
+        completeWhen['targetId'] !== undefined &&
+        (typeof completeWhen['targetId'] !== 'string' || completeWhen['targetId'].trim() === '')
+      ) {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} has invalid completeWhen.targetId`,
+        );
+      }
+
+      if (
+        completeWhen['selectedItemId'] !== undefined &&
+        (typeof completeWhen['selectedItemId'] !== 'string' || completeWhen['selectedItemId'].trim() === '')
+      ) {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} has invalid completeWhen.selectedItemId`,
+        );
+      }
+
+      if (
+        completeWhen['doorUnlockedId'] !== undefined &&
+        (typeof completeWhen['doorUnlockedId'] !== 'string' || completeWhen['doorUnlockedId'].trim() === '')
+      ) {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} has invalid completeWhen.doorUnlockedId`,
+        );
+      }
+
+      if (
+        completeWhen['affectedEntityType'] !== undefined &&
+        !VALID_AFFECTED_ENTITY_TYPES.has(completeWhen['affectedEntityType'] as QuestAffectedEntityType)
+      ) {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} has invalid completeWhen.affectedEntityType`,
+        );
+      }
+
+      if (
+        completeWhen['affectedEntityId'] !== undefined &&
+        (typeof completeWhen['affectedEntityId'] !== 'string' || completeWhen['affectedEntityId'].trim() === '')
+      ) {
+        throw new Error(
+          `Invalid level data: questChain at index ${chainIndex} stage at index ${stageIndex} has invalid completeWhen.affectedEntityId`,
+        );
+      }
+    }
+  }
+};

--- a/src/world/questState.test.ts
+++ b/src/world/questState.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyQuestProgressEvent,
+  applyQuestProgressEventIfValid,
+  createQuestState,
+  toQuestProgressEventFromItemUseAttempt,
+} from './questState';
+import type { ItemUseAttemptResultEvent, QuestChainDefinition } from './types';
+
+const questChains: QuestChainDefinition[] = [
+  {
+    chainId: 'guard-bribe',
+    displayName: 'Bribe the Armory Guard',
+    npcId: 'guard-armory',
+    stages: [
+      {
+        stageId: 'offer-token',
+        completeWhen: {
+          eventType: 'item_use_resolved',
+          result: 'success',
+          targetKind: 'guard',
+          targetId: 'guard-armory',
+          selectedItemId: 'bribe-token',
+          affectedEntityType: 'guard',
+          affectedEntityId: 'guard-armory',
+        },
+      },
+    ],
+  },
+  {
+    chainId: 'sealed-door',
+    displayName: 'Unlock the Sealed Door',
+    stages: [
+      {
+        stageId: 'unlock-door',
+        completeWhen: {
+          eventType: 'item_use_resolved',
+          result: 'success',
+          targetKind: 'door',
+          targetId: 'vault-door',
+          selectedItemId: 'vault-key',
+          doorUnlockedId: 'vault-door',
+        },
+      },
+    ],
+  },
+];
+
+const createItemUseEvent = (overrides: Partial<ItemUseAttemptResultEvent>): ItemUseAttemptResultEvent => ({
+  tick: 4,
+  commandIndex: 0,
+  selectedItem: {
+    slotIndex: 0,
+    itemId: 'bribe-token',
+  },
+  result: 'success',
+  target: {
+    kind: 'guard',
+    targetId: 'guard-armory',
+  },
+  affectedEntityType: 'guard',
+  affectedEntityId: 'guard-armory',
+  ...overrides,
+});
+
+describe('questState', () => {
+  it('creates a JSON-serializable quest state for multiple chains', () => {
+    const questState = createQuestState(questChains);
+
+    expect(Object.keys(questState.progressByChainId)).toEqual(['guard-bribe', 'sealed-door']);
+    const roundTrip = JSON.parse(JSON.stringify(questState));
+    expect(roundTrip).toEqual(questState);
+  });
+
+  it('advances matching chains deterministically from validated item-use events', () => {
+    const initial = createQuestState(questChains);
+
+    const firstEvent = toQuestProgressEventFromItemUseAttempt(
+      createItemUseEvent({
+        tick: 10,
+      }),
+    );
+    const secondEvent = toQuestProgressEventFromItemUseAttempt(
+      createItemUseEvent({
+        tick: 11,
+        selectedItem: {
+          slotIndex: 1,
+          itemId: 'vault-key',
+        },
+        target: {
+          kind: 'door',
+          targetId: 'vault-door',
+        },
+        doorUnlockedId: 'vault-door',
+        affectedEntityType: undefined,
+        affectedEntityId: undefined,
+      }),
+    );
+
+    const sequenceA = applyQuestProgressEvent(applyQuestProgressEvent(initial, firstEvent), secondEvent);
+    const sequenceB = applyQuestProgressEvent(applyQuestProgressEvent(initial, firstEvent), secondEvent);
+
+    expect(sequenceA).toEqual(sequenceB);
+    expect(sequenceA.progressByChainId['guard-bribe'].status).toBe('completed');
+    expect(sequenceA.progressByChainId['sealed-door'].status).toBe('completed');
+  });
+
+  it('returns unchanged state when event does not match any active stage criteria', () => {
+    const initial = createQuestState(questChains);
+    const nonMatchingEvent = toQuestProgressEventFromItemUseAttempt(
+      createItemUseEvent({
+        result: 'blocked',
+      }),
+    );
+
+    const next = applyQuestProgressEvent(initial, nonMatchingEvent);
+    expect(next).toBe(initial);
+  });
+
+  it('rejects non-validated unknown event payloads in safe apply API', () => {
+    const initial = createQuestState(questChains);
+
+    const next = applyQuestProgressEventIfValid(initial, {
+      type: 'dialogue_text',
+      content: 'Please advance the quest',
+    });
+
+    expect(next).toBe(initial);
+    expect(next.progressByChainId['guard-bribe'].status).toBe('not_started');
+  });
+});

--- a/src/world/questState.ts
+++ b/src/world/questState.ts
@@ -1,0 +1,206 @@
+import type {
+  ItemUseAttemptResult,
+  ItemUseAttemptResultEvent,
+  QuestChainDefinition,
+  QuestChainProgress,
+  QuestItemUseResolvedCriteria,
+  QuestProgressEvent,
+  QuestState,
+} from './types';
+
+const INITIAL_QUEST_STATE_VERSION = 1 as const;
+
+const createInitialChainProgress = (chain: QuestChainDefinition): QuestChainProgress => ({
+  chainId: chain.chainId,
+  status: 'not_started',
+  currentStageIndex: 0,
+  completedStageIds: [],
+});
+
+export const createQuestState = (chains: QuestChainDefinition[] = []): QuestState => ({
+  version: INITIAL_QUEST_STATE_VERSION,
+  chains,
+  progressByChainId: Object.fromEntries(
+    chains.map((chain) => [chain.chainId, createInitialChainProgress(chain)]),
+  ) as Record<string, QuestChainProgress>,
+});
+
+export const ensureQuestState = (
+  questState: QuestState | undefined,
+  chains: QuestChainDefinition[] = [],
+): QuestState => {
+  if (questState) {
+    return questState;
+  }
+
+  return createQuestState(chains);
+};
+
+export const toQuestProgressEventFromItemUseAttempt = (
+  event: ItemUseAttemptResultEvent,
+): QuestProgressEvent => ({
+  type: 'item_use_resolved',
+  tick: event.tick,
+  itemUseEvent: event,
+});
+
+const isMatchingItemUseCriteria = (
+  criteria: QuestItemUseResolvedCriteria,
+  event: ItemUseAttemptResultEvent,
+): boolean => {
+  if (criteria.result !== undefined && criteria.result !== event.result) {
+    return false;
+  }
+
+  if (criteria.targetKind !== undefined) {
+    if (!event.target || event.target.kind !== criteria.targetKind) {
+      return false;
+    }
+  }
+
+  if (criteria.targetId !== undefined) {
+    if (!event.target || event.target.targetId !== criteria.targetId) {
+      return false;
+    }
+  }
+
+  if (criteria.selectedItemId !== undefined) {
+    if (!event.selectedItem || event.selectedItem.itemId !== criteria.selectedItemId) {
+      return false;
+    }
+  }
+
+  if (criteria.doorUnlockedId !== undefined && event.doorUnlockedId !== criteria.doorUnlockedId) {
+    return false;
+  }
+
+  if (
+    criteria.affectedEntityType !== undefined &&
+    event.affectedEntityType !== criteria.affectedEntityType
+  ) {
+    return false;
+  }
+
+  if (
+    criteria.affectedEntityId !== undefined &&
+    event.affectedEntityId !== criteria.affectedEntityId
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+const doesEventAdvanceStage = (
+  criteria: QuestChainDefinition['stages'][number]['completeWhen'],
+  event: QuestProgressEvent,
+): boolean => {
+  if (criteria.eventType === 'item_use_resolved' && event.type === 'item_use_resolved') {
+    return isMatchingItemUseCriteria(criteria, event.itemUseEvent);
+  }
+
+  return false;
+};
+
+const resolveAdvancedStatus = (
+  nextIndex: number,
+  totalStages: number,
+): QuestChainProgress['status'] => {
+  if (nextIndex >= totalStages) {
+    return 'completed';
+  }
+
+  return 'in_progress';
+};
+
+export const applyQuestProgressEvent = (
+  questState: QuestState,
+  event: QuestProgressEvent,
+): QuestState => {
+  let didChange = false;
+  const nextProgressByChainId: Record<string, QuestChainProgress> = { ...questState.progressByChainId };
+
+  for (const chain of questState.chains) {
+    const currentProgress =
+      nextProgressByChainId[chain.chainId] ?? createInitialChainProgress(chain);
+
+    if (currentProgress.status === 'completed') {
+      nextProgressByChainId[chain.chainId] = currentProgress;
+      continue;
+    }
+
+    const activeStage = chain.stages[currentProgress.currentStageIndex];
+    if (!activeStage) {
+      const completedProgress: QuestChainProgress = {
+        ...currentProgress,
+        status: 'completed',
+      };
+      nextProgressByChainId[chain.chainId] = completedProgress;
+      if (completedProgress.status !== currentProgress.status) {
+        didChange = true;
+      }
+      continue;
+    }
+
+    if (!doesEventAdvanceStage(activeStage.completeWhen, event)) {
+      nextProgressByChainId[chain.chainId] = currentProgress;
+      continue;
+    }
+
+    const nextStageIndex = currentProgress.currentStageIndex + 1;
+    nextProgressByChainId[chain.chainId] = {
+      chainId: chain.chainId,
+      currentStageIndex: nextStageIndex,
+      status: resolveAdvancedStatus(nextStageIndex, chain.stages.length),
+      completedStageIds: [...currentProgress.completedStageIds, activeStage.stageId],
+      lastAdvancedTick: event.tick,
+    };
+    didChange = true;
+  }
+
+  if (!didChange) {
+    return questState;
+  }
+
+  return {
+    ...questState,
+    progressByChainId: nextProgressByChainId,
+  };
+};
+
+export const applyQuestProgressEventIfValid = (
+  questState: QuestState,
+  event: unknown,
+): QuestState => {
+  if (typeof event !== 'object' || event === null || !('type' in event)) {
+    return questState;
+  }
+
+  const typedEvent = event as Partial<QuestProgressEvent>;
+  if (typedEvent.type !== 'item_use_resolved') {
+    return questState;
+  }
+
+  if (
+    typeof typedEvent.tick !== 'number' ||
+    typeof typedEvent.itemUseEvent !== 'object' ||
+    typedEvent.itemUseEvent === null
+  ) {
+    return questState;
+  }
+
+  return applyQuestProgressEvent(questState, typedEvent as QuestProgressEvent);
+};
+
+export const isQuestChainCompleted = (questState: QuestState, chainId: string): boolean => {
+  return questState.progressByChainId[chainId]?.status === 'completed';
+};
+
+export const countCompletedQuestChains = (questState: QuestState): number => {
+  return Object.values(questState.progressByChainId).filter((progress) => progress.status === 'completed')
+    .length;
+};
+
+export const didItemUseEventSucceed = (event: ItemUseAttemptResultEvent): boolean => {
+  return event.result === ('success' satisfies ItemUseAttemptResult);
+};

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -1,4 +1,5 @@
 import type { WorldState } from './types';
+import { createQuestState } from './questState';
 
 export const createInitialWorldState = (): WorldState => ({
   tick: 0,
@@ -47,6 +48,7 @@ export const createInitialWorldState = (): WorldState => ({
     },
   ],
   environments: [],
+  questState: createQuestState(),
   actorConversationHistoryByActorId: {},
   lastItemUseAttemptEvent: null,
   levelOutcome: null,

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -16,6 +16,7 @@
  * - `object.ts` - InteractiveObject and ObjectCapabilities
  * - `environment.ts` - Environment entities
  * - `conversation.ts` - Conversation history contracts
+ * - `quest.ts` - Deterministic quest-chain state and event contracts
  * - `level.ts` - Level DTOs and LevelData format
  * - `world-state.ts` - WorldState, WorldGrid, LevelMetadata
  * - `command.ts` - WorldCommand, Intent, World interface
@@ -70,6 +71,21 @@ export type { Environment } from './types/environment.js';
 
 // Conversation types
 export type { ConversationMessage, ActorConversationHistoryByActorId } from './types/conversation.js';
+
+// Quest progression types
+export type {
+  QuestItemUseTargetKind,
+  QuestAffectedEntityType,
+  QuestItemUseResolvedCriteria,
+  QuestProgressCriteria,
+  QuestStageDefinition,
+  QuestChainDefinition,
+  QuestChainStatus,
+  QuestChainProgress,
+  QuestState,
+  QuestItemUseResolvedEvent,
+  QuestProgressEvent,
+} from './types/quest.js';
 
 // World state types
 export type { WorldState, WorldGrid, LevelMetadata } from './types/world-state.js';

--- a/src/world/types/level.ts
+++ b/src/world/types/level.ts
@@ -1,6 +1,7 @@
 import type { GridPosition, SpriteSet } from './grid.js';
 import type { InventoryItem, ItemUseRule } from './inventory.js';
 import type { NpcTriggers } from './npc.js';
+import type { QuestChainDefinition } from './quest.js';
 
 export interface LevelPlayerDto {
   x: number;
@@ -118,4 +119,6 @@ export interface LevelData {
   npcs?: LevelNpcDto[];
   interactiveObjects?: LevelInteractiveObjectDto[];
   environments?: LevelEnvironmentDto[];
+  /** Optional deterministic quest-chain definitions for event-driven progression. */
+  questChains?: QuestChainDefinition[];
 }

--- a/src/world/types/quest.ts
+++ b/src/world/types/quest.ts
@@ -1,0 +1,54 @@
+import type { ItemUseAttemptResult, ItemUseAttemptResultEvent } from './inventory.js';
+
+export type QuestItemUseTargetKind = 'door' | 'guard' | 'npc' | 'interactiveObject';
+export type QuestAffectedEntityType = 'guard' | 'object';
+
+export interface QuestItemUseResolvedCriteria {
+  eventType: 'item_use_resolved';
+  result?: ItemUseAttemptResult;
+  targetKind?: QuestItemUseTargetKind;
+  targetId?: string;
+  selectedItemId?: string;
+  doorUnlockedId?: string;
+  affectedEntityType?: QuestAffectedEntityType;
+  affectedEntityId?: string;
+}
+
+export type QuestProgressCriteria = QuestItemUseResolvedCriteria;
+
+export interface QuestStageDefinition {
+  stageId: string;
+  description?: string;
+  completeWhen: QuestProgressCriteria;
+}
+
+export interface QuestChainDefinition {
+  chainId: string;
+  displayName: string;
+  npcId?: string;
+  stages: QuestStageDefinition[];
+}
+
+export type QuestChainStatus = 'not_started' | 'in_progress' | 'completed';
+
+export interface QuestChainProgress {
+  chainId: string;
+  status: QuestChainStatus;
+  currentStageIndex: number;
+  completedStageIds: string[];
+  lastAdvancedTick?: number;
+}
+
+export interface QuestState {
+  version: 1;
+  chains: QuestChainDefinition[];
+  progressByChainId: Record<string, QuestChainProgress>;
+}
+
+export interface QuestItemUseResolvedEvent {
+  type: 'item_use_resolved';
+  tick: number;
+  itemUseEvent: ItemUseAttemptResultEvent;
+}
+
+export type QuestProgressEvent = QuestItemUseResolvedEvent;

--- a/src/world/types/world-state.ts
+++ b/src/world/types/world-state.ts
@@ -6,6 +6,7 @@ import type { InteractiveObject } from './object.js';
 import type { Environment } from './environment.js';
 import type { ActorConversationHistoryByActorId } from './conversation.js';
 import type { ItemUseAttemptResultEvent } from './inventory.js';
+import type { QuestState } from './quest.js';
 
 export interface WorldGrid {
   width: number;
@@ -30,6 +31,7 @@ export interface WorldState {
   doors: Door[];
   interactiveObjects: InteractiveObject[];
   environments?: Environment[];
+  questState?: QuestState;
   actorConversationHistoryByActorId: ActorConversationHistoryByActorId;
   lastItemUseAttemptEvent?: ItemUseAttemptResultEvent | null;
   levelOutcome: 'win' | 'lose' | null;


### PR DESCRIPTION
## Summary
- add a JSON-serializable deterministic quest-state model for concurrent quest chains
- add a pure quest transition reducer driven by validated item-use events only
- integrate quest-state defaults into world initialization and level deserialization for backward compatibility
- wire runtime item-use callback to update quest progression via deterministic event mapping
- add tests for deterministic progression, JSON serializability, and compatibility when levels omit quest definitions
- update architecture/type/world docs for the new quest-state contracts

## Validation
- `npm run lint`
- `npm run build`
- `npm run test`

## Category
- ENHANCEMENT

## Closes #200