### PR TITLE
#209 map production outcome payload into deterministic consequence path

### DIFF
--- a/src/integration/npcFunctionCalling.test.ts
+++ b/src/integration/npcFunctionCalling.test.ts
@@ -60,6 +60,85 @@ const createWorldState = (overrides: Partial<WorldState> = {}): WorldState => {
 };
 
 describe('npc function-calling integration', () => {
+  it('maps production structured outcome payloads into deterministic consequence application', async () => {
+    const { service } = createService(
+      createGeminiPayload([
+        {
+          text: JSON.stringify({
+            responseText: 'Take this seal phrase.',
+            outcome: {
+              grantKnowledgeTokens: ['seal-alpha'],
+            },
+          }),
+        },
+      ]),
+    );
+    const worldState = createWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Any clue?',
+    });
+
+    expect(result.responseText).toBe('Archivist: Take this seal phrase.');
+    expect(result.consequenceTrace?.outcomeStatus).toBe('accepted');
+    expect(result.updatedWorldState.knowledgeState?.tokensById['seal-alpha']).toEqual({
+      tokenId: 'seal-alpha',
+      grantedAtTick: worldState.tick,
+      grantedByActorId: npc.id,
+    });
+  });
+
+  it('treats missing production outcome payloads as deterministic no-consequence without mutation', async () => {
+    const { service } = createService(
+      createGeminiPayload([{ text: 'I have no exchange for you yet.' }]),
+    );
+    const worldState = createWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Can we trade?',
+    });
+
+    expect(result.consequenceTrace?.outcomeStatus).toBe('none');
+    expect(result.updatedWorldState.player.inventory.items).toEqual(worldState.player.inventory.items);
+    expect(result.updatedWorldState.npcs[0].inventory).toEqual(npc.inventory);
+    expect(result.updatedWorldState.knowledgeState).toEqual(worldState.knowledgeState);
+    expect(result.updatedWorldState.questState).toEqual(worldState.questState);
+  });
+
+  it('rejects malformed production outcome payloads without mutating deterministic consequence state', async () => {
+    const { service } = createService(
+      createGeminiPayload([
+        {
+          text: '{"responseText":"Trade complete","outcome":',
+        },
+      ]),
+    );
+    const worldState = createWorldState();
+    const npc = worldState.npcs[0];
+
+    const result = await service.handleNpcInteraction({
+      npc,
+      player: worldState.player,
+      worldState,
+      playerMessage: 'Can we trade now?',
+    });
+
+    expect(result.responseText).toBe('');
+    expect(result.consequenceTrace?.outcomeStatus).toBe('rejected');
+    expect(result.updatedWorldState.player.inventory.items).toEqual(worldState.player.inventory.items);
+    expect(result.updatedWorldState.npcs[0].inventory).toEqual(npc.inventory);
+    expect(result.updatedWorldState.knowledgeState).toEqual(worldState.knowledgeState);
+    expect(result.updatedWorldState.questState).toEqual(worldState.questState);
+  });
+
   it('supports text-only responses without creating an action trace', async () => {
     const { fetchImpl, service } = createService(
       createGeminiPayload([{ text: 'The eastern archive is sealed.' }]),

--- a/src/llm/client.test.ts
+++ b/src/llm/client.test.ts
@@ -165,6 +165,102 @@ describe('createGeminiLlmClient', () => {
     });
   });
 
+  it('maps production structured text payload outcome into LlmResponse.outcome', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: JSON.stringify({
+                    responseText: 'The exchange is done.',
+                    outcome: {
+                      takeItem: 'seal-token',
+                      giveItem: 'archive-pass',
+                    },
+                  }),
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    }));
+
+    const client = createGeminiLlmClient({
+      apiKey: 'test-key',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await client.complete(prompt);
+
+    expect(response).toEqual({
+      text: 'The exchange is done.',
+      outcome: {
+        takeItem: 'seal-token',
+        giveItem: 'archive-pass',
+      },
+    });
+  });
+
+  it('does not infer outcome when production payload is plain text only', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'No consequence attached.' }],
+            },
+          },
+        ],
+      }),
+    }));
+
+    const client = createGeminiLlmClient({
+      apiKey: 'test-key',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await client.complete(prompt);
+
+    expect(response).toEqual({ text: 'No consequence attached.' });
+  });
+
+  it('marks malformed structured payloads with deterministic invalid outcome marker', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: '{"responseText":"Offer accepted","outcome":',
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    }));
+
+    const client = createGeminiLlmClient({
+      apiKey: 'test-key',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const response = await client.complete(prompt);
+
+    expect(response).toEqual({
+      outcome: {
+        questProgressEvent: '__malformed_outcome_payload__',
+      },
+    });
+  });
+
   it('returns deterministic structured error for malformed function payloads', async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: true,

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -62,6 +62,76 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
 
+const MALFORMED_OUTCOME_PAYLOAD: NonNullable<LlmResponse['outcome']> = {
+  questProgressEvent: '__malformed_outcome_payload__',
+};
+
+const stripMarkdownCodeFence = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('```') || !trimmed.endsWith('```')) {
+    return value;
+  }
+
+  const lines = trimmed.split('\n');
+  if (lines.length < 2) {
+    return value;
+  }
+
+  return lines.slice(1, -1).join('\n').trim();
+};
+
+interface ParsedStructuredDialoguePayload {
+  detected: boolean;
+  malformed: boolean;
+  responseText?: string;
+  outcome?: unknown;
+}
+
+const parseStructuredDialoguePayloadFromText = (
+  text: string,
+): ParsedStructuredDialoguePayload | null => {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const maybeStructuredJson = trimmed.startsWith('{') || trimmed.startsWith('```');
+  if (!maybeStructuredJson || !trimmed.includes('outcome')) {
+    return null;
+  }
+
+  const jsonCandidate = stripMarkdownCodeFence(trimmed);
+
+  try {
+    const parsed = JSON.parse(jsonCandidate) as unknown;
+    if (!isRecord(parsed) || !('outcome' in parsed)) {
+      return null;
+    }
+
+    const responseText =
+      typeof parsed.responseText === 'string'
+        ? parsed.responseText
+        : typeof parsed.text === 'string'
+          ? parsed.text
+          : typeof parsed.message === 'string'
+            ? parsed.message
+            : undefined;
+
+    return {
+      detected: true,
+      malformed: false,
+      responseText,
+      outcome: parsed.outcome,
+    };
+  } catch {
+    return {
+      detected: true,
+      malformed: true,
+      outcome: MALFORMED_OUTCOME_PAYLOAD,
+    };
+  }
+};
+
 const hasOnlyAllowedKeys = (record: Record<string, unknown>, allowedKeys: string[]): boolean => {
   return Object.keys(record).every((key) => allowedKeys.includes(key));
 };
@@ -242,6 +312,17 @@ const parseGeminiResponse = (payload: unknown): LlmResponse | LlmRequestError =>
 
   const textParts: string[] = [];
   const actions: NpcActionCall[] = [];
+  let outcome: LlmResponse['outcome'] = undefined;
+  let hasOutcomePayload = false;
+
+  const setOutcome = (value: unknown): void => {
+    if (hasOutcomePayload) {
+      return;
+    }
+
+    hasOutcomePayload = true;
+    outcome = value as LlmResponse['outcome'];
+  };
 
   for (const part of parts) {
     if (!isRecord(part)) {
@@ -249,7 +330,24 @@ const parseGeminiResponse = (payload: unknown): LlmResponse | LlmRequestError =>
     }
 
     if (typeof part.text === 'string') {
-      textParts.push(part.text);
+      const structuredPayload = parseStructuredDialoguePayloadFromText(part.text);
+      if (structuredPayload?.detected) {
+        if (structuredPayload.responseText) {
+          textParts.push(structuredPayload.responseText);
+        }
+
+        setOutcome(
+          structuredPayload.malformed
+            ? MALFORMED_OUTCOME_PAYLOAD
+            : structuredPayload.outcome,
+        );
+      } else {
+        textParts.push(part.text);
+      }
+    }
+
+    if ('outcome' in part) {
+      setOutcome(part.outcome);
     }
 
     if ('functionCall' in part && part.functionCall !== undefined) {
@@ -266,7 +364,7 @@ const parseGeminiResponse = (payload: unknown): LlmResponse | LlmRequestError =>
   }
 
   const text = textParts.join('').trim();
-  if (!text && actions.length === 0) {
+  if (!text && actions.length === 0 && !hasOutcomePayload) {
     return {
       kind: 'llm_request_error',
       message: 'Empty or unparseable response from LLM.',
@@ -276,6 +374,7 @@ const parseGeminiResponse = (payload: unknown): LlmResponse | LlmRequestError =>
   return {
     ...(text ? { text } : {}),
     ...(actions.length > 0 ? { actions } : {}),
+    ...(hasOutcomePayload ? { outcome } : {}),
   };
 };
 


### PR DESCRIPTION
## Summary
- map production Gemini structured dialogue payloads into `LlmResponse.outcome` in the live parsing path
- preserve existing deterministic consequence boundary by routing parsed outcomes through existing `applyNpcDialogueConsequences(...)` flow
- mark malformed structured payloads with an invalid deterministic marker so consequence evaluation rejects with no mutation instead of silently skipping
- add parser + integration regression coverage for valid, missing, and malformed production outcome payload cases (including #183 progression-reliability guardrails)

## Validation
- `npm run lint`
- `npm run build`
- `npm run test`

Closes #209