### PR TITLE
#199 add deterministic knowledge-token grant and validation system

### DIFF
--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -15,6 +15,7 @@ Source of truth:
   - `src/world/types/environment.ts` - Environment
   - `src/world/types/conversation.ts` - ConversationMessage, ActorConversationHistoryByActorId
   - `src/world/types/quest.ts` - QuestState, QuestChainDefinition, QuestProgressEvent
+  - `src/world/types/knowledge.ts` - KnowledgeState, KnowledgeTokenOutcome, KnowledgeTokenValidationResult
   - `src/world/types/world-state.ts` - WorldState, WorldGrid, LevelMetadata
   - `src/world/types/level.ts` - LevelData, Level*Dto types
   - `src/world/types/command.ts` - WorldCommand, Intent, World interface
@@ -396,9 +397,27 @@ Stores conversation history by actor id. The current conversational actors are g
 - `interactiveObjects: InteractiveObject[]`
 - `environments?: Environment[]`
 - `questState?: QuestState` - deterministic quest-chain definitions and progression snapshot
+- `knowledgeState?: KnowledgeState` - deterministic persistent knowledge-token grant ledger
 - `actorConversationHistoryByActorId: ActorConversationHistoryByActorId`
 - `lastItemUseAttemptEvent?: ItemUseAttemptResultEvent | null` - latest resolved selected-item use attempt
 - `levelOutcome: 'win' | 'lose' | null`
+
+### KnowledgeState
+- `version: 1`
+- `tokensById: Record<string, KnowledgeTokenGrantRecord>`
+
+### KnowledgeTokenGrantRecord
+- `tokenId: string`
+- `grantedAtTick: number`
+- `grantedByActorId?: string`
+
+### KnowledgeTokenOutcome
+- `requireKnowledgeTokens?: string[]`
+- `grantKnowledgeTokens?: string[]`
+
+### KnowledgeTokenValidationResult
+- `isValid: boolean`
+- `missingKnowledgeTokens: string[]`
 
 ### QuestChainDefinition
 - `chainId: string`

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -66,6 +66,7 @@ Legacy `WorldCommand` objects (`move`, `selectInventorySlot`, `useSelectedItem`,
 - `interactiveObjects`
 - `environments`
 - `questState`
+- `knowledgeState`
 - `actorConversationHistoryByActorId`
 - `lastItemUseAttemptEvent`
 - `levelOutcome`
@@ -144,6 +145,17 @@ Deterministic rules:
 - Level deserialization initializes `questState` from optional `levelData.questChains` with safe defaults when omitted.
 - Quest progression is advanced only from validated item-use events emitted by the deterministic item-use resolver (`ItemUseAttemptResultEvent`) and never from LLM response text.
 - Quest transitions are pure world-layer reducer logic (`src/world/questState.ts`), so identical event sequences produce identical progression state.
+
+### Knowledge Token State
+
+`knowledgeState` is a serializable world field storing deterministic, persistent knowledge-token grants and validation readiness.
+
+Deterministic rules:
+- New runtime state initializes `knowledgeState` to an empty schema (`version: 1`, empty token map).
+- Level deserialization initializes `knowledgeState` with the same empty default, so levels without token content remain backward-compatible.
+- Token requirement checks are deterministic and non-consuming (persistent policy): validating required tokens never removes granted tokens.
+- Token grant and requirement evaluation are handled by pure world-layer reducers in `src/world/knowledgeState.ts`.
+- Token application is keyed only by structured outcome fields (`requireKnowledgeTokens`, `grantKnowledgeTokens`) and never by free-form LLM response text.
 
 ### Door Unlock State
 

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -631,4 +631,73 @@ describe('createNpcInteractionService', () => {
 
     expect(result.updatedWorldState.knowledgeState?.tokensById['seal-b']).toBeUndefined();
   });
+
+  it('blocks give/take inventory outcomes when knowledge token requirements are not satisfied', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({
+        text: 'You cannot trade yet.',
+        outcome: {
+          requireKnowledgeTokens: ['seal-a'],
+          giveItem: 'npc-token',
+          takeItem: 'player-token',
+        },
+      }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      inventory: [
+        {
+          itemId: 'npc-token',
+          displayName: 'NPC Token',
+          sourceObjectId: 'npc-1',
+          pickedUpAtTick: 0,
+        },
+      ],
+    };
+    const player = {
+      ...worldState.player,
+      inventory: {
+        ...worldState.player.inventory,
+        items: [
+          {
+            itemId: 'player-token',
+            displayName: 'Player Token',
+            sourceObjectId: 'object-2',
+            pickedUpAtTick: 1,
+          },
+        ],
+      },
+    };
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player,
+      worldState: {
+        ...worldState,
+        player,
+        npcs: [npc],
+      },
+      playerMessage: 'Trade?',
+    });
+
+    expect(result.updatedWorldState.player.inventory.items).toEqual([
+      {
+        itemId: 'player-token',
+        displayName: 'Player Token',
+        sourceObjectId: 'object-2',
+        pickedUpAtTick: 1,
+      },
+    ]);
+    expect(result.updatedWorldState.npcs[0].inventory).toEqual([
+      {
+        itemId: 'npc-token',
+        displayName: 'NPC Token',
+        sourceObjectId: 'npc-1',
+        pickedUpAtTick: 0,
+      },
+    ]);
+    expect(result.updatedWorldState.knowledgeState?.tokensById['seal-a']).toBeUndefined();
+  });
 });

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -576,4 +576,59 @@ describe('createNpcInteractionService', () => {
       },
     ]);
   });
+
+  it('grants knowledge tokens from structured outcome fields regardless of assistant wording', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({
+        text: 'Completely unrelated prose.',
+        outcome: {
+          grantKnowledgeTokens: ['seal-c', 'seal-a', 'seal-c'],
+        },
+      }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Share knowledge?',
+    });
+
+    expect(Object.keys(result.updatedWorldState.knowledgeState?.tokensById ?? {})).toEqual([
+      'seal-a',
+      'seal-c',
+    ]);
+    expect(result.updatedWorldState.knowledgeState?.tokensById['seal-a']).toEqual({
+      tokenId: 'seal-a',
+      grantedAtTick: 0,
+      grantedByActorId: npc.id,
+    });
+  });
+
+  it('does not grant new knowledge tokens when outcome requirements are not satisfied', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({
+        text: 'You are not ready for this yet.',
+        outcome: {
+          requireKnowledgeTokens: ['seal-a'],
+          grantKnowledgeTokens: ['seal-b'],
+        },
+      }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Share the second phrase?',
+    });
+
+    expect(result.updatedWorldState.knowledgeState?.tokensById['seal-b']).toBeUndefined();
+  });
 });

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -1,5 +1,6 @@
 import { isLlmRequestError, type LlmRequestError, type LlmClient } from '../llm/client';
 import { Item } from '../world/entities/items/Item';
+import { applyKnowledgeTokenOutcomeIfValid } from '../world/knowledgeState';
 import type { ConversationMessage, Npc, Player, WorldState } from '../world/types';
 import {
   createDefaultNpcFunctionRegistry,
@@ -15,6 +16,8 @@ import { buildNpcPromptContext } from './npcPromptContext';
 interface NpcInteractionOutcome {
   giveItem?: string;
   takeItem?: string;
+  requireKnowledgeTokens?: string[];
+  grantKnowledgeTokens?: string[];
 }
 
 const applyTalkTrigger = (npc: Npc): Npc => {
@@ -206,19 +209,33 @@ export const createNpcInteractionService = (
       actorConversationHistoryByActorId: updatedHistoryByActorId,
     };
 
+    const knowledgeOutcomeResolution = applyKnowledgeTokenOutcomeIfValid(
+      stateWithUpdatedHistory.knowledgeState,
+      llmResult.outcome,
+      {
+        tick: stateWithUpdatedHistory.tick,
+        grantedByActorId: request.npc.id,
+      },
+    );
+
+    const stateWithKnowledgeTokens: WorldState = {
+      ...stateWithUpdatedHistory,
+      knowledgeState: knowledgeOutcomeResolution.knowledgeState,
+    };
+
     const npcFromWorldState =
-      stateWithUpdatedHistory.npcs.find((candidate) => candidate.id === request.npc.id) ?? request.npc;
+      stateWithKnowledgeTokens.npcs.find((candidate) => candidate.id === request.npc.id) ?? request.npc;
     const npcAfterTalkTrigger = applyTalkTrigger(npcFromWorldState);
     const inventoryResult = applyInventoryOutcome(
       npcAfterTalkTrigger,
-      stateWithUpdatedHistory.player,
+      stateWithKnowledgeTokens.player,
       llmResult.outcome,
     );
 
     const updatedWorldState: WorldState = {
-      ...stateWithUpdatedHistory,
+      ...stateWithKnowledgeTokens,
       player: inventoryResult.player,
-      npcs: stateWithUpdatedHistory.npcs.map((npc) =>
+      npcs: stateWithKnowledgeTokens.npcs.map((npc) =>
         npc.id === request.npc.id ? inventoryResult.npc : npc,
       ),
     };

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -229,7 +229,7 @@ export const createNpcInteractionService = (
     const inventoryResult = applyInventoryOutcome(
       npcAfterTalkTrigger,
       stateWithKnowledgeTokens.player,
-      llmResult.outcome,
+      knowledgeOutcomeResolution.isValid ? llmResult.outcome : undefined,
     );
 
     const updatedWorldState: WorldState = {

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -19,6 +19,8 @@ export interface LlmResponse {
   outcome?: {
     giveItem?: string;
     takeItem?: string;
+    requireKnowledgeTokens?: string[];
+    grantKnowledgeTokens?: string[];
   };
 }
 

--- a/src/world/knowledgeState.test.ts
+++ b/src/world/knowledgeState.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyKnowledgeTokenOutcome,
+  applyKnowledgeTokenOutcomeIfValid,
+  createKnowledgeState,
+  ensureKnowledgeState,
+  validateKnowledgeTokenRequirements,
+} from './knowledgeState';
+
+describe('knowledgeState', () => {
+  it('creates JSON-serializable deterministic default state', () => {
+    const knowledgeState = createKnowledgeState();
+
+    expect(knowledgeState).toEqual({
+      version: 1,
+      tokensById: {},
+    });
+
+    const roundTrip = JSON.parse(JSON.stringify(knowledgeState));
+    expect(roundTrip).toEqual(knowledgeState);
+  });
+
+  it('grants knowledge tokens deterministically from a validated outcome', () => {
+    const initial = createKnowledgeState();
+
+    const first = applyKnowledgeTokenOutcome(
+      initial,
+      {
+        grantKnowledgeTokens: ['seal-b', 'seal-a', 'seal-b'],
+      },
+      {
+        tick: 14,
+        grantedByActorId: 'npc-archivist',
+      },
+    );
+
+    const second = applyKnowledgeTokenOutcome(
+      initial,
+      {
+        grantKnowledgeTokens: ['seal-b', 'seal-a', 'seal-b'],
+      },
+      {
+        tick: 14,
+        grantedByActorId: 'npc-archivist',
+      },
+    );
+
+    expect(first).toEqual(second);
+    expect(Object.keys(first.knowledgeState.tokensById)).toEqual(['seal-a', 'seal-b']);
+    expect(first.knowledgeState.tokensById['seal-a']).toEqual({
+      tokenId: 'seal-a',
+      grantedAtTick: 14,
+      grantedByActorId: 'npc-archivist',
+    });
+  });
+
+  it('validates requirements successfully when all tokens are present', () => {
+    const seeded = applyKnowledgeTokenOutcome(
+      createKnowledgeState(),
+      {
+        grantKnowledgeTokens: ['seal-a', 'seal-b'],
+      },
+      {
+        tick: 3,
+      },
+    ).knowledgeState;
+
+    const validation = validateKnowledgeTokenRequirements(seeded, ['seal-b', 'seal-a']);
+
+    expect(validation).toEqual({
+      isValid: true,
+      missingKnowledgeTokens: [],
+    });
+  });
+
+  it('fails validation with deterministic sorted missing token ids', () => {
+    const validation = validateKnowledgeTokenRequirements(createKnowledgeState(), [
+      'seal-c',
+      'seal-a',
+      'seal-b',
+    ]);
+
+    expect(validation).toEqual({
+      isValid: false,
+      missingKnowledgeTokens: ['seal-a', 'seal-b', 'seal-c'],
+    });
+  });
+
+  it('keeps token requirements persistent and non-consuming across repeated validation', () => {
+    const seeded = applyKnowledgeTokenOutcome(
+      createKnowledgeState(),
+      {
+        grantKnowledgeTokens: ['seal-a'],
+      },
+      {
+        tick: 9,
+      },
+    ).knowledgeState;
+
+    const firstValidation = validateKnowledgeTokenRequirements(seeded, ['seal-a']);
+    const secondValidation = validateKnowledgeTokenRequirements(seeded, ['seal-a']);
+
+    expect(firstValidation).toEqual({
+      isValid: true,
+      missingKnowledgeTokens: [],
+    });
+    expect(secondValidation).toEqual(firstValidation);
+    expect(seeded.tokensById['seal-a']).toBeDefined();
+  });
+
+  it('blocks grants when required tokens are missing', () => {
+    const result = applyKnowledgeTokenOutcome(
+      createKnowledgeState(),
+      {
+        requireKnowledgeTokens: ['seal-a'],
+        grantKnowledgeTokens: ['seal-b'],
+      },
+      {
+        tick: 22,
+      },
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.missingKnowledgeTokens).toEqual(['seal-a']);
+    expect(result.knowledgeState.tokensById['seal-b']).toBeUndefined();
+  });
+
+  it('ignores malformed unknown outcomes in safe apply API', () => {
+    const initial = createKnowledgeState();
+
+    const result = applyKnowledgeTokenOutcomeIfValid(initial, { grantKnowledgeTokens: [42] }, { tick: 1 });
+
+    expect(result).toEqual({
+      isValid: false,
+      missingKnowledgeTokens: [],
+      knowledgeState: initial,
+    });
+  });
+
+  it('ensures backward-compatible defaults for undefined state', () => {
+    const ensured = ensureKnowledgeState(undefined);
+
+    expect(ensured).toEqual(createKnowledgeState());
+  });
+});

--- a/src/world/knowledgeState.ts
+++ b/src/world/knowledgeState.ts
@@ -1,0 +1,158 @@
+import type {
+  KnowledgeState,
+  KnowledgeTokenOutcome,
+  KnowledgeTokenOutcomeResolution,
+  KnowledgeTokenValidationResult,
+} from './types';
+
+const INITIAL_KNOWLEDGE_STATE_VERSION = 1 as const;
+
+const normalizeTokenIds = (tokenIds: readonly string[]): string[] => {
+  const normalized = tokenIds
+    .filter((tokenId) => typeof tokenId === 'string')
+    .map((tokenId) => tokenId.trim())
+    .filter((tokenId) => tokenId.length > 0);
+
+  return [...new Set(normalized)].sort();
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+export const createKnowledgeState = (): KnowledgeState => ({
+  version: INITIAL_KNOWLEDGE_STATE_VERSION,
+  tokensById: {},
+});
+
+export const ensureKnowledgeState = (knowledgeState: KnowledgeState | undefined): KnowledgeState => {
+  return knowledgeState ?? createKnowledgeState();
+};
+
+export const validateKnowledgeTokenRequirements = (
+  knowledgeState: KnowledgeState | undefined,
+  requiredTokenIds: readonly string[] = [],
+): KnowledgeTokenValidationResult => {
+  const stableKnowledgeState = ensureKnowledgeState(knowledgeState);
+  const required = normalizeTokenIds(requiredTokenIds);
+  const missingKnowledgeTokens = required.filter(
+    (tokenId) => stableKnowledgeState.tokensById[tokenId] === undefined,
+  );
+
+  return {
+    isValid: missingKnowledgeTokens.length === 0,
+    missingKnowledgeTokens,
+  };
+};
+
+export interface ApplyKnowledgeTokenOutcomeOptions {
+  tick: number;
+  grantedByActorId?: string;
+}
+
+export const applyKnowledgeTokenOutcome = (
+  knowledgeState: KnowledgeState | undefined,
+  outcome: KnowledgeTokenOutcome | undefined,
+  options: ApplyKnowledgeTokenOutcomeOptions,
+): KnowledgeTokenOutcomeResolution => {
+  const stableKnowledgeState = ensureKnowledgeState(knowledgeState);
+  if (!outcome) {
+    return {
+      isValid: true,
+      missingKnowledgeTokens: [],
+      knowledgeState: stableKnowledgeState,
+    };
+  }
+
+  const validation = validateKnowledgeTokenRequirements(
+    stableKnowledgeState,
+    outcome.requireKnowledgeTokens ?? [],
+  );
+  if (!validation.isValid) {
+    return {
+      ...validation,
+      knowledgeState: stableKnowledgeState,
+    };
+  }
+
+  const grantKnowledgeTokens = normalizeTokenIds(outcome.grantKnowledgeTokens ?? []);
+  if (grantKnowledgeTokens.length === 0) {
+    return {
+      isValid: true,
+      missingKnowledgeTokens: [],
+      knowledgeState: stableKnowledgeState,
+    };
+  }
+
+  let didChange = false;
+  const nextTokensById = { ...stableKnowledgeState.tokensById };
+
+  for (const tokenId of grantKnowledgeTokens) {
+    if (nextTokensById[tokenId] !== undefined) {
+      continue;
+    }
+
+    nextTokensById[tokenId] = {
+      tokenId,
+      grantedAtTick: options.tick,
+      ...(options.grantedByActorId ? { grantedByActorId: options.grantedByActorId } : {}),
+    };
+    didChange = true;
+  }
+
+  return {
+    isValid: true,
+    missingKnowledgeTokens: [],
+    knowledgeState: didChange
+      ? {
+          ...stableKnowledgeState,
+          tokensById: nextTokensById,
+        }
+      : stableKnowledgeState,
+  };
+};
+
+const isStringArray = (value: unknown): value is string[] => {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+};
+
+export const isKnowledgeTokenOutcome = (value: unknown): value is KnowledgeTokenOutcome => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (
+    'requireKnowledgeTokens' in value &&
+    value.requireKnowledgeTokens !== undefined &&
+    !isStringArray(value.requireKnowledgeTokens)
+  ) {
+    return false;
+  }
+
+  if (
+    'grantKnowledgeTokens' in value &&
+    value.grantKnowledgeTokens !== undefined &&
+    !isStringArray(value.grantKnowledgeTokens)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+export const applyKnowledgeTokenOutcomeIfValid = (
+  knowledgeState: KnowledgeState | undefined,
+  outcome: unknown,
+  options: ApplyKnowledgeTokenOutcomeOptions,
+): KnowledgeTokenOutcomeResolution => {
+  const stableKnowledgeState = ensureKnowledgeState(knowledgeState);
+  if (!isKnowledgeTokenOutcome(outcome)) {
+    return {
+      isValid: false,
+      missingKnowledgeTokens: [],
+      knowledgeState: stableKnowledgeState,
+    };
+  }
+
+  return applyKnowledgeTokenOutcome(stableKnowledgeState, outcome, options);
+};

--- a/src/world/level.ts
+++ b/src/world/level.ts
@@ -18,6 +18,7 @@ import { mapPlayerDtoToRuntime } from './levelMapping/mapPlayer';
 import { mapDoorDtoToRuntime } from './levelMapping/mapDoor';
 import { mapNpcWithRiddleClue } from './levelMapping/mapNpcWithRiddleClue';
 import { createQuestState } from './questState';
+import { createKnowledgeState } from './knowledgeState';
 
 interface LayoutBounds {
   width: number;
@@ -143,6 +144,7 @@ export function deserializeLevel(levelData: LevelData, parsedLayout: ParsedLayou
       mapEnvironmentDtoToRuntime(environment),
     ),
     questState: createQuestState(levelData.questChains ?? []),
+    knowledgeState: createKnowledgeState(),
     actorConversationHistoryByActorId: {},
     lastItemUseAttemptEvent: null,
     levelOutcome: null,

--- a/src/world/state.ts
+++ b/src/world/state.ts
@@ -1,5 +1,6 @@
 import type { WorldState } from './types';
 import { createQuestState } from './questState';
+import { createKnowledgeState } from './knowledgeState';
 
 export const createInitialWorldState = (): WorldState => ({
   tick: 0,
@@ -49,6 +50,7 @@ export const createInitialWorldState = (): WorldState => ({
   ],
   environments: [],
   questState: createQuestState(),
+  knowledgeState: createKnowledgeState(),
   actorConversationHistoryByActorId: {},
   lastItemUseAttemptEvent: null,
   levelOutcome: null,

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -17,6 +17,7 @@
  * - `environment.ts` - Environment entities
  * - `conversation.ts` - Conversation history contracts
  * - `quest.ts` - Deterministic quest-chain state and event contracts
+ * - `knowledge.ts` - Deterministic knowledge-token state and validation contracts
  * - `level.ts` - Level DTOs and LevelData format
  * - `world-state.ts` - WorldState, WorldGrid, LevelMetadata
  * - `command.ts` - WorldCommand, Intent, World interface
@@ -86,6 +87,15 @@ export type {
   QuestItemUseResolvedEvent,
   QuestProgressEvent,
 } from './types/quest.js';
+
+// Knowledge-token progression types
+export type {
+  KnowledgeTokenGrantRecord,
+  KnowledgeState,
+  KnowledgeTokenOutcome,
+  KnowledgeTokenValidationResult,
+  KnowledgeTokenOutcomeResolution,
+} from './types/knowledge.js';
 
 // World state types
 export type { WorldState, WorldGrid, LevelMetadata } from './types/world-state.js';

--- a/src/world/types/knowledge.ts
+++ b/src/world/types/knowledge.ts
@@ -1,0 +1,24 @@
+export interface KnowledgeTokenGrantRecord {
+  tokenId: string;
+  grantedAtTick: number;
+  grantedByActorId?: string;
+}
+
+export interface KnowledgeState {
+  version: 1;
+  tokensById: Record<string, KnowledgeTokenGrantRecord>;
+}
+
+export interface KnowledgeTokenOutcome {
+  requireKnowledgeTokens?: string[];
+  grantKnowledgeTokens?: string[];
+}
+
+export interface KnowledgeTokenValidationResult {
+  isValid: boolean;
+  missingKnowledgeTokens: string[];
+}
+
+export interface KnowledgeTokenOutcomeResolution extends KnowledgeTokenValidationResult {
+  knowledgeState: KnowledgeState;
+}

--- a/src/world/types/world-state.ts
+++ b/src/world/types/world-state.ts
@@ -7,6 +7,7 @@ import type { Environment } from './environment.js';
 import type { ActorConversationHistoryByActorId } from './conversation.js';
 import type { ItemUseAttemptResultEvent } from './inventory.js';
 import type { QuestState } from './quest.js';
+import type { KnowledgeState } from './knowledge.js';
 
 export interface WorldGrid {
   width: number;
@@ -32,6 +33,7 @@ export interface WorldState {
   interactiveObjects: InteractiveObject[];
   environments?: Environment[];
   questState?: QuestState;
+  knowledgeState?: KnowledgeState;
   actorConversationHistoryByActorId: ActorConversationHistoryByActorId;
   lastItemUseAttemptEvent?: ItemUseAttemptResultEvent | null;
   levelOutcome: 'win' | 'lose' | null;


### PR DESCRIPTION
## Summary
- add deterministic, JSON-serializable knowledge-token world model (`knowledgeState`) with a dedicated world-layer reducer module
- add deterministic grant/requirement validation APIs with persistent-token policy (validation does not consume tokens)
- apply structured knowledge-token outcomes in NPC interaction flow using validated fields (`requireKnowledgeTokens`, `grantKnowledgeTokens`) independent from assistant wording
- preserve backward compatibility by initializing defaults in baseline world state and level deserialization
- update type and world-layer documentation for the new contract

## Validation
- `npm run lint`
- `npm run build`
- `npm run test`

## Closes #199