### PR TITLE
#201 deterministic multi-key gate unlock requirement

### DIFF
--- a/docs/LEVEL_FORMAT.md
+++ b/docs/LEVEL_FORMAT.md
@@ -46,6 +46,22 @@ Notes:
 - Example: `/levels/riddle.json` loads `/levels/riddle.layout.txt` first, and JSON must contain `"layoutPath": "riddle.layout.txt"`.
 - `width`/`height` are no longer part of runtime level authoring.
 
+## Door Unlock Requirements
+
+Doors support two deterministic key schemas:
+
+- Legacy single-key: `requiredItemId: string`
+- Multi-key: `requiredItemIds: string[]`
+
+Rules:
+
+- `requiredItemIds` must be a non-empty array of unique, non-empty strings.
+- A door must not define both `requiredItemId` and `requiredItemIds`.
+- For `requiredItemIds`, item-use unlock succeeds only when:
+  - selected inventory item is one of the listed required key IDs, and
+  - player inventory contains the full required key set.
+- Keys are not consumed by door unlock.
+
 ## Deterministic Load Order
 
 Runtime composition order is fixed:

--- a/docs/TYPES_REFERENCE.md
+++ b/docs/TYPES_REFERENCE.md
@@ -256,7 +256,7 @@ Opt-in capability container for game entities. Omit a key if the entity lacks th
 - `inventory?: { items: InventoryItem[] }` - Entity can carry items
 - `dialogue?: { threadId?: string }` - Entity participates in conversation threads
 - `patrol?: { path: GridPosition[] }` - Entity follows a patrol path
-- `lock?: { isLocked: boolean; requiredItemId?: string }` - Entity has a lock mechanism
+- `lock?: { isLocked: boolean; requiredItemId?: string; requiredItemIds?: string[] }` - Entity has a lock mechanism
 
 ### TriggerEffect
 - `setFact: string` - Fact key to update on the NPC facts bag
@@ -363,6 +363,7 @@ Extends `GameEntity`:
 - `doorState: 'open' | 'closed' | 'locked'`
 - `outcome?: 'safe' | 'danger'`
 - `requiredItemId?: string` - Item id required to unlock this door via item-use. If set, door must be interacted with using this item before traversal is allowed.
+- `requiredItemIds?: string[]` - Item ids required to unlock this door as a full key set. Unlock requires the selected item to be in this set and inventory to contain the full set.
 - `isUnlocked?: boolean` - Whether this door has been unlocked via item-use. Once set to true, door allows traversal regardless of doorState. Persists through world state serialization (default: false).
 - `spriteAssetPath?: string`
 - `spriteSet?: SpriteSet`

--- a/docs/WORLD_LAYER.md
+++ b/docs/WORLD_LAYER.md
@@ -175,7 +175,7 @@ Deterministic rules:
 Deterministic rules:
 - New runtime state initializes all doors with `isUnlocked: false` (default, omitted if false).
 - Level deserialization also initializes all doors with `isUnlocked: false` unless explicitly set in the level JSON.
-- Item-use resolver emits `doorUnlockedId` when player's selected item matches a door's `requiredItemId`.
+- Item-use resolver emits `doorUnlockedId` when deterministic key requirements are satisfied: legacy `requiredItemId` match, or multi-key `requiredItemIds` full-set possession with selected required key.
 - The item-use callback wiring in `src/runtime/createRuntimeApp.ts` commits unlock mutations: when `event.doorUnlockedId` is present, the corresponding door is mutated to set `isUnlocked: true`.
 - Once `isUnlocked` is true, the door allows traversal: `canMovePlayerTo()` in [src/world/spatialRules.ts](../src/world/spatialRules.ts#L38) skips blocked-door checks for unlocked doors.
 - Unlock state persists through JSON serialization and level state save/restore, enabling preserved progress across play sessions.
@@ -189,7 +189,7 @@ Deterministic rules:
 | `validateHeader.ts` | `version`, `layoutPath`, `name`, `premise`, `goal` |
 | `validatePlayer.ts` | player `x`/`y`, optional `spriteAssetPath` and `spriteSet` |
 | `validateGuards.ts` | guards array: identity, position, guardState, traits, sprites, instance fields, itemUseRules |
-| `validateDoors.ts` | doors array: identity, position, doorState, outcome, requiredItemId, sprites |
+| `validateDoors.ts` | doors array: identity, position, doorState, outcome, requiredItemId/requiredItemIds schema, sprites |
 | `validateNpcs.ts` | npcs array: identity, position, npcType, patrol path bounds, triggers, inventory, tradeRules, riddleClue |
 | `validateObjects.ts` | interactiveObjects array: identity, position, objectType, interactionType, state, pickupItem, sprites, capabilities, itemUseRules |
 | `validateEnvironments.ts` | environments array: identity, position, isBlocking |

--- a/src/interaction/itemUse.test.ts
+++ b/src/interaction/itemUse.test.ts
@@ -121,6 +121,180 @@ describe('itemUseResolver', () => {
     expect(event.target).toEqual({ kind: 'door', targetId: 'door-1' });
   });
 
+  it('returns blocked for multi-key doors when selected item is not part of requiredItemIds', () => {
+    const worldState = createTestWorldState({
+      player: {
+        id: 'player-1',
+        displayName: 'Hero',
+        position: { x: 5, y: 5 },
+        inventory: {
+          items: [
+            { itemId: 'seal-a', displayName: 'Seal A', sourceObjectId: 'obj-1', pickedUpAtTick: 10 },
+            { itemId: 'seal-b', displayName: 'Seal B', sourceObjectId: 'obj-2', pickedUpAtTick: 11 },
+            { itemId: 'seal-c', displayName: 'Seal C', sourceObjectId: 'obj-3', pickedUpAtTick: 12 },
+            { itemId: 'random-token', displayName: 'Random Token', sourceObjectId: 'obj-4', pickedUpAtTick: 13 },
+          ],
+          selectedItem: { slotIndex: 3, itemId: 'random-token' },
+        },
+      },
+      doors: [
+        {
+          id: 'seal-door',
+          displayName: 'Seal Door',
+          position: { x: 5, y: 6 },
+          isOpen: false,
+          isLocked: true,
+          requiredItemIds: ['seal-a', 'seal-b', 'seal-c'],
+        },
+      ],
+    });
+
+    const event = resolver.resolveItemUseAttempt({ worldState, commandIndex: 10 });
+
+    expect(event.result).toBe('blocked');
+    expect(event.target).toEqual({ kind: 'door', targetId: 'seal-door' });
+    expect(event.doorUnlockedId).toBeUndefined();
+  });
+
+  it('returns blocked for multi-key doors when required inventory key set is incomplete', () => {
+    const worldState = createTestWorldState({
+      player: {
+        id: 'player-1',
+        displayName: 'Hero',
+        position: { x: 5, y: 5 },
+        inventory: {
+          items: [
+            { itemId: 'seal-a', displayName: 'Seal A', sourceObjectId: 'obj-1', pickedUpAtTick: 10 },
+            { itemId: 'seal-b', displayName: 'Seal B', sourceObjectId: 'obj-2', pickedUpAtTick: 11 },
+          ],
+          selectedItem: { slotIndex: 0, itemId: 'seal-a' },
+        },
+      },
+      doors: [
+        {
+          id: 'seal-door',
+          displayName: 'Seal Door',
+          position: { x: 5, y: 6 },
+          isOpen: false,
+          isLocked: true,
+          requiredItemIds: ['seal-a', 'seal-b', 'seal-c'],
+        },
+      ],
+    });
+
+    const event = resolver.resolveItemUseAttempt({ worldState, commandIndex: 11 });
+
+    expect(event.result).toBe('blocked');
+    expect(event.target).toEqual({ kind: 'door', targetId: 'seal-door' });
+    expect(event.doorUnlockedId).toBeUndefined();
+  });
+
+  it('returns success for multi-key doors when selected key is in requiredItemIds and full key set exists', () => {
+    const worldState = createTestWorldState({
+      player: {
+        id: 'player-1',
+        displayName: 'Hero',
+        position: { x: 5, y: 5 },
+        inventory: {
+          items: [
+            { itemId: 'seal-a', displayName: 'Seal A', sourceObjectId: 'obj-1', pickedUpAtTick: 10 },
+            { itemId: 'seal-b', displayName: 'Seal B', sourceObjectId: 'obj-2', pickedUpAtTick: 11 },
+            { itemId: 'seal-c', displayName: 'Seal C', sourceObjectId: 'obj-3', pickedUpAtTick: 12 },
+          ],
+          selectedItem: { slotIndex: 1, itemId: 'seal-b' },
+        },
+      },
+      doors: [
+        {
+          id: 'seal-door',
+          displayName: 'Seal Door',
+          position: { x: 5, y: 6 },
+          isOpen: false,
+          isLocked: true,
+          requiredItemIds: ['seal-a', 'seal-b', 'seal-c'],
+        },
+      ],
+    });
+
+    const inventoryBefore = JSON.parse(JSON.stringify(worldState.player.inventory.items));
+    const event = resolver.resolveItemUseAttempt({ worldState, commandIndex: 12 });
+
+    expect(event.result).toBe('success');
+    expect(event.target).toEqual({ kind: 'door', targetId: 'seal-door' });
+    expect(event.doorUnlockedId).toBe('seal-door');
+    expect(worldState.player.inventory.items).toEqual(inventoryBefore);
+  });
+
+  it('keeps legacy requiredItemId unlock behavior for backward compatibility', () => {
+    const worldState = createTestWorldState({
+      player: {
+        id: 'player-1',
+        displayName: 'Hero',
+        position: { x: 5, y: 5 },
+        inventory: {
+          items: [{ itemId: 'golden-key', displayName: 'Golden Key', sourceObjectId: 'obj-1', pickedUpAtTick: 10 }],
+          selectedItem: { slotIndex: 0, itemId: 'golden-key' },
+        },
+      },
+      doors: [
+        {
+          id: 'legacy-door',
+          displayName: 'Legacy Door',
+          position: { x: 5, y: 6 },
+          isOpen: false,
+          isLocked: true,
+          requiredItemId: 'golden-key',
+        },
+      ],
+    });
+
+    const event = resolver.resolveItemUseAttempt({ worldState, commandIndex: 13 });
+
+    expect(event.result).toBe('success');
+    expect(event.target).toEqual({ kind: 'door', targetId: 'legacy-door' });
+    expect(event.doorUnlockedId).toBe('legacy-door');
+  });
+
+  it('does not emit duplicate unlock side effects from an equivalent unlocked resulting world state', () => {
+    const lockedState = createTestWorldState({
+      player: {
+        id: 'player-1',
+        displayName: 'Hero',
+        position: { x: 5, y: 5 },
+        inventory: {
+          items: [
+            { itemId: 'seal-a', displayName: 'Seal A', sourceObjectId: 'obj-1', pickedUpAtTick: 10 },
+            { itemId: 'seal-b', displayName: 'Seal B', sourceObjectId: 'obj-2', pickedUpAtTick: 11 },
+            { itemId: 'seal-c', displayName: 'Seal C', sourceObjectId: 'obj-3', pickedUpAtTick: 12 },
+          ],
+          selectedItem: { slotIndex: 0, itemId: 'seal-a' },
+        },
+      },
+      doors: [
+        {
+          id: 'seal-door',
+          displayName: 'Seal Door',
+          position: { x: 5, y: 6 },
+          isOpen: false,
+          isLocked: true,
+          requiredItemIds: ['seal-a', 'seal-b', 'seal-c'],
+        },
+      ],
+    });
+    const unlockedEquivalentState = {
+      ...lockedState,
+      doors: [{ ...lockedState.doors[0], isOpen: true, isLocked: false }],
+    };
+
+    const first = resolver.resolveItemUseAttempt({ worldState: lockedState, commandIndex: 14 });
+    const second = resolver.resolveItemUseAttempt({ worldState: unlockedEquivalentState, commandIndex: 14 });
+
+    expect(first.result).toBe('success');
+    expect(first.doorUnlockedId).toBe('seal-door');
+    expect(second.result).toBe('no-target');
+    expect(second.doorUnlockedId).toBeUndefined();
+  });
+
   it('returns no-rule when guard has no matching itemUseRules entry', () => {
     const worldState = createTestWorldState({
       player: {

--- a/src/interaction/itemUse.ts
+++ b/src/interaction/itemUse.ts
@@ -87,6 +87,41 @@ export const createDefaultItemUseResolver = (): ItemUseResolver => {
           };
         }
 
+        const requiredItemIds = door.requiredItemIds;
+        if (requiredItemIds && requiredItemIds.length > 0) {
+          const selectedItemIsInRequiredSet = requiredItemIds.some((itemId) =>
+            selectedInventoryItem.matchesItemId(itemId),
+          );
+          const inventoryContainsFullRequiredSet = requiredItemIds.every((itemId) =>
+            worldState.player.inventory.items.some((inventoryItem) => inventoryItem.itemId === itemId),
+          );
+
+          if (selectedItemIsInRequiredSet && inventoryContainsFullRequiredSet) {
+            return {
+              tick: worldState.tick,
+              commandIndex,
+              selectedItem,
+              result: 'success',
+              target: {
+                kind: 'door',
+                targetId: door.id,
+              },
+              doorUnlockedId: door.id,
+            };
+          }
+
+          return {
+            tick: worldState.tick,
+            commandIndex,
+            selectedItem,
+            result: 'blocked',
+            target: {
+              kind: 'door',
+              targetId: door.id,
+            },
+          };
+        }
+
         // Door has no required item: item-use has no effect on this door
         if (!door.requiredItemId) {
           return {

--- a/src/world/level.test.ts
+++ b/src/world/level.test.ts
@@ -884,6 +884,149 @@ describe('isSafe field', () => {
   });
 });
 
+describe('door requiredItemIds field', () => {
+  it('accepts requiredItemIds when it is a non-empty unique string array', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      doors: [
+        {
+          id: 'seal-door',
+          displayName: 'Seal Door',
+          x: 0,
+          y: 10,
+          isOpen: false,
+          isLocked: true,
+          requiredItemIds: ['seal-a', 'seal-b', 'seal-c'],
+        },
+      ],
+    };
+
+    const state = deserializeLevelWithDefaultLayout(validateLevelData(level));
+
+    expect(state.doors[0].requiredItemIds).toEqual(['seal-a', 'seal-b', 'seal-c']);
+  });
+
+  it('keeps requiredItemId backward-compatible when requiredItemIds is absent', () => {
+    const level: LevelData = {
+      ...minimalLevel,
+      doors: [
+        {
+          id: 'legacy-door',
+          displayName: 'Legacy Door',
+          x: 0,
+          y: 10,
+          isOpen: false,
+          isLocked: true,
+          requiredItemId: 'golden-key',
+        },
+      ],
+    };
+
+    const state = deserializeLevelWithDefaultLayout(validateLevelData(level));
+
+    expect(state.doors[0].requiredItemId).toBe('golden-key');
+    expect(state.doors[0].requiredItemIds).toBeUndefined();
+  });
+
+  it('rejects door configs that include both requiredItemId and requiredItemIds', () => {
+    const bad = {
+      ...minimalLevel,
+      doors: [
+        {
+          id: 'bad-door',
+          displayName: 'Bad Door',
+          x: 0,
+          y: 10,
+          isOpen: false,
+          isLocked: true,
+          requiredItemId: 'key-a',
+          requiredItemIds: ['key-a', 'key-b'],
+        },
+      ],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('cannot define both requiredItemId and requiredItemIds');
+  });
+
+  it('rejects non-array requiredItemIds', () => {
+    const bad = {
+      ...minimalLevel,
+      doors: [
+        {
+          id: 'bad-door',
+          displayName: 'Bad Door',
+          x: 0,
+          y: 10,
+          isOpen: false,
+          isLocked: true,
+          requiredItemIds: 'key-a',
+        },
+      ],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid requiredItemIds (must be an array when provided)');
+  });
+
+  it('rejects empty requiredItemIds arrays', () => {
+    const bad = {
+      ...minimalLevel,
+      doors: [
+        {
+          id: 'bad-door',
+          displayName: 'Bad Door',
+          x: 0,
+          y: 10,
+          isOpen: false,
+          isLocked: true,
+          requiredItemIds: [],
+        },
+      ],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid requiredItemIds (must be a non-empty array)');
+  });
+
+  it('rejects requiredItemIds entries that are not non-empty strings', () => {
+    const bad = {
+      ...minimalLevel,
+      doors: [
+        {
+          id: 'bad-door',
+          displayName: 'Bad Door',
+          x: 0,
+          y: 10,
+          isOpen: false,
+          isLocked: true,
+          requiredItemIds: ['key-a', ''],
+        },
+      ],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError(
+      'invalid requiredItemIds (all entries must be non-empty strings)',
+    );
+  });
+
+  it('rejects duplicate requiredItemIds entries', () => {
+    const bad = {
+      ...minimalLevel,
+      doors: [
+        {
+          id: 'bad-door',
+          displayName: 'Bad Door',
+          x: 0,
+          y: 10,
+          isOpen: false,
+          isLocked: true,
+          requiredItemIds: ['key-a', 'key-a'],
+        },
+      ],
+    };
+
+    expect(() => validateLevelData(bad)).toThrowError('invalid requiredItemIds (duplicate entries are not allowed)');
+  });
+});
+
 describe('levelOutcome field', () => {
   it('initializes to null when level is deserialized', () => {
     const level: LevelData = {

--- a/src/world/levelMapping/mapDoor.test.ts
+++ b/src/world/levelMapping/mapDoor.test.ts
@@ -56,6 +56,18 @@ describe('mapDoorDtoToRuntime', () => {
     expect(result.requiredItemId).toBeUndefined();
   });
 
+  it('passes through requiredItemIds when provided', () => {
+    const result = mapDoorDtoToRuntime({ ...baseDoor, requiredItemIds: ['seal-a', 'seal-b'] });
+
+    expect(result.requiredItemIds).toEqual(['seal-a', 'seal-b']);
+  });
+
+  it('omits requiredItemIds when not provided', () => {
+    const result = mapDoorDtoToRuntime(baseDoor);
+
+    expect(result.requiredItemIds).toBeUndefined();
+  });
+
   it('passes through spriteAssetPath when provided', () => {
     const result = mapDoorDtoToRuntime({ ...baseDoor, spriteAssetPath: '/assets/door.svg' });
 

--- a/src/world/levelMapping/mapDoor.ts
+++ b/src/world/levelMapping/mapDoor.ts
@@ -13,6 +13,7 @@ export const mapDoorDtoToRuntime = (dto: LevelDoorDto): Door => {
     isLocked: dto.isLocked,
     ...(dto.isSafe !== undefined ? { isSafe: dto.isSafe } : {}),
     ...(dto.requiredItemId !== undefined ? { requiredItemId: dto.requiredItemId } : {}),
+    ...(dto.requiredItemIds !== undefined ? { requiredItemIds: [...dto.requiredItemIds] } : {}),
     ...(dto.spriteAssetPath !== undefined ? { spriteAssetPath: dto.spriteAssetPath } : {}),
     ...(dto.spriteSet !== undefined ? { spriteSet: dto.spriteSet } : {}),
   };

--- a/src/world/levelValidation/validateDoors.ts
+++ b/src/world/levelValidation/validateDoors.ts
@@ -38,10 +38,44 @@ export const validateDoors = (raw: Record<string, unknown>): void => {
       );
     }
 
+    if (door['requiredItemId'] !== undefined && door['requiredItemIds'] !== undefined) {
+      throw new Error(
+        `Invalid level data: door at index ${i} cannot define both requiredItemId and requiredItemIds`,
+      );
+    }
+
     if (door['requiredItemId'] !== undefined && typeof door['requiredItemId'] !== 'string') {
       throw new Error(
         `Invalid level data: door at index ${i} has invalid requiredItemId (must be a string when provided)`,
       );
+    }
+
+    if (door['requiredItemIds'] !== undefined) {
+      if (!Array.isArray(door['requiredItemIds'])) {
+        throw new Error(
+          `Invalid level data: door at index ${i} has invalid requiredItemIds (must be an array when provided)`,
+        );
+      }
+
+      const requiredItemIds = door['requiredItemIds'] as unknown[];
+      if (requiredItemIds.length === 0) {
+        throw new Error(
+          `Invalid level data: door at index ${i} has invalid requiredItemIds (must be a non-empty array)`,
+        );
+      }
+
+      if (requiredItemIds.some((itemId) => typeof itemId !== 'string' || itemId.trim() === '')) {
+        throw new Error(
+          `Invalid level data: door at index ${i} has invalid requiredItemIds (all entries must be non-empty strings)`,
+        );
+      }
+
+      const normalizedItemIds = requiredItemIds as string[];
+      if (new Set(normalizedItemIds).size !== normalizedItemIds.length) {
+        throw new Error(
+          `Invalid level data: door at index ${i} has invalid requiredItemIds (duplicate entries are not allowed)`,
+        );
+      }
     }
 
     if (door['spriteAssetPath'] !== undefined && typeof door['spriteAssetPath'] !== 'string') {

--- a/src/world/types/door.ts
+++ b/src/world/types/door.ts
@@ -10,4 +10,6 @@ export interface Door extends GameEntity {
   isSafe?: boolean;
   /** Item ID required to unlock this door (if set, door must be interacted with using this item) */
   requiredItemId?: string;
+  /** Item IDs required to unlock this door as a full key set. */
+  requiredItemIds?: string[];
 }

--- a/src/world/types/entity.ts
+++ b/src/world/types/entity.ts
@@ -25,5 +25,5 @@ export interface EntityCapabilities {
   inventory?: { items: InventoryItem[] };
   dialogue?: { threadId?: string };
   patrol?: { path: GridPosition[] };
-  lock?: { isLocked: boolean; requiredItemId?: string };
+  lock?: { isLocked: boolean; requiredItemId?: string; requiredItemIds?: string[] };
 }

--- a/src/world/types/level.ts
+++ b/src/world/types/level.ts
@@ -41,6 +41,8 @@ export interface LevelDoorDto {
   isSafe?: boolean;
   /** Item ID required to unlock this door */
   requiredItemId?: string;
+  /** Item IDs required to unlock this door as a full key set. */
+  requiredItemIds?: string[];
   spriteAssetPath?: string;
   spriteSet?: SpriteSet;
 }


### PR DESCRIPTION
## Summary
- add door schema support for multi-key unlock requirements via `requiredItemIds`
- preserve legacy single-key behavior via `requiredItemId`
- enforce validation errors for invalid multi-key configurations and mixed schema usage
- update deterministic item-use unlock logic to require full key-set possession and selected-key membership
- add tests for pass/fail paths, idempotent unlock side effects, backward compatibility, and invalid mixed schema
- update level/type/world docs for the new door key contract

## Validation
- npm run lint
- npm run build
- npm run test

## Closes #201
Closes #201