### PR TITLE
#210 prevent locked doors from resolving level outcomes

### DIFF
--- a/src/interaction/doorInteraction.test.ts
+++ b/src/interaction/doorInteraction.test.ts
@@ -49,8 +49,8 @@ describe('handleDoorInteraction', () => {
     expect(first).toEqual(second);
   });
 
-  it('returns "win" outcome when door has isSafe=true', () => {
-    const door = makeDoor({ isOpen: true, isLocked: false }, { isSafe: true });
+  it('returns "win" outcome when door is unlocked and has isSafe=true', () => {
+    const door = makeDoor({ isOpen: false, isLocked: false }, { isSafe: true });
     const result = handleDoorInteraction({ door, player });
 
     expect(result.doorId).toBe('door-1');
@@ -71,5 +71,24 @@ describe('handleDoorInteraction', () => {
 
     expect(result.doorId).toBe('door-1');
     expect(result.levelOutcome).toBeUndefined();
+  });
+
+  it('does not include levelOutcome when door is locked even when isSafe is defined', () => {
+    const door = makeDoor({ isOpen: false, isLocked: true }, { isSafe: true });
+    const result = handleDoorInteraction({ door, player });
+
+    expect(result.doorId).toBe('door-1');
+    expect(result.responseText).toBe('The door is locked.');
+    expect(result.levelOutcome).toBeUndefined();
+  });
+
+  it('keeps locked-door interactions idempotent without outcome side effects', () => {
+    const door = makeDoor({ isOpen: false, isLocked: true }, { isSafe: false });
+
+    const first = handleDoorInteraction({ door, player });
+    const second = handleDoorInteraction({ door, player });
+
+    expect(first).toEqual(second);
+    expect(first.levelOutcome).toBeUndefined();
   });
 });

--- a/src/interaction/doorInteraction.ts
+++ b/src/interaction/doorInteraction.ts
@@ -29,7 +29,7 @@ export const handleDoorInteraction = (request: DoorInteractionRequest): DoorInte
     responseText: getDoorStateResponse(request.door),
   };
 
-  if (request.door.isSafe !== undefined) {
+  if (request.door.isSafe !== undefined && !request.door.isLocked) {
     baseResult.levelOutcome = request.door.isSafe ? 'win' : 'lose';
   }
 

--- a/src/interaction/interactionDispatcher.test.ts
+++ b/src/interaction/interactionDispatcher.test.ts
@@ -370,6 +370,23 @@ describe('InteractionDispatcher', () => {
       expect(result.levelOutcome).toBe(null);
     });
 
+    it('locked door with configured outcome does not emit levelOutcome', async () => {
+      const dispatcher = createInteractionDispatcher({ llmClient });
+      const door: Door = {
+        ...createTestDoor('door-locked'),
+        isOpen: false,
+        isLocked: true,
+        isSafe: true,
+      };
+      const worldState = createTestWorldState({ doors: [door] });
+      const target = { kind: 'door' as const, target: door };
+
+      const result = await dispatcher.dispatch(target, worldState);
+
+      expect(result.responseText).toBe('The door is locked.');
+      expect(result.levelOutcome).toBe(null);
+    });
+
     it('interactive object first use sets levelOutcome', async () => {
       const dispatcher = createInteractionDispatcher({ llmClient });
       const obj: InteractiveObject = {


### PR DESCRIPTION
## Summary
- gate door outcome resolution on deterministic lock state
- keep locked door interactions non-resolving while preserving existing response text behavior
- add regression tests for locked-door no-outcome and repeated locked interaction idempotency
- add dispatcher coverage for locked door interactions with configured outcome metadata

## Validation
- npm run lint
- npm run build
- npm run test
- npm run test -- src/interaction/doorInteraction.test.ts src/interaction/interactionDispatcher.test.ts

Closes #210