### PR TITLE
#202 add deterministic npc trade rules

### DIFF
--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -126,6 +126,13 @@ LLM boundary note:
 - No LLM call is involved in item-use result determination.
 - Guard and object item-use rules are entirely code-determined; success/failure outcomes cannot be negotiated with the LLM.
 
+### NPC Trade Resolution Boundary
+
+Conversational NPC turns may still use the LLM for dialogue text, but NPC item-required reward trades are resolved separately from the response text:
+- `src/interaction/npcInteraction.ts` records the conversation turn and then calls deterministic world trade logic in `src/world/npcTrade.ts`.
+- `npc.tradeRules` data, current player inventory, and `npc.tradeState` decide whether a trade succeeds.
+- When an NPC has trade rules, trade inventory mutation is world-owned; free-form assistant wording does not grant or deny the reward.
+
 ## Conversation Pause Lifecycle
 
 When the player chooses Chat from an action-modal session, `onConversationStarted` is routed from [src/runtime/interactionResultBridge.ts](../src/runtime/interactionResultBridge.ts) into [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts). The runtime bridge + modal coordinator then perform three side effects in order:

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -9,7 +9,7 @@ Source of truth:
   - `src/world/types/player.ts` - Player
   - `src/world/types/inventory.ts` - Inventory and item-use types
   - `src/world/types/guard.ts` - Guard
-  - `src/world/types/npc.ts` - Npc, RiddleClue, RiddleClueConstraint
+  - `src/world/types/npc.ts` - Npc, NpcTradeRule, NpcTradeState, RiddleClue, RiddleClueConstraint
   - `src/world/types/door.ts` - Door
   - `src/world/types/object.ts` - InteractiveObject, ObjectCapabilities
   - `src/world/types/environment.ts` - Environment
@@ -90,13 +90,15 @@ Extends `ActorInit`:
 - `patrol?: { path: Array<{ x: number; y: number }> }`
 - `triggers?: NpcTriggers`
 - `inventory?: InventoryItem[]`
+- `tradeRules?: NpcTradeRule[]`
+- `tradeState?: NpcTradeState`
 - `instanceKnowledge?: string`
 - `instanceBehavior?: string`
 - `riddleClue?: RiddleClue`
 
 ### GuardNpcInit
 Extends `NpcInit` with guard-specialized constraints:
-- omits `npcType`, `dialogueContextKey`, `patrol`, `triggers`, `inventory`, `riddleClue` from constructor input
+- omits `npcType`, `dialogueContextKey`, `patrol`, `triggers`, `inventory`, `tradeRules`, `tradeState`, `riddleClue` from constructor input
 - `guardState: 'idle' | 'patrolling' | 'alert'`
 - `itemUseRules?: Record<string, ItemUseRule>`
 
@@ -235,6 +237,24 @@ Serializable trigger mutation used by NPC approach/talk hooks.
 - `onTalk?: TriggerEffect`
 
 Optional trigger hooks for deterministic NPC state updates.
+
+### NpcTradeRewardItem
+- `itemId: string`
+- `displayName: string`
+
+Serializable reward descriptor used by deterministic NPC trade rules.
+
+### NpcTradeRule
+- `ruleId: string`
+- `requiredItemIds: string[]`
+- `rewardItems: NpcTradeRewardItem[]`
+
+Declarative deterministic NPC exchange rule. Satisfied requirements consume player inventory items and grant reward items through world logic.
+
+### NpcTradeState
+- `completedRuleIds: string[]`
+
+Serializable replay guard for one-time NPC trade rewards.
 
 ### Player
 - `id: string`

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -157,6 +157,17 @@ Deterministic rules:
 - Token grant and requirement evaluation are handled by pure world-layer reducers in `src/world/knowledgeState.ts`.
 - Token application is keyed only by structured outcome fields (`requireKnowledgeTokens`, `grantKnowledgeTokens`) and never by free-form LLM response text.
 
+### NPC Trade State
+
+`npc.tradeRules` and `npc.tradeState` are serializable world-owned fields that define deterministic item-required reward exchanges and one-time completion tracking.
+
+Deterministic rules:
+- Levels may omit `tradeRules` entirely; NPC loading remains backward-compatible.
+- Trade requirements are evaluated from player inventory by pure world logic in `src/world/npcTrade.ts`.
+- Successful trades consume the configured required items and grant configured reward items exactly once per `ruleId`.
+- Repeated interactions from an already-completed resulting world state cannot duplicate rewards because `tradeState.completedRuleIds` blocks replay.
+- NPC trade success or failure is never inferred from free-form LLM wording.
+
 ### Door Unlock State
 
 `door.isUnlocked` is a serializable boolean flag that tracks whether a door has been unlocked via item-use interaction.
@@ -179,7 +190,7 @@ Deterministic rules:
 | `validatePlayer.ts` | player `x`/`y`, optional `spriteAssetPath` and `spriteSet` |
 | `validateGuards.ts` | guards array: identity, position, guardState, traits, sprites, instance fields, itemUseRules |
 | `validateDoors.ts` | doors array: identity, position, doorState, outcome, requiredItemId, sprites |
-| `validateNpcs.ts` | npcs array: identity, position, npcType, patrol path bounds, triggers, inventory, riddleClue |
+| `validateNpcs.ts` | npcs array: identity, position, npcType, patrol path bounds, triggers, inventory, tradeRules, riddleClue |
 | `validateObjects.ts` | interactiveObjects array: identity, position, objectType, interactionType, state, pickupItem, sprites, capabilities, itemUseRules |
 | `validateEnvironments.ts` | environments array: identity, position, isBlocking |
 | `validateQuestChains.ts` | optional questChains array: chain identity, stage identity, and deterministic item-use event criteria |
@@ -193,6 +204,7 @@ Deterministic rules:
 - `validateTriggerEffect()` — enforces setFact + typed value
 - `validateNpcTriggers()` — enforces known trigger keys and delegates to validateTriggerEffect
 - `validateInventoryItems()` — enforces inventory item shape
+- `validateNpcTradeRules()` — enforces deterministic NPC trade rule schema
 
 Validation boundary rule:
 - validation remains DTO-only and does not instantiate runtime classes

--- a/src/interaction/npcInteraction.test.ts
+++ b/src/interaction/npcInteraction.test.ts
@@ -700,4 +700,116 @@ describe('createNpcInteractionService', () => {
     ]);
     expect(result.updatedWorldState.knowledgeState?.tokensById['seal-a']).toBeUndefined();
   });
+
+  it('applies npc trade rules from world data instead of LLM inventory outcome fields', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({
+        text: 'I can make that exchange.',
+        outcome: {
+          giveItem: 'llm-only-item',
+          takeItem: 'llm-only-cost',
+        },
+      }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      tradeRules: [
+        {
+          ruleId: 'swap-pass-for-key',
+          requiredItemIds: ['gate-pass'],
+          rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+        },
+      ],
+    };
+    const player = {
+      ...worldState.player,
+      inventory: {
+        ...worldState.player.inventory,
+        items: [
+          {
+            itemId: 'gate-pass',
+            displayName: 'Gate Pass',
+            sourceObjectId: 'object-2',
+            pickedUpAtTick: 1,
+          },
+        ],
+      },
+    };
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player,
+      worldState: {
+        ...worldState,
+        player,
+        npcs: [npc],
+      },
+      playerMessage: 'Trade?',
+    });
+
+    expect(result.updatedWorldState.player.inventory.items).toEqual([
+      {
+        itemId: 'archive-key',
+        displayName: 'Archive Key',
+        sourceObjectId: npc.id,
+        pickedUpAtTick: 0,
+      },
+    ]);
+    expect(result.updatedWorldState.npcs[0].tradeState).toEqual({
+      completedRuleIds: ['swap-pass-for-key'],
+    });
+  });
+
+  it('does not mutate inventory when npc trade requirements are missing even if the LLM returns item outcomes', async () => {
+    const llmClient: LlmClient = {
+      complete: async () => ({
+        text: 'You still need the pass.',
+        outcome: {
+          giveItem: 'llm-only-item',
+        },
+      }),
+    };
+    const service = createNpcInteractionService(llmClient);
+    const worldState = createInitialWorldState();
+    const npc = {
+      ...worldState.npcs[0],
+      tradeRules: [
+        {
+          ruleId: 'swap-pass-for-key',
+          requiredItemIds: ['gate-pass'],
+          rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+        },
+      ],
+    };
+    const player = {
+      ...worldState.player,
+      inventory: {
+        ...worldState.player.inventory,
+        items: [
+          {
+            itemId: 'apple',
+            displayName: 'Apple',
+            sourceObjectId: 'object-2',
+            pickedUpAtTick: 1,
+          },
+        ],
+      },
+    };
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player,
+      worldState: {
+        ...worldState,
+        player,
+        npcs: [npc],
+      },
+      playerMessage: 'Trade?',
+    });
+
+    expect(result.updatedWorldState.player.inventory.items).toEqual(player.inventory.items);
+    expect(result.updatedWorldState.npcs[0].tradeState).toBeUndefined();
+  });
 });

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -1,6 +1,7 @@
 import { isLlmRequestError, type LlmRequestError, type LlmClient } from '../llm/client';
 import { Item } from '../world/entities/items/Item';
 import { applyKnowledgeTokenOutcomeIfValid } from '../world/knowledgeState';
+import { resolveNpcTrade } from '../world/npcTrade';
 import type { ConversationMessage, Npc, Player, WorldState } from '../world/types';
 import {
   createDefaultNpcFunctionRegistry,
@@ -226,10 +227,17 @@ export const createNpcInteractionService = (
     const npcFromWorldState =
       stateWithKnowledgeTokens.npcs.find((candidate) => candidate.id === request.npc.id) ?? request.npc;
     const npcAfterTalkTrigger = applyTalkTrigger(npcFromWorldState);
-    const inventoryResult = applyInventoryOutcome(
+    const tradeResult = resolveNpcTrade(
       npcAfterTalkTrigger,
       stateWithKnowledgeTokens.player,
-      knowledgeOutcomeResolution.isValid ? llmResult.outcome : undefined,
+      stateWithKnowledgeTokens.tick,
+    );
+    const inventoryResult = applyInventoryOutcome(
+      tradeResult.npc,
+      tradeResult.player,
+      knowledgeOutcomeResolution.isValid && !(tradeResult.npc.tradeRules?.length)
+        ? llmResult.outcome
+        : undefined,
     );
 
     const updatedWorldState: WorldState = {

--- a/src/world/entities/dtoRuntimeSeams.ts
+++ b/src/world/entities/dtoRuntimeSeams.ts
@@ -53,6 +53,7 @@ export const mapNpcDtoToRuntime = (dto: NpcDtoContract): Npc =>
     patrol: dto.patrol,
     triggers: dto.triggers,
     inventory: dto.inventory?.map(mapInventoryItemDtoToRuntime),
+    tradeRules: dto.tradeRules,
     instanceKnowledge: dto.instanceKnowledge,
     instanceBehavior: dto.instanceBehavior,
   });

--- a/src/world/entities/npcs/GuardNpc.ts
+++ b/src/world/entities/npcs/GuardNpc.ts
@@ -1,7 +1,11 @@
 import type { ItemUseRule } from '../../types';
 import { Npc, type NpcInit } from './Npc';
 
-export interface GuardNpcInit extends Omit<NpcInit, 'npcType' | 'dialogueContextKey' | 'patrol' | 'triggers' | 'inventory' | 'riddleClue'> {
+export interface GuardNpcInit
+  extends Omit<
+    NpcInit,
+    'npcType' | 'dialogueContextKey' | 'patrol' | 'triggers' | 'inventory' | 'tradeRules' | 'tradeState' | 'riddleClue'
+  > {
   guardState: 'idle' | 'patrolling' | 'alert';
   itemUseRules?: Record<string, ItemUseRule>;
 }

--- a/src/world/entities/npcs/Npc.ts
+++ b/src/world/entities/npcs/Npc.ts
@@ -1,4 +1,10 @@
-import type { InventoryItem, NpcTriggers, RiddleClue } from '../../types';
+import type {
+  InventoryItem,
+  NpcTradeRule,
+  NpcTradeState,
+  NpcTriggers,
+  RiddleClue,
+} from '../../types';
 import { Actor, type ActorInit } from '../base/Actor';
 import { Item } from '../items/Item';
 
@@ -8,6 +14,8 @@ export interface NpcInit extends ActorInit {
   patrol?: { path: Array<{ x: number; y: number }> };
   triggers?: NpcTriggers;
   inventory?: InventoryItem[];
+  tradeRules?: NpcTradeRule[];
+  tradeState?: NpcTradeState;
   instanceKnowledge?: string;
   instanceBehavior?: string;
   riddleClue?: RiddleClue;
@@ -19,6 +27,8 @@ export class Npc extends Actor {
   public patrol?: { path: Array<{ x: number; y: number }> };
   public triggers?: NpcTriggers;
   public inventory?: InventoryItem[];
+  public tradeRules?: NpcTradeRule[];
+  public tradeState?: NpcTradeState;
   public instanceKnowledge?: string;
   public instanceBehavior?: string;
   public riddleClue?: RiddleClue;
@@ -30,6 +40,16 @@ export class Npc extends Actor {
     this.patrol = init.patrol ? { path: init.patrol.path.map((position) => ({ ...position })) } : undefined;
     this.triggers = init.triggers;
     this.inventory = init.inventory?.map((item) => Item.fromInventoryItem(item));
+    this.tradeRules = init.tradeRules?.map((rule) => ({
+      ruleId: rule.ruleId,
+      requiredItemIds: [...rule.requiredItemIds],
+      rewardItems: rule.rewardItems.map((item) => ({ ...item })),
+    }));
+    this.tradeState = init.tradeState
+      ? {
+          completedRuleIds: [...init.tradeState.completedRuleIds],
+        }
+      : undefined;
     this.instanceKnowledge = init.instanceKnowledge;
     this.instanceBehavior = init.instanceBehavior;
     this.riddleClue = init.riddleClue ? { ...init.riddleClue } : undefined;

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -1034,6 +1034,50 @@ describe('npcs field', () => {
     expect(state.npcs[0].dialogueContextKey).toBe('npc_guard_captain');
   });
 
+  it('maps optional npc trade rules into serializable runtime state', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      npcs: [
+        {
+          id: 'npc-1',
+          displayName: 'Archivist',
+          x: 5,
+          y: 5,
+          npcType: 'archive_keeper',
+          tradeRules: [
+            {
+              ruleId: 'swap-pass-for-key',
+              requiredItemIds: ['gate-pass'],
+              rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+            },
+          ],
+        },
+      ],
+      doors: [{ id: 'door-1', displayName: 'Door', x: 0, y: 10, isOpen: true, isLocked: false, isSafe: true }],
+    };
+
+    const validated = validateLevelData(level);
+    const state = deserializeLevelWithDefaultLayout(validated);
+
+    expect(state.npcs[0].tradeRules).toEqual([
+      {
+        ruleId: 'swap-pass-for-key',
+        requiredItemIds: ['gate-pass'],
+        rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+      },
+    ]);
+    expect(JSON.parse(JSON.stringify(state.npcs[0]))).toMatchObject({
+      id: 'npc-1',
+      tradeRules: [
+        {
+          ruleId: 'swap-pass-for-key',
+          requiredItemIds: ['gate-pass'],
+          rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+        },
+      ],
+    });
+  });
+
   it('throws when npcs is not an array', () => {
     const bad = {
       ...minimalLevel,

--- a/src/world/levelValidation/shared.ts
+++ b/src/world/levelValidation/shared.ts
@@ -169,3 +169,77 @@ export const validateInventoryItems = (value: unknown, contextLabel: string): vo
     }
   }
 };
+
+export const validateNpcTradeRules = (value: unknown, contextLabel: string): void => {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid level data: ${contextLabel} must be an array when provided`);
+  }
+
+  const seenRuleIds = new Set<string>();
+
+  for (let index = 0; index < value.length; index++) {
+    const rule = value[index] as Record<string, unknown>;
+    if (
+      typeof rule !== 'object' ||
+      rule === null ||
+      typeof rule['ruleId'] !== 'string' ||
+      rule['ruleId'].trim() === ''
+    ) {
+      throw new Error(
+        `Invalid level data: ${contextLabel}[${index}] must include a non-empty ruleId`,
+      );
+    }
+
+    if (seenRuleIds.has(rule['ruleId'])) {
+      throw new Error(
+        `Invalid level data: ${contextLabel}[${index}].ruleId must be unique`,
+      );
+    }
+    seenRuleIds.add(rule['ruleId']);
+
+    if (!Array.isArray(rule['requiredItemIds'])) {
+      throw new Error(
+        `Invalid level data: ${contextLabel}[${index}].requiredItemIds must be an array`,
+      );
+    }
+
+    const requiredItemIds = rule['requiredItemIds'] as unknown[];
+    if (
+      requiredItemIds.length === 0 ||
+      requiredItemIds.some((itemId) => typeof itemId !== 'string' || itemId.trim() === '')
+    ) {
+      throw new Error(
+        `Invalid level data: ${contextLabel}[${index}].requiredItemIds must contain non-empty strings`,
+      );
+    }
+
+    if (!Array.isArray(rule['rewardItems'])) {
+      throw new Error(
+        `Invalid level data: ${contextLabel}[${index}].rewardItems must be an array`,
+      );
+    }
+
+    const rewardItems = rule['rewardItems'] as unknown[];
+    if (rewardItems.length === 0) {
+      throw new Error(
+        `Invalid level data: ${contextLabel}[${index}].rewardItems must contain at least one reward item`,
+      );
+    }
+
+    for (let rewardIndex = 0; rewardIndex < rewardItems.length; rewardIndex++) {
+      const rewardItem = rewardItems[rewardIndex] as Record<string, unknown>;
+      if (
+        typeof rewardItem !== 'object' ||
+        rewardItem === null ||
+        typeof rewardItem['itemId'] !== 'string' ||
+        rewardItem['itemId'].trim() === '' ||
+        typeof rewardItem['displayName'] !== 'string' ||
+        rewardItem['displayName'].trim() === ''
+      ) {
+        throw new Error(
+          `Invalid level data: ${contextLabel}[${index}].rewardItems[${rewardIndex}] must include non-empty itemId and displayName`,
+        );
+      }
+    }
+  }
+};

--- a/src/world/levelValidation/validateNpcs.ts
+++ b/src/world/levelValidation/validateNpcs.ts
@@ -1,6 +1,7 @@
 import {
   validateGridPositionInBounds,
   validateInventoryItems,
+  validateNpcTradeRules,
   validateNpcTriggers,
   validateSpriteSet,
 } from './shared';
@@ -79,6 +80,10 @@ export const validateNpcs = (
 
     if (npc['inventory'] !== undefined) {
       validateInventoryItems(npc['inventory'], `npc at index ${i} inventory`);
+    }
+
+    if (npc['tradeRules'] !== undefined) {
+      validateNpcTradeRules(npc['tradeRules'], `npc at index ${i} tradeRules`);
     }
 
     if (npc['instanceKnowledge'] !== undefined && typeof npc['instanceKnowledge'] !== 'string') {

--- a/src/world/npcTrade.test.ts
+++ b/src/world/npcTrade.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { createTestInventoryItem, createTestNpc, createTestWorldState } from '../test-support/worldState';
+import { resolveNpcTrade } from './npcTrade';
+
+describe('resolveNpcTrade', () => {
+  it('consumes required items, grants configured rewards, and records rule completion once', () => {
+    const npc = createTestNpc('npc-trader', {
+      tradeRules: [
+        {
+          ruleId: 'swap-pass-for-key',
+          requiredItemIds: ['gate-pass'],
+          rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+        },
+      ],
+    });
+    const player = createTestWorldState({
+      player: {
+        inventory: {
+          items: [createTestInventoryItem('gate-pass', { displayName: 'Gate Pass' })],
+          selectedItem: { slotIndex: 0, itemId: 'gate-pass' },
+        },
+      },
+    }).player;
+
+    const result = resolveNpcTrade(npc, player, 7);
+
+    expect(result.appliedRuleId).toBe('swap-pass-for-key');
+    expect(result.player.inventory.items).toEqual([
+      {
+        itemId: 'archive-key',
+        displayName: 'Archive Key',
+        sourceObjectId: 'npc-trader',
+        pickedUpAtTick: 7,
+      },
+    ]);
+    expect(result.player.inventory.selectedItem).toBeNull();
+    expect(result.npc.tradeState).toEqual({
+      completedRuleIds: ['swap-pass-for-key'],
+    });
+  });
+
+  it('does not mutate inventory or trade state when requirements are missing', () => {
+    const npc = createTestNpc('npc-trader', {
+      tradeRules: [
+        {
+          ruleId: 'swap-pass-for-key',
+          requiredItemIds: ['gate-pass'],
+          rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+        },
+      ],
+    });
+    const player = createTestWorldState({
+      player: {
+        inventory: {
+          items: [createTestInventoryItem('apple', { displayName: 'Apple' })],
+          selectedItem: null,
+        },
+      },
+    }).player;
+
+    const result = resolveNpcTrade(npc, player, 7);
+
+    expect(result.appliedRuleId).toBeNull();
+    expect(result.player).toEqual(player);
+    expect(result.npc).toEqual(npc);
+  });
+
+  it('prevents duplicate reward grants after the rule is already completed', () => {
+    const npc = createTestNpc('npc-trader', {
+      tradeRules: [
+        {
+          ruleId: 'swap-pass-for-key',
+          requiredItemIds: ['gate-pass'],
+          rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+        },
+      ],
+    });
+    const player = createTestWorldState({
+      player: {
+        inventory: {
+          items: [createTestInventoryItem('gate-pass', { displayName: 'Gate Pass' })],
+          selectedItem: null,
+        },
+      },
+    }).player;
+
+    const first = resolveNpcTrade(npc, player, 7);
+    const second = resolveNpcTrade(first.npc, first.player, 8);
+
+    expect(first.player.inventory.items).toEqual([
+      {
+        itemId: 'archive-key',
+        displayName: 'Archive Key',
+        sourceObjectId: 'npc-trader',
+        pickedUpAtTick: 7,
+      },
+    ]);
+    expect(second.appliedRuleId).toBeNull();
+    expect(second.player.inventory.items).toEqual(first.player.inventory.items);
+    expect(second.npc.tradeState).toEqual({
+      completedRuleIds: ['swap-pass-for-key'],
+    });
+  });
+});

--- a/src/world/npcTrade.ts
+++ b/src/world/npcTrade.ts
@@ -1,0 +1,120 @@
+import { Item } from './entities/items/Item';
+import type { InventoryItem, Npc, Player } from './types';
+
+export interface NpcTradeResolution {
+  npc: Npc;
+  player: Player;
+  appliedRuleId: string | null;
+}
+
+const reindexSelectedSlotAfterRemoval = (
+  selectedItem: Player['inventory']['selectedItem'],
+  removedSlotIndex: number,
+): Player['inventory']['selectedItem'] => {
+  if (!selectedItem) {
+    return selectedItem;
+  }
+
+  if (selectedItem.slotIndex === removedSlotIndex) {
+    return null;
+  }
+
+  if (selectedItem.slotIndex > removedSlotIndex) {
+    return {
+      ...selectedItem,
+      slotIndex: selectedItem.slotIndex - 1,
+    };
+  }
+
+  return selectedItem;
+};
+
+const takeRequiredItems = (
+  inventoryItems: InventoryItem[],
+  requiredItemIds: string[],
+  selectedItem: Player['inventory']['selectedItem'],
+): { remainingItems: InventoryItem[]; selectedItem: Player['inventory']['selectedItem'] } | null => {
+  let remainingItems = [...inventoryItems];
+  let nextSelectedItem: Player['inventory']['selectedItem'] = selectedItem ?? null;
+
+  for (const requiredItemId of requiredItemIds) {
+    const removedIndex = remainingItems.findIndex((item) => item.itemId === requiredItemId);
+    const transferResult = Item.takeFirstByItemId(remainingItems, requiredItemId);
+    if (!transferResult.item) {
+      return null;
+    }
+
+    remainingItems = transferResult.remainingItems;
+    nextSelectedItem = reindexSelectedSlotAfterRemoval(nextSelectedItem, removedIndex);
+  }
+
+  return {
+    remainingItems,
+    selectedItem: nextSelectedItem,
+  };
+};
+
+export const resolveNpcTrade = (
+  npc: Npc,
+  player: Player,
+  currentTick: number,
+): NpcTradeResolution => {
+  const tradeRules = npc.tradeRules ?? [];
+  if (tradeRules.length === 0) {
+    return {
+      npc,
+      player,
+      appliedRuleId: null,
+    };
+  }
+
+  const completedRuleIds = new Set(npc.tradeState?.completedRuleIds ?? []);
+
+  for (const rule of tradeRules) {
+    if (completedRuleIds.has(rule.ruleId)) {
+      continue;
+    }
+
+    const tradeConsumption = takeRequiredItems(
+      player.inventory.items,
+      rule.requiredItemIds,
+      player.inventory.selectedItem ?? null,
+    );
+    if (!tradeConsumption) {
+      continue;
+    }
+
+    const rewardItems = rule.rewardItems.map((rewardItem) =>
+      Item.fromInventoryItem({
+        itemId: rewardItem.itemId,
+        displayName: rewardItem.displayName,
+        sourceObjectId: npc.id,
+        pickedUpAtTick: currentTick,
+      }).toInventoryItem(),
+    );
+
+    return {
+      npc: {
+        ...npc,
+        tradeState: {
+          completedRuleIds: [...completedRuleIds, rule.ruleId],
+        },
+      },
+      player: {
+        ...player,
+        inventory: {
+          ...player.inventory,
+            items: [...tradeConsumption.remainingItems, ...rewardItems],
+            selectedItem: tradeConsumption.selectedItem,
+        },
+      },
+      appliedRuleId: rule.ruleId,
+    };
+  }
+
+  return {
+    npc,
+    player,
+    appliedRuleId: null,
+  };
+};

--- a/src/world/types.ts
+++ b/src/world/types.ts
@@ -59,7 +59,16 @@ export type {
 export type { Guard } from './types/guard.js';
 
 // NPC types
-export type { RiddleClue, RiddleClueConstraint, TriggerEffect, NpcTriggers, Npc } from './types/npc.js';
+export type {
+  RiddleClue,
+  RiddleClueConstraint,
+  TriggerEffect,
+  NpcTriggers,
+  NpcTradeRewardItem,
+  NpcTradeRule,
+  NpcTradeState,
+  Npc,
+} from './types/npc.js';
 
 // Door types
 export type { Door } from './types/door.js';

--- a/src/world/types/level.ts
+++ b/src/world/types/level.ts
@@ -1,6 +1,6 @@
 import type { GridPosition, SpriteSet } from './grid.js';
 import type { InventoryItem, ItemUseRule } from './inventory.js';
-import type { NpcTriggers } from './npc.js';
+import type { NpcTradeRule, NpcTriggers } from './npc.js';
 import type { QuestChainDefinition } from './quest.js';
 
 export interface LevelPlayerDto {
@@ -60,6 +60,7 @@ export interface LevelNpcDto {
   patrol?: { path: GridPosition[] };
   triggers?: NpcTriggers;
   inventory?: InventoryItem[];
+  tradeRules?: NpcTradeRule[];
   spriteAssetPath?: string;
   spriteSet?: SpriteSet;
   /** Instance-specific knowledge this NPC has. */

--- a/src/world/types/npc.ts
+++ b/src/world/types/npc.ts
@@ -32,12 +32,29 @@ export interface NpcTriggers {
   onTalk?: TriggerEffect;
 }
 
+export interface NpcTradeRewardItem {
+  itemId: string;
+  displayName: string;
+}
+
+export interface NpcTradeRule {
+  ruleId: string;
+  requiredItemIds: string[];
+  rewardItems: NpcTradeRewardItem[];
+}
+
+export interface NpcTradeState {
+  completedRuleIds: string[];
+}
+
 export interface Npc extends GameEntity {
   npcType: string;
   dialogueContextKey: string;
   patrol?: { path: Array<{ x: number; y: number }> };
   triggers?: NpcTriggers;
   inventory?: InventoryItem[];
+  tradeRules?: NpcTradeRule[];
+  tradeState?: NpcTradeState;
   /** Instance-specific knowledge this NPC has (overrides or extends type-level knowledge). */
   instanceKnowledge?: string;
   /** Instance-specific behavior traits for this NPC (overrides or extends type-level behavior). */


### PR DESCRIPTION
## Summary
- add serializable NPC trade rule and trade state contracts to level/runtime types
- resolve item-required NPC rewards through deterministic world logic instead of LLM inventory text
- cover success, failure, consumption, replay/idempotency, and serialization/loading with tests

## Validation
- npm run lint
- npm run build
- npm run test

Parent: #183

Closes #202