### PR TITLE
#203 add deterministic NPC dialogue consequence hooks

### DIFF
--- a/docs/INTERACTION_LAYER.md
+++ b/docs/INTERACTION_LAYER.md
@@ -133,6 +133,23 @@ Conversational NPC turns may still use the LLM for dialogue text, but NPC item-r
 - `npc.tradeRules` data, current player inventory, and `npc.tradeState` decide whether a trade succeeds.
 - When an NPC has trade rules, trade inventory mutation is world-owned; free-form assistant wording does not grant or deny the reward.
 
+### NPC Dialogue Consequence Hook Boundary
+
+NPC dialogue outcomes are now routed through `src/interaction/npcDialogueConsequenceHook.ts` before any gameplay mutation is applied.
+
+Deterministic consequence pipeline:
+- validates the outcome shape (`isNpcDialogueOutcome`)
+- validates/applies knowledge token requirements and grants via `src/world/knowledgeState.ts`
+- resolves trade rules via `src/world/npcTrade.ts`
+- optionally applies legacy give/take inventory transfer only when no declarative trade rule exists
+- validates/applies quest progression via `src/world/questState.ts`
+
+Safety guarantees:
+- malformed or rejected dialogue outcomes are deterministic no-mutation results
+- assistant prose alone does not mutate world state
+- quest/token/trade mutations occur only through deterministic validators/executors
+- replay behavior remains deterministic through existing quest/token/trade idempotency controls
+
 ## Conversation Pause Lifecycle
 
 When the player chooses Chat from an action-modal session, `onConversationStarted` is routed from [src/runtime/interactionResultBridge.ts](../src/runtime/interactionResultBridge.ts) into [src/runtime/modalCoordinator.ts](../src/runtime/modalCoordinator.ts). The runtime bridge + modal coordinator then perform three side effects in order:

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -31,6 +31,7 @@ Source of truth:
 - `src/world/entities/environment/Environment.ts`
 - `src/world/entities/dtoRuntimeSeams.ts`
 - `src/interaction/npcPromptContext.ts`
+- `src/interaction/npcDialogueConsequenceHook.ts`
 - `src/interaction/objectInteraction.ts`
 - `src/interaction/adjacencyResolver.ts`
 - `src/runtime/runtimeController.ts`
@@ -54,6 +55,37 @@ Forward-looking type for action modal routing. Represents a session where the pl
 - **Chat:** Open conversational modal with LLM
 - **Inventory:** Display current inventory (view-only or select item)
 - **Back:** Close modal and resume gameplay
+
+### NpcDialogueOutcome
+- `giveItem?: string`
+- `takeItem?: string`
+- `requireKnowledgeTokens?: string[]`
+- `grantKnowledgeTokens?: string[]`
+- `questProgressEvent?: QuestProgressEvent`
+
+Serializable dialogue-consequence payload consumed by deterministic validators/executors.
+
+### NpcDialogueConsequenceRequest
+- `npcId: string`
+- `worldState: WorldState`
+- `outcome: unknown`
+
+Boundary request contract used by `applyNpcDialogueConsequences(...)`.
+
+### NpcDialogueConsequenceTrace
+- `outcomeStatus: 'none' | 'accepted' | 'rejected'`
+- `missingKnowledgeTokens: string[]`
+- `inventoryMutated: boolean`
+- `tradeRuleIdApplied: string | null`
+- `questStateMutated: boolean`
+
+Deterministic trace metadata for testing/debugging dialogue consequence evaluation.
+
+### NpcDialogueConsequenceResult
+- `updatedWorldState: WorldState`
+- `trace: NpcDialogueConsequenceTrace`
+
+Deterministic output contract from `applyNpcDialogueConsequences(...)`.
 
 ### ActionModalEligibleTarget
 

--- a/src/interaction/npcDialogueConsequenceHook.test.ts
+++ b/src/interaction/npcDialogueConsequenceHook.test.ts
@@ -116,6 +116,32 @@ describe('applyNpcDialogueConsequences', () => {
     expect(result.updatedWorldState).toEqual(worldState);
   });
 
+  it('rejects malformed questProgressEvent payloads with deterministic no-mutation state', () => {
+    const npc = createTestNpc('npc-1');
+    const worldState = createTestWorldState({
+      npcs: [npc],
+    });
+
+    const result = applyNpcDialogueConsequences({
+      npcId: npc.id,
+      worldState,
+      outcome: {
+        grantKnowledgeTokens: ['seal-alpha'],
+        questProgressEvent: {
+          type: 'item_use_resolved',
+          tick: worldState.tick,
+        },
+      },
+    });
+
+    expect(result.trace.outcomeStatus).toBe('rejected');
+    expect(result.trace.missingKnowledgeTokens).toEqual([]);
+    expect(result.trace.tradeRuleIdApplied).toBeNull();
+    expect(result.trace.inventoryMutated).toBe(false);
+    expect(result.trace.questStateMutated).toBe(false);
+    expect(result.updatedWorldState).toEqual(worldState);
+  });
+
   it('remains deterministic and idempotent when replaying the same accepted outcome', () => {
     const npc = createTestNpc('npc-trader', {
       tradeRules: [

--- a/src/interaction/npcDialogueConsequenceHook.test.ts
+++ b/src/interaction/npcDialogueConsequenceHook.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { createQuestState } from '../world/questState';
+import type { ItemUseAttemptResultEvent, QuestChainDefinition } from '../world/types';
+import {
+  createTestInventoryItem,
+  createTestNpc,
+  createTestWorldState,
+} from '../test-support/worldState';
+import { applyNpcDialogueConsequences } from './npcDialogueConsequenceHook';
+
+const buildQuestEvent = (overrides: Partial<ItemUseAttemptResultEvent> = {}): ItemUseAttemptResultEvent => {
+  return {
+    tick: 0,
+    commandIndex: 0,
+    selectedItem: null,
+    result: 'success',
+    target: null,
+    ...overrides,
+  };
+};
+
+describe('applyNpcDialogueConsequences', () => {
+  it('routes valid dialogue outcomes through deterministic token/trade/quest executors', () => {
+    const npc = createTestNpc('npc-trader', {
+      tradeRules: [
+        {
+          ruleId: 'swap-pass-for-key',
+          requiredItemIds: ['gate-pass'],
+          rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+        },
+      ],
+    });
+
+    const questChain: QuestChainDefinition = {
+      chainId: 'chain-1',
+      displayName: 'First Step',
+      npcId: npc.id,
+      stages: [
+        {
+          stageId: 'stage-1',
+          completeWhen: {
+            eventType: 'item_use_resolved',
+            result: 'success',
+          },
+        },
+      ],
+    };
+
+    const worldState = createTestWorldState({
+      npcs: [npc],
+      player: {
+        inventory: {
+          items: [createTestInventoryItem('gate-pass', { displayName: 'Gate Pass' })],
+          selectedItem: null,
+        },
+      },
+      questState: createQuestState([questChain]),
+    });
+
+    const result = applyNpcDialogueConsequences({
+      npcId: npc.id,
+      worldState,
+      outcome: {
+        grantKnowledgeTokens: ['seal-alpha'],
+        questProgressEvent: {
+          type: 'item_use_resolved',
+          tick: worldState.tick,
+          itemUseEvent: buildQuestEvent(),
+        },
+      },
+    });
+
+    expect(result.trace.outcomeStatus).toBe('accepted');
+    expect(result.trace.tradeRuleIdApplied).toBe('swap-pass-for-key');
+    expect(result.trace.questStateMutated).toBe(true);
+    expect(result.updatedWorldState.knowledgeState?.tokensById['seal-alpha']).toEqual({
+      tokenId: 'seal-alpha',
+      grantedAtTick: 0,
+      grantedByActorId: npc.id,
+    });
+    expect(result.updatedWorldState.player.inventory.items).toEqual([
+      {
+        itemId: 'archive-key',
+        displayName: 'Archive Key',
+        sourceObjectId: npc.id,
+        pickedUpAtTick: 0,
+      },
+    ]);
+    expect(result.updatedWorldState.questState?.progressByChainId['chain-1']).toEqual({
+      chainId: 'chain-1',
+      status: 'completed',
+      currentStageIndex: 1,
+      completedStageIds: ['stage-1'],
+      lastAdvancedTick: 0,
+    });
+  });
+
+  it('rejects invalid dialogue outcomes with deterministic no-mutation state', () => {
+    const npc = createTestNpc('npc-1');
+    const worldState = createTestWorldState({
+      npcs: [npc],
+    });
+
+    const result = applyNpcDialogueConsequences({
+      npcId: npc.id,
+      worldState,
+      outcome: {
+        grantKnowledgeTokens: 'not-an-array',
+      },
+    });
+
+    expect(result.trace.outcomeStatus).toBe('rejected');
+    expect(result.trace.tradeRuleIdApplied).toBeNull();
+    expect(result.trace.inventoryMutated).toBe(false);
+    expect(result.trace.questStateMutated).toBe(false);
+    expect(result.updatedWorldState).toEqual(worldState);
+  });
+
+  it('remains deterministic and idempotent when replaying the same accepted outcome', () => {
+    const npc = createTestNpc('npc-trader', {
+      tradeRules: [
+        {
+          ruleId: 'swap-pass-for-key',
+          requiredItemIds: ['gate-pass'],
+          rewardItems: [{ itemId: 'archive-key', displayName: 'Archive Key' }],
+        },
+      ],
+    });
+
+    const worldState = createTestWorldState({
+      npcs: [npc],
+      player: {
+        inventory: {
+          items: [createTestInventoryItem('gate-pass', { displayName: 'Gate Pass' })],
+          selectedItem: null,
+        },
+      },
+    });
+
+    const outcome = {
+      grantKnowledgeTokens: ['seal-alpha'],
+    };
+
+    const first = applyNpcDialogueConsequences({
+      npcId: npc.id,
+      worldState,
+      outcome,
+    });
+    const second = applyNpcDialogueConsequences({
+      npcId: npc.id,
+      worldState: first.updatedWorldState,
+      outcome,
+    });
+
+    expect(first.trace.tradeRuleIdApplied).toBe('swap-pass-for-key');
+    expect(second.trace.tradeRuleIdApplied).toBeNull();
+    expect(second.updatedWorldState.player.inventory.items).toEqual(
+      first.updatedWorldState.player.inventory.items,
+    );
+    expect(second.updatedWorldState.knowledgeState).toEqual(first.updatedWorldState.knowledgeState);
+    expect(second.updatedWorldState.npcs).toEqual(first.updatedWorldState.npcs);
+  });
+});

--- a/src/interaction/npcDialogueConsequenceHook.ts
+++ b/src/interaction/npcDialogueConsequenceHook.ts
@@ -122,7 +122,10 @@ const isItemUseAttemptResultEvent = (value: unknown): value is ItemUseAttemptRes
     return false;
   }
 
-  if (typeof value.result !== 'string' || !ITEM_USE_ATTEMPT_RESULTS.has(value.result)) {
+  if (
+    typeof value.result !== 'string' ||
+    !ITEM_USE_ATTEMPT_RESULTS.has(value.result as ItemUseAttemptResultEvent['result'])
+  ) {
     return false;
   }
 

--- a/src/interaction/npcDialogueConsequenceHook.ts
+++ b/src/interaction/npcDialogueConsequenceHook.ts
@@ -1,0 +1,326 @@
+import { Item } from '../world/entities/items/Item';
+import { applyKnowledgeTokenOutcome } from '../world/knowledgeState';
+import { ensureQuestState, applyQuestProgressEventIfValid } from '../world/questState';
+import { resolveNpcTrade } from '../world/npcTrade';
+import type { Npc, Player, QuestProgressEvent, WorldState } from '../world/types';
+
+export interface NpcDialogueOutcome {
+  giveItem?: string;
+  takeItem?: string;
+  requireKnowledgeTokens?: string[];
+  grantKnowledgeTokens?: string[];
+  questProgressEvent?: QuestProgressEvent;
+}
+
+export interface NpcDialogueConsequenceRequest {
+  npcId: string;
+  worldState: WorldState;
+  outcome: unknown;
+}
+
+export interface NpcDialogueConsequenceTrace {
+  outcomeStatus: 'none' | 'accepted' | 'rejected';
+  missingKnowledgeTokens: string[];
+  inventoryMutated: boolean;
+  tradeRuleIdApplied: string | null;
+  questStateMutated: boolean;
+}
+
+export interface NpcDialogueConsequenceResult {
+  updatedWorldState: WorldState;
+  trace: NpcDialogueConsequenceTrace;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const isStringArray = (value: unknown): value is string[] => {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+};
+
+const hasOnlyAllowedKeys = (record: Record<string, unknown>, allowedKeys: readonly string[]): boolean => {
+  return Object.keys(record).every((key) => allowedKeys.includes(key));
+};
+
+export const isNpcDialogueOutcome = (value: unknown): value is NpcDialogueOutcome => {
+  if (value === undefined) {
+    return true;
+  }
+
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (
+    !hasOnlyAllowedKeys(value, [
+      'giveItem',
+      'takeItem',
+      'requireKnowledgeTokens',
+      'grantKnowledgeTokens',
+      'questProgressEvent',
+    ])
+  ) {
+    return false;
+  }
+
+  if ('giveItem' in value && value.giveItem !== undefined && typeof value.giveItem !== 'string') {
+    return false;
+  }
+
+  if ('takeItem' in value && value.takeItem !== undefined && typeof value.takeItem !== 'string') {
+    return false;
+  }
+
+  if (
+    'requireKnowledgeTokens' in value &&
+    value.requireKnowledgeTokens !== undefined &&
+    !isStringArray(value.requireKnowledgeTokens)
+  ) {
+    return false;
+  }
+
+  if (
+    'grantKnowledgeTokens' in value &&
+    value.grantKnowledgeTokens !== undefined &&
+    !isStringArray(value.grantKnowledgeTokens)
+  ) {
+    return false;
+  }
+
+  if (
+    'questProgressEvent' in value &&
+    value.questProgressEvent !== undefined &&
+    !isRecord(value.questProgressEvent)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+const reindexSelectedSlotAfterRemoval = (
+  selectedItem: Player['inventory']['selectedItem'],
+  removedSlotIndex: number,
+): Player['inventory']['selectedItem'] => {
+  if (!selectedItem) {
+    return selectedItem;
+  }
+
+  if (selectedItem.slotIndex === removedSlotIndex) {
+    return null;
+  }
+
+  if (selectedItem.slotIndex > removedSlotIndex) {
+    return {
+      ...selectedItem,
+      slotIndex: selectedItem.slotIndex - 1,
+    };
+  }
+
+  return selectedItem;
+};
+
+const applyInventoryOutcome = (
+  npc: Npc,
+  player: Player,
+  outcome: NpcDialogueOutcome | undefined,
+): { npc: Npc; player: Player; inventoryMutated: boolean } => {
+  if (!outcome) {
+    return { npc, player, inventoryMutated: false };
+  }
+
+  const npcItems = [...(npc.inventory ?? [])];
+  const playerItems = [...player.inventory.items];
+  let selectedItem = player.inventory.selectedItem ?? null;
+  let npcInventoryChanged = false;
+  let playerInventoryChanged = false;
+
+  if (typeof outcome.giveItem === 'string') {
+    const transferResult = Item.takeFirstByItemId(npcItems, outcome.giveItem);
+    npcItems.splice(0, npcItems.length, ...transferResult.remainingItems);
+    if (transferResult.item) {
+      playerItems.push(transferResult.item.toInventoryItem());
+      npcInventoryChanged = true;
+      playerInventoryChanged = true;
+    }
+  }
+
+  if (typeof outcome.takeItem === 'string') {
+    const playerItemIndex = playerItems.findIndex((item) => item.itemId === outcome.takeItem);
+    const transferResult = Item.takeFirstByItemId(playerItems, outcome.takeItem);
+    playerItems.splice(0, playerItems.length, ...transferResult.remainingItems);
+    if (transferResult.item) {
+      selectedItem = reindexSelectedSlotAfterRemoval(selectedItem, playerItemIndex) ?? null;
+      npcItems.push(transferResult.item.toInventoryItem());
+      npcInventoryChanged = true;
+      playerInventoryChanged = true;
+    }
+  }
+
+  const nextNpc = npcInventoryChanged
+    ? {
+        ...npc,
+        inventory: npcItems,
+      }
+    : npc;
+
+  const nextPlayer = playerInventoryChanged
+    ? {
+        ...player,
+        inventory: {
+          ...player.inventory,
+          items: playerItems,
+          selectedItem,
+        },
+      }
+    : player;
+
+  return {
+    npc: nextNpc,
+    player: nextPlayer,
+    inventoryMutated: npcInventoryChanged || playerInventoryChanged,
+  };
+};
+
+const replaceNpc = (worldState: WorldState, npc: Npc): WorldState => {
+  return {
+    ...worldState,
+    npcs: worldState.npcs.map((candidate) => (candidate.id === npc.id ? npc : candidate)),
+  };
+};
+
+const applyQuestProgressEvent = (
+  worldState: WorldState,
+  outcome: NpcDialogueOutcome,
+): { worldState: WorldState; questStateMutated: boolean } => {
+  if (!outcome.questProgressEvent) {
+    return {
+      worldState,
+      questStateMutated: false,
+    };
+  }
+
+  const currentQuestState = ensureQuestState(worldState.questState);
+  const nextQuestState = applyQuestProgressEventIfValid(currentQuestState, outcome.questProgressEvent);
+  if (nextQuestState === currentQuestState) {
+    return {
+      worldState,
+      questStateMutated: false,
+    };
+  }
+
+  return {
+    worldState: {
+      ...worldState,
+      questState: nextQuestState,
+    },
+    questStateMutated: true,
+  };
+};
+
+export const applyNpcDialogueConsequences = (
+  request: NpcDialogueConsequenceRequest,
+): NpcDialogueConsequenceResult => {
+  const npc = request.worldState.npcs.find((candidate) => candidate.id === request.npcId);
+  if (!npc) {
+    return {
+      updatedWorldState: request.worldState,
+      trace: {
+        outcomeStatus: 'rejected',
+        missingKnowledgeTokens: [],
+        inventoryMutated: false,
+        tradeRuleIdApplied: null,
+        questStateMutated: false,
+      },
+    };
+  }
+
+  if (!isNpcDialogueOutcome(request.outcome)) {
+    return {
+      updatedWorldState: request.worldState,
+      trace: {
+        outcomeStatus: 'rejected',
+        missingKnowledgeTokens: [],
+        inventoryMutated: false,
+        tradeRuleIdApplied: null,
+        questStateMutated: false,
+      },
+    };
+  }
+
+  const normalizedOutcome = request.outcome;
+  if (normalizedOutcome === undefined) {
+    return {
+      updatedWorldState: request.worldState,
+      trace: {
+        outcomeStatus: 'none',
+        missingKnowledgeTokens: [],
+        inventoryMutated: false,
+        tradeRuleIdApplied: null,
+        questStateMutated: false,
+      },
+    };
+  }
+
+  const knowledgeResolution = applyKnowledgeTokenOutcome(
+    request.worldState.knowledgeState,
+    normalizedOutcome,
+    {
+      tick: request.worldState.tick,
+      grantedByActorId: request.npcId,
+    },
+  );
+  if (!knowledgeResolution.isValid) {
+    return {
+      updatedWorldState: request.worldState,
+      trace: {
+        outcomeStatus: 'rejected',
+        missingKnowledgeTokens: knowledgeResolution.missingKnowledgeTokens,
+        inventoryMutated: false,
+        tradeRuleIdApplied: null,
+        questStateMutated: false,
+      },
+    };
+  }
+
+  const stateWithKnowledgeTokens: WorldState = {
+    ...request.worldState,
+    knowledgeState: knowledgeResolution.knowledgeState,
+  };
+
+  const npcAfterKnowledge =
+    stateWithKnowledgeTokens.npcs.find((candidate) => candidate.id === request.npcId) ?? npc;
+  const tradeResult = resolveNpcTrade(
+    npcAfterKnowledge,
+    stateWithKnowledgeTokens.player,
+    stateWithKnowledgeTokens.tick,
+  );
+
+  const inventoryResult = applyInventoryOutcome(
+    tradeResult.npc,
+    tradeResult.player,
+    tradeResult.npc.tradeRules?.length ? undefined : normalizedOutcome,
+  );
+
+  const stateWithNpcPlayer = replaceNpc(
+    {
+      ...stateWithKnowledgeTokens,
+      player: inventoryResult.player,
+    },
+    inventoryResult.npc,
+  );
+
+  const questResult = applyQuestProgressEvent(stateWithNpcPlayer, normalizedOutcome);
+
+  return {
+    updatedWorldState: questResult.worldState,
+    trace: {
+      outcomeStatus: 'accepted',
+      missingKnowledgeTokens: [],
+      inventoryMutated: inventoryResult.inventoryMutated,
+      tradeRuleIdApplied: tradeResult.appliedRuleId,
+      questStateMutated: questResult.questStateMutated,
+    },
+  };
+};

--- a/src/interaction/npcDialogueConsequenceHook.ts
+++ b/src/interaction/npcDialogueConsequenceHook.ts
@@ -2,7 +2,14 @@ import { Item } from '../world/entities/items/Item';
 import { applyKnowledgeTokenOutcome } from '../world/knowledgeState';
 import { ensureQuestState, applyQuestProgressEventIfValid } from '../world/questState';
 import { resolveNpcTrade } from '../world/npcTrade';
-import type { Npc, Player, QuestProgressEvent, WorldState } from '../world/types';
+import type {
+  ItemUseAttemptResultEvent,
+  Npc,
+  Player,
+  QuestProgressEvent,
+  SelectedInventoryItem,
+  WorldState,
+} from '../world/types';
 
 export interface NpcDialogueOutcome {
   giveItem?: string;
@@ -41,6 +48,134 @@ const isStringArray = (value: unknown): value is string[] => {
 
 const hasOnlyAllowedKeys = (record: Record<string, unknown>, allowedKeys: readonly string[]): boolean => {
   return Object.keys(record).every((key) => allowedKeys.includes(key));
+};
+
+const ITEM_USE_ATTEMPT_RESULTS = new Set<ItemUseAttemptResultEvent['result']>([
+  'no-selection',
+  'no-target',
+  'blocked',
+  'success',
+  'no-rule',
+]);
+
+const ITEM_USE_TARGET_KINDS = new Set<NonNullable<ItemUseAttemptResultEvent['target']>['kind']>([
+  'door',
+  'guard',
+  'npc',
+  'interactiveObject',
+]);
+
+const isSelectedInventoryItem = (value: unknown): value is SelectedInventoryItem => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return typeof value.slotIndex === 'number' && typeof value.itemId === 'string';
+};
+
+const isItemUseTarget = (value: unknown): value is ItemUseAttemptResultEvent['target'] => {
+  if (value === null) {
+    return true;
+  }
+
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.targetId === 'string' &&
+    typeof value.kind === 'string' &&
+    ITEM_USE_TARGET_KINDS.has(value.kind as NonNullable<ItemUseAttemptResultEvent['target']>['kind'])
+  );
+};
+
+const isItemUseAttemptResultEvent = (value: unknown): value is ItemUseAttemptResultEvent => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (
+    !hasOnlyAllowedKeys(value, [
+      'tick',
+      'commandIndex',
+      'selectedItem',
+      'result',
+      'target',
+      'doorUnlockedId',
+      'affectedEntityType',
+      'affectedEntityId',
+      'ruleResponseText',
+    ])
+  ) {
+    return false;
+  }
+
+  if (typeof value.tick !== 'number' || typeof value.commandIndex !== 'number') {
+    return false;
+  }
+
+  if (
+    value.selectedItem !== null &&
+    value.selectedItem !== undefined &&
+    !isSelectedInventoryItem(value.selectedItem)
+  ) {
+    return false;
+  }
+
+  if (typeof value.result !== 'string' || !ITEM_USE_ATTEMPT_RESULTS.has(value.result)) {
+    return false;
+  }
+
+  if (!isItemUseTarget(value.target)) {
+    return false;
+  }
+
+  if ('doorUnlockedId' in value && value.doorUnlockedId !== undefined && typeof value.doorUnlockedId !== 'string') {
+    return false;
+  }
+
+  if (
+    'affectedEntityType' in value &&
+    value.affectedEntityType !== undefined &&
+    value.affectedEntityType !== 'guard' &&
+    value.affectedEntityType !== 'object'
+  ) {
+    return false;
+  }
+
+  if (
+    'affectedEntityId' in value &&
+    value.affectedEntityId !== undefined &&
+    typeof value.affectedEntityId !== 'string'
+  ) {
+    return false;
+  }
+
+  if (
+    'ruleResponseText' in value &&
+    value.ruleResponseText !== undefined &&
+    typeof value.ruleResponseText !== 'string'
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+const isQuestProgressEvent = (value: unknown): value is QuestProgressEvent => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (!hasOnlyAllowedKeys(value, ['type', 'tick', 'itemUseEvent'])) {
+    return false;
+  }
+
+  return (
+    value.type === 'item_use_resolved' &&
+    typeof value.tick === 'number' &&
+    isItemUseAttemptResultEvent(value.itemUseEvent)
+  );
 };
 
 export const isNpcDialogueOutcome = (value: unknown): value is NpcDialogueOutcome => {
@@ -91,7 +226,7 @@ export const isNpcDialogueOutcome = (value: unknown): value is NpcDialogueOutcom
   if (
     'questProgressEvent' in value &&
     value.questProgressEvent !== undefined &&
-    !isRecord(value.questProgressEvent)
+    !isQuestProgressEvent(value.questProgressEvent)
   ) {
     return false;
   }

--- a/src/interaction/npcInteraction.ts
+++ b/src/interaction/npcInteraction.ts
@@ -1,7 +1,4 @@
 import { isLlmRequestError, type LlmRequestError, type LlmClient } from '../llm/client';
-import { Item } from '../world/entities/items/Item';
-import { applyKnowledgeTokenOutcomeIfValid } from '../world/knowledgeState';
-import { resolveNpcTrade } from '../world/npcTrade';
 import type { ConversationMessage, Npc, Player, WorldState } from '../world/types';
 import {
   createDefaultNpcFunctionRegistry,
@@ -12,14 +9,11 @@ import {
   type NpcActionExecutionResult,
   type NpcActionExecutor,
 } from './npcActionExecutor';
+import {
+  applyNpcDialogueConsequences,
+  type NpcDialogueConsequenceTrace,
+} from './npcDialogueConsequenceHook';
 import { buildNpcPromptContext } from './npcPromptContext';
-
-interface NpcInteractionOutcome {
-  giveItem?: string;
-  takeItem?: string;
-  requireKnowledgeTokens?: string[];
-  grantKnowledgeTokens?: string[];
-}
 
 const applyTalkTrigger = (npc: Npc): Npc => {
   const talkTrigger = npc.triggers?.onTalk;
@@ -36,89 +30,6 @@ const applyTalkTrigger = (npc: Npc): Npc => {
   };
 };
 
-const reindexSelectedSlotAfterRemoval = (
-  selectedItem: Player['inventory']['selectedItem'],
-  removedSlotIndex: number,
-): Player['inventory']['selectedItem'] => {
-  if (!selectedItem) {
-    return selectedItem;
-  }
-
-  if (selectedItem.slotIndex === removedSlotIndex) {
-    return null;
-  }
-
-  if (selectedItem.slotIndex > removedSlotIndex) {
-    return {
-      ...selectedItem,
-      slotIndex: selectedItem.slotIndex - 1,
-    };
-  }
-
-  return selectedItem;
-};
-
-const applyInventoryOutcome = (
-  npc: Npc,
-  player: Player,
-  outcome: NpcInteractionOutcome | undefined,
-): { npc: Npc; player: Player } => {
-  if (!outcome) {
-    return { npc, player };
-  }
-
-  const npcItems = [...(npc.inventory ?? [])];
-  const playerItems = [...player.inventory.items];
-  let selectedItem = player.inventory.selectedItem ?? null;
-  let npcInventoryChanged = false;
-  let playerInventoryChanged = false;
-
-  if (typeof outcome.giveItem === 'string') {
-    const transferResult = Item.takeFirstByItemId(npcItems, outcome.giveItem);
-    npcItems.splice(0, npcItems.length, ...transferResult.remainingItems);
-    if (transferResult.item) {
-      playerItems.push(transferResult.item.toInventoryItem());
-      npcInventoryChanged = true;
-      playerInventoryChanged = true;
-    }
-  }
-
-  if (typeof outcome.takeItem === 'string') {
-    const playerItemIndex = playerItems.findIndex((item) => item.itemId === outcome.takeItem);
-    const transferResult = Item.takeFirstByItemId(playerItems, outcome.takeItem);
-    playerItems.splice(0, playerItems.length, ...transferResult.remainingItems);
-    if (transferResult.item) {
-      selectedItem = reindexSelectedSlotAfterRemoval(selectedItem, playerItemIndex) ?? null;
-      npcItems.push(transferResult.item.toInventoryItem());
-      npcInventoryChanged = true;
-      playerInventoryChanged = true;
-    }
-  }
-
-  const nextNpc = npcInventoryChanged
-    ? {
-        ...npc,
-        inventory: npcItems,
-      }
-    : npc;
-
-  const nextPlayer = playerInventoryChanged
-    ? {
-        ...player,
-        inventory: {
-          ...player.inventory,
-          items: playerItems,
-          selectedItem,
-        },
-      }
-    : player;
-
-  return {
-    npc: nextNpc,
-    player: nextPlayer,
-  };
-};
-
 export interface NpcInteractionRequest {
   npc: Npc;
   player: Player;
@@ -132,6 +43,7 @@ export interface NpcInteractionResult {
   updatedWorldState: WorldState;
   llmError?: LlmRequestError;
   actionExecutionTrace?: NpcActionExecutionResult;
+  consequenceTrace?: NpcDialogueConsequenceTrace;
 }
 
 export interface NpcInteractionService {
@@ -210,43 +122,23 @@ export const createNpcInteractionService = (
       actorConversationHistoryByActorId: updatedHistoryByActorId,
     };
 
-    const knowledgeOutcomeResolution = applyKnowledgeTokenOutcomeIfValid(
-      stateWithUpdatedHistory.knowledgeState,
-      llmResult.outcome,
-      {
-        tick: stateWithUpdatedHistory.tick,
-        grantedByActorId: request.npc.id,
-      },
-    );
-
-    const stateWithKnowledgeTokens: WorldState = {
-      ...stateWithUpdatedHistory,
-      knowledgeState: knowledgeOutcomeResolution.knowledgeState,
-    };
-
     const npcFromWorldState =
-      stateWithKnowledgeTokens.npcs.find((candidate) => candidate.id === request.npc.id) ?? request.npc;
+      stateWithUpdatedHistory.npcs.find((candidate) => candidate.id === request.npc.id) ?? request.npc;
     const npcAfterTalkTrigger = applyTalkTrigger(npcFromWorldState);
-    const tradeResult = resolveNpcTrade(
-      npcAfterTalkTrigger,
-      stateWithKnowledgeTokens.player,
-      stateWithKnowledgeTokens.tick,
-    );
-    const inventoryResult = applyInventoryOutcome(
-      tradeResult.npc,
-      tradeResult.player,
-      knowledgeOutcomeResolution.isValid && !(tradeResult.npc.tradeRules?.length)
-        ? llmResult.outcome
-        : undefined,
-    );
-
-    const updatedWorldState: WorldState = {
-      ...stateWithKnowledgeTokens,
-      player: inventoryResult.player,
-      npcs: stateWithKnowledgeTokens.npcs.map((npc) =>
-        npc.id === request.npc.id ? inventoryResult.npc : npc,
+    const worldStateWithTalkTrigger: WorldState = {
+      ...stateWithUpdatedHistory,
+      npcs: stateWithUpdatedHistory.npcs.map((npc) =>
+        npc.id === request.npc.id ? npcAfterTalkTrigger : npc,
       ),
     };
+
+    const consequenceResult = applyNpcDialogueConsequences({
+      npcId: request.npc.id,
+      worldState: worldStateWithTalkTrigger,
+      outcome: llmResult.outcome,
+    });
+
+    const updatedWorldState = consequenceResult.updatedWorldState;
 
     const actionExecutionTrace = llmResult.actions?.length
       ? actionExecutor.execute({
@@ -261,6 +153,7 @@ export const createNpcInteractionService = (
       responseText: assistantText ? `${request.npc.displayName}: ${assistantText}` : '',
       updatedWorldState: actionExecutionTrace?.updatedWorldState ?? updatedWorldState,
       actionExecutionTrace,
+      consequenceTrace: consequenceResult.trace,
     };
   },
   };

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -21,6 +21,7 @@ export interface LlmResponse {
     takeItem?: string;
     requireKnowledgeTokens?: string[];
     grantKnowledgeTokens?: string[];
+    questProgressEvent?: unknown;
   };
 }
 


### PR DESCRIPTION
## Summary
- add `applyNpcDialogueConsequences(...)` as a narrow deterministic consequence-hook contract for NPC dialogue outcomes
- route validated dialogue outcomes to deterministic token, trade, and quest executors
- reject malformed/invalid outcomes with deterministic no-mutation behavior
- keep gameplay mutation out of LLM prose path; only validated structured outcomes are applied
- add focused valid/rejected/replay tests for dialogue consequences
- document the new interaction boundary and type contracts

## Validation
- `npm run lint`
- `npm run build`
- `npm run test`

## Closes #203
